### PR TITLE
Fix non-deterministic test failures on PostgreSQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 ### Fixed
 
 * Raise a compile-time error when mixing aggregate and non-aggregate expressions in an `ORDER BY` clause without a `GROUP BY` clause
+* Fix non-deterministic test failures on PostgreSQL caused by loading rows without `ORDER BY` and assuming insertion order
 
 ### Changed
 

--- a/diesel_tests/tests/combination.rs
+++ b/diesel_tests/tests/combination.rs
@@ -102,7 +102,7 @@ fn except() {
         NewUser::new("Jim", None),
     ];
     insert_into(users).values(&data).execute(conn).unwrap();
-    let data = users.load::<User>(conn).unwrap();
+    let data = users.order(id).load::<User>(conn).unwrap();
     let sean = &data[0];
     let tess = &data[1];
     let _jim = &data[2];

--- a/diesel_tests/tests/copy.rs
+++ b/diesel_tests/tests/copy.rs
@@ -183,6 +183,7 @@ fn copy_from_from_insertable_struct() {
     assert_eq!(user_count, 2);
     let users = users::table
         .select((users::name, users::hair_color))
+        .order(users::id)
         .load::<(String, Option<String>)>(conn)
         .unwrap();
 
@@ -211,6 +212,7 @@ fn copy_from_from_insertable_tuple() {
     assert_eq!(user_count, 2);
     let users = users::table
         .select((users::name, users::hair_color))
+        .order(users::id)
         .load::<(String, Option<String>)>(conn)
         .unwrap();
 
@@ -239,6 +241,7 @@ fn copy_from_from_insertable_vec() {
     assert_eq!(user_count, 2);
     let users = users::table
         .select((users::name, users::hair_color))
+        .order(users::id)
         .load::<(String, Option<String>)>(conn)
         .unwrap();
 

--- a/diesel_tests/tests/filter_operators.rs
+++ b/diesel_tests/tests/filter_operators.rs
@@ -144,7 +144,7 @@ fn filter_by_like() {
         .values(&data)
         .execute(connection)
         .unwrap();
-    let data = users.load::<User>(connection).unwrap();
+    let data = users.order(id).load::<User>(connection).unwrap();
     let sean = data[0].clone();
     let tess = data[1].clone();
     let jim = data[2].clone();
@@ -182,7 +182,7 @@ fn filter_by_ilike() {
         .values(&data)
         .execute(connection)
         .unwrap();
-    let data = users.load::<User>(connection).unwrap();
+    let data = users.order(id).load::<User>(connection).unwrap();
     let sean = data[0].clone();
     let tess = data[1].clone();
     let jim = data[2].clone();

--- a/diesel_tests/tests/insert.rs
+++ b/diesel_tests/tests/insert.rs
@@ -3,7 +3,7 @@ use diesel::*;
 
 #[diesel_test_helper::test]
 fn insert_records() {
-    use crate::schema::users::table as users;
+    use crate::schema::users::{id, table as users};
     let connection = &mut connection();
     let new_users: &[_] = &[
         NewUser::new("Sean", Some("Black")),
@@ -14,7 +14,7 @@ fn insert_records() {
         .values(new_users)
         .execute(connection)
         .unwrap();
-    let actual_users = users.load::<User>(connection).unwrap();
+    let actual_users = users.order(id).load::<User>(connection).unwrap();
 
     let expected_users = vec![
         User {
@@ -33,7 +33,7 @@ fn insert_records() {
 
 #[diesel_test_helper::test]
 fn insert_records_as_vec() {
-    use crate::schema::users::table as users;
+    use crate::schema::users::{id, table as users};
     let connection = &mut connection();
     let new_users = vec![
         NewUser::new("Sean", Some("Black")),
@@ -44,7 +44,7 @@ fn insert_records_as_vec() {
         .values(new_users)
         .execute(connection)
         .unwrap();
-    let actual_users = users.load::<User>(connection).unwrap();
+    let actual_users = users.order(id).load::<User>(connection).unwrap();
 
     let expected_users = vec![
         User {
@@ -63,7 +63,7 @@ fn insert_records_as_vec() {
 
 #[diesel_test_helper::test]
 fn insert_records_as_static_array() {
-    use crate::schema::users::table as users;
+    use crate::schema::users::{id, table as users};
     let connection = &mut connection();
     let new_users = [
         NewUser::new("Sean", Some("Black")),
@@ -74,7 +74,7 @@ fn insert_records_as_static_array() {
         .values(new_users)
         .execute(connection)
         .unwrap();
-    let actual_users = users.load::<User>(connection).unwrap();
+    let actual_users = users.order(id).load::<User>(connection).unwrap();
 
     let expected_users = vec![
         User {
@@ -93,7 +93,7 @@ fn insert_records_as_static_array() {
 
 #[diesel_test_helper::test]
 fn insert_records_as_static_array_ref() {
-    use crate::schema::users::table as users;
+    use crate::schema::users::{id, table as users};
     let connection = &mut connection();
     let new_users = &[
         NewUser::new("Sean", Some("Black")),
@@ -104,7 +104,7 @@ fn insert_records_as_static_array_ref() {
         .values(new_users)
         .execute(connection)
         .unwrap();
-    let actual_users = users.load::<User>(connection).unwrap();
+    let actual_users = users.order(id).load::<User>(connection).unwrap();
 
     let expected_users = vec![
         User {
@@ -123,7 +123,7 @@ fn insert_records_as_static_array_ref() {
 
 #[diesel_test_helper::test]
 fn insert_records_as_boxed_static_array() {
-    use crate::schema::users::table as users;
+    use crate::schema::users::{id, table as users};
     let connection = &mut connection();
     let new_users = Box::new([
         NewUser::new("Sean", Some("Black")),
@@ -134,7 +134,7 @@ fn insert_records_as_boxed_static_array() {
         .values(new_users)
         .execute(connection)
         .unwrap();
-    let actual_users = users.load::<User>(connection).unwrap();
+    let actual_users = users.order(id).load::<User>(connection).unwrap();
 
     let expected_users = vec![
         User {
@@ -505,7 +505,7 @@ struct BorrowedUser<'a> {
 
 #[diesel_test_helper::test]
 fn insert_borrowed_content() {
-    use crate::schema::users::table as users;
+    use crate::schema::users::{id, table as users};
     let connection = &mut connection();
     let new_users: &[_] = &[BorrowedUser { name: "Sean" }, BorrowedUser { name: "Tess" }];
     insert_into(users)
@@ -513,7 +513,7 @@ fn insert_borrowed_content() {
         .execute(connection)
         .unwrap();
 
-    let actual_users = users.load::<User>(connection).unwrap();
+    let actual_users = users.order(id).load::<User>(connection).unwrap();
     let expected_users = vec![
         User::new(actual_users[0].id, "Sean"),
         User::new(actual_users[1].id, "Tess"),
@@ -929,6 +929,7 @@ fn upsert_with_composite_primary_key_do_nothing() {
         .unwrap();
     let users = users::table
         .select(users::name)
+        .order(users::id)
         .load::<String>(conn)
         .unwrap();
 

--- a/diesel_tests/tests/order.rs
+++ b/diesel_tests/tests/order.rs
@@ -51,7 +51,7 @@ fn order_by_descending_column() {
         NewUser::new("Jim", None),
     ];
     insert_into(users).values(&data).execute(conn).unwrap();
-    let data = users.load::<User>(conn).unwrap();
+    let data = users.order(id).load::<User>(conn).unwrap();
     let sean = &data[0];
     let tess = &data[1];
     let jim = &data[2];


### PR DESCRIPTION
PostgreSQL does not guarantee row order without an explicit ORDER BY clause — "the actual order will depend on the scan and join plan types and the order on disk, but it must not be relied on" [1].

Tests that loaded rows unordered and then indexed into the result (data[0], data[1], ...) were silently assuming insertion order, which caused intermittent failures when PostgreSQL returned rows in a different order.

Add ORDER BY id to the initial loads in order_by_descending_column, except, filter_by_like, and filter_by_ilike to guarantee stable ordering.

[1] https://www.postgresql.org/docs/current/queries-order.html

Closes #2949

- [x] I checked for similar changes and make sure to reference them
- [x] I included a changelog entry for relevant new features or changes
