### PR TITLE
embed_migrations! skips empty directories

### DIFF
--- a/diesel_migrations/migrations_internals/src/lib.rs
+++ b/diesel_migrations/migrations_internals/src/lib.rs
@@ -93,6 +93,14 @@ pub fn migrations_directories(
                         || entry.file_name().to_string_lossy().starts_with('.')
                     {
                         None
+                    } else if entry.metadata()?.is_dir() {
+                        let inner_dir_entry_count = entry.path().read_dir()?.count();
+
+                        if inner_dir_entry_count == 0 {
+                            None
+                        } else {
+                            Some(entry)
+                        }
                     } else {
                         Some(entry)
                     },

--- a/diesel_migrations/src/file_based_migrations.rs
+++ b/diesel_migrations/src/file_based_migrations.rs
@@ -386,4 +386,22 @@ mod tests {
 
         assert_eq!(0, migrations.len());
     }
+
+    #[test]
+    fn migration_paths_in_directory_ignores_empty_directories() {
+        let dir = Builder::new().prefix("diesel").tempdir().unwrap();
+        let temp_path = dir.path().canonicalize().unwrap();
+        let migrations_path = temp_path.join("migrations");
+        let empty_path = migrations_path.join("an_empty_migration_dir");
+
+        fs::create_dir(migrations_path.as_path()).unwrap();
+        fs::create_dir(empty_path.as_path()).unwrap();
+
+        let migrations = migrations_in_directory(&migrations_path)
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+
+        assert_eq!(0, migrations.len());
+    }
 }


### PR DESCRIPTION
Fixed #5016  
With this change the `embed_migrations` macro ignores empty subdirectories. 

- [V ] I checked for similar changes and make sure to reference them
- [X ] I included a changelog entry for relevant new features or changes
