### PR TITLE
Add doc example for #[diesel(table_name)] in Insertable derive

### DIFF
--- a/diesel_derives/build.rs
+++ b/diesel_derives/build.rs
@@ -231,7 +231,13 @@ fn main() {
         ),
         (
             "insertable",
-            vec![Example::new("diesel_derives__tests__insertable_1.snap")],
+            vec![
+                Example::new("diesel_derives__tests__insertable_1.snap"),
+                Example::with_heading(
+                    "diesel_derives__tests__insertable_table_name_1.snap",
+                    "With `#[diesel(table_name = crate::schema::users)]`",
+                ),
+            ],
         ),
         (
             "multiconnection",

--- a/diesel_derives/build.rs
+++ b/diesel_derives/build.rs
@@ -232,7 +232,10 @@ fn main() {
         (
             "insertable",
             vec![
-                Example::new("diesel_derives__tests__insertable_1.snap"),
+                Example::with_heading(
+                    "diesel_derives__tests__insertable_1.snap",
+                    "Without attributes",
+                ),
                 Example::with_heading(
                     "diesel_derives__tests__insertable_table_name_1.snap",
                     "With `#[diesel(table_name = crate::schema::users)]`",

--- a/diesel_derives/src/tests/insertable.rs
+++ b/diesel_derives/src/tests/insertable.rs
@@ -18,3 +18,20 @@ pub(crate) fn insertable_1() {
         "insertable_1",
     );
 }
+
+#[test]
+pub(crate) fn insertable_table_name_1() {
+    let input = quote::quote! {
+        #[diesel(table_name = crate::schema::users)]
+        struct User {
+            id: i32,
+            name: String,
+        }
+    };
+    expand_with(
+        &crate::derive_insertable_inner as &dyn Fn(_) -> _,
+        input,
+        derive(syn::parse_quote!(#[derive(Insertable)])),
+        "insertable_table_name_1",
+    );
+}

--- a/diesel_derives/src/tests/insertable.rs
+++ b/diesel_derives/src/tests/insertable.rs
@@ -22,7 +22,7 @@ pub(crate) fn insertable_1() {
 #[test]
 pub(crate) fn insertable_table_name_1() {
     let input = quote::quote! {
-        #[diesel(table_name = crate::schema::users)]
+        #[diesel(table_name = crate::schema::admin_users)]
         struct User {
             id: i32,
             name: String,

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__insertable_table_name_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__insertable_table_name_1.snap
@@ -2,81 +2,91 @@
 source: diesel_derives/src/tests/mod.rs
 expression: out
 info:
-  input: "#[derive(Insertable)]\n#[diesel(table_name = crate::schema::users)]\nstruct User {\n    id: i32,\n    name: String,\n}\n"
+  input: "#[derive(Insertable)]\n#[diesel(table_name = crate::schema::admin_users)]\nstruct User {\n    id: i32,\n    name: String,\n}\n"
 ---
 const _: () = {
     use diesel;
-    impl diesel::insertable::Insertable<crate::schema::users::table> for User
+    impl diesel::insertable::Insertable<crate::schema::admin_users::table> for User
     where
         i32: diesel::expression::AsExpression<
-            <crate::schema::users::r#id as diesel::Expression>::SqlType,
+            <crate::schema::admin_users::r#id as diesel::Expression>::SqlType,
         >,
         String: diesel::expression::AsExpression<
-            <crate::schema::users::r#name as diesel::Expression>::SqlType,
+            <crate::schema::admin_users::r#name as diesel::Expression>::SqlType,
         >,
     {
         type Values = <(
-            std::option::Option<diesel::dsl::Eq<crate::schema::users::r#id, i32>>,
-            std::option::Option<diesel::dsl::Eq<crate::schema::users::r#name, String>>,
-        ) as diesel::insertable::Insertable<crate::schema::users::table>>::Values;
+            std::option::Option<diesel::dsl::Eq<crate::schema::admin_users::r#id, i32>>,
+            std::option::Option<
+                diesel::dsl::Eq<crate::schema::admin_users::r#name, String>,
+            >,
+        ) as diesel::insertable::Insertable<crate::schema::admin_users::table>>::Values;
         fn values(
             self,
         ) -> <(
-            std::option::Option<diesel::dsl::Eq<crate::schema::users::r#id, i32>>,
-            std::option::Option<diesel::dsl::Eq<crate::schema::users::r#name, String>>,
-        ) as diesel::insertable::Insertable<crate::schema::users::table>>::Values {
+            std::option::Option<diesel::dsl::Eq<crate::schema::admin_users::r#id, i32>>,
+            std::option::Option<
+                diesel::dsl::Eq<crate::schema::admin_users::r#name, String>,
+            >,
+        ) as diesel::insertable::Insertable<crate::schema::admin_users::table>>::Values {
             diesel::insertable::Insertable::<
-                crate::schema::users::table,
+                crate::schema::admin_users::table,
             >::values((
                 std::option::Option::Some(
-                    diesel::ExpressionMethods::eq(crate::schema::users::r#id, self.id),
+                    diesel::ExpressionMethods::eq(
+                        crate::schema::admin_users::r#id,
+                        self.id,
+                    ),
                 ),
                 std::option::Option::Some(
                     diesel::ExpressionMethods::eq(
-                        crate::schema::users::r#name,
+                        crate::schema::admin_users::r#name,
                         self.name,
                     ),
                 ),
             ))
         }
     }
-    impl<'insert> diesel::insertable::Insertable<crate::schema::users::table>
+    impl<'insert> diesel::insertable::Insertable<crate::schema::admin_users::table>
     for &'insert User
     where
         &'insert i32: diesel::expression::AsExpression<
-            <crate::schema::users::r#id as diesel::Expression>::SqlType,
+            <crate::schema::admin_users::r#id as diesel::Expression>::SqlType,
         >,
         &'insert String: diesel::expression::AsExpression<
-            <crate::schema::users::r#name as diesel::Expression>::SqlType,
+            <crate::schema::admin_users::r#name as diesel::Expression>::SqlType,
         >,
     {
         type Values = <(
             std::option::Option<
-                diesel::dsl::Eq<crate::schema::users::r#id, &'insert i32>,
+                diesel::dsl::Eq<crate::schema::admin_users::r#id, &'insert i32>,
             >,
             std::option::Option<
-                diesel::dsl::Eq<crate::schema::users::r#name, &'insert String>,
+                diesel::dsl::Eq<crate::schema::admin_users::r#name, &'insert String>,
             >,
-        ) as diesel::insertable::Insertable<crate::schema::users::table>>::Values;
+        ) as diesel::insertable::Insertable<crate::schema::admin_users::table>>::Values;
         fn values(
             self,
         ) -> <(
             std::option::Option<
-                diesel::dsl::Eq<crate::schema::users::r#id, &'insert i32>,
+                diesel::dsl::Eq<crate::schema::admin_users::r#id, &'insert i32>,
             >,
             std::option::Option<
-                diesel::dsl::Eq<crate::schema::users::r#name, &'insert String>,
+                diesel::dsl::Eq<crate::schema::admin_users::r#name, &'insert String>,
             >,
-        ) as diesel::insertable::Insertable<crate::schema::users::table>>::Values {
+        ) as diesel::insertable::Insertable<crate::schema::admin_users::table>>::Values {
             diesel::insertable::Insertable::<
-                crate::schema::users::table,
+                crate::schema::admin_users::table,
             >::values((
                 std::option::Option::Some(
-                    diesel::ExpressionMethods::eq(crate::schema::users::r#id, &self.id),
+                    diesel::ExpressionMethods::eq(
+                        crate::schema::admin_users::r#id,
+                        &self.id,
+                    ),
                 ),
                 std::option::Option::Some(
                     diesel::ExpressionMethods::eq(
-                        crate::schema::users::r#name,
+                        crate::schema::admin_users::r#name,
                         &self.name,
                     ),
                 ),
@@ -84,6 +94,6 @@ const _: () = {
         }
     }
     impl diesel::internal::derives::insertable::UndecoratedInsertRecord<
-        crate::schema::users::table,
+        crate::schema::admin_users::table,
     > for User {}
 };

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__insertable_table_name_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__insertable_table_name_1.snap
@@ -1,0 +1,89 @@
+---
+source: diesel_derives/src/tests/mod.rs
+expression: out
+info:
+  input: "#[derive(Insertable)]\n#[diesel(table_name = crate::schema::users)]\nstruct User {\n    id: i32,\n    name: String,\n}\n"
+---
+const _: () = {
+    use diesel;
+    impl diesel::insertable::Insertable<crate::schema::users::table> for User
+    where
+        i32: diesel::expression::AsExpression<
+            <crate::schema::users::r#id as diesel::Expression>::SqlType,
+        >,
+        String: diesel::expression::AsExpression<
+            <crate::schema::users::r#name as diesel::Expression>::SqlType,
+        >,
+    {
+        type Values = <(
+            std::option::Option<diesel::dsl::Eq<crate::schema::users::r#id, i32>>,
+            std::option::Option<diesel::dsl::Eq<crate::schema::users::r#name, String>>,
+        ) as diesel::insertable::Insertable<crate::schema::users::table>>::Values;
+        fn values(
+            self,
+        ) -> <(
+            std::option::Option<diesel::dsl::Eq<crate::schema::users::r#id, i32>>,
+            std::option::Option<diesel::dsl::Eq<crate::schema::users::r#name, String>>,
+        ) as diesel::insertable::Insertable<crate::schema::users::table>>::Values {
+            diesel::insertable::Insertable::<
+                crate::schema::users::table,
+            >::values((
+                std::option::Option::Some(
+                    diesel::ExpressionMethods::eq(crate::schema::users::r#id, self.id),
+                ),
+                std::option::Option::Some(
+                    diesel::ExpressionMethods::eq(
+                        crate::schema::users::r#name,
+                        self.name,
+                    ),
+                ),
+            ))
+        }
+    }
+    impl<'insert> diesel::insertable::Insertable<crate::schema::users::table>
+    for &'insert User
+    where
+        &'insert i32: diesel::expression::AsExpression<
+            <crate::schema::users::r#id as diesel::Expression>::SqlType,
+        >,
+        &'insert String: diesel::expression::AsExpression<
+            <crate::schema::users::r#name as diesel::Expression>::SqlType,
+        >,
+    {
+        type Values = <(
+            std::option::Option<
+                diesel::dsl::Eq<crate::schema::users::r#id, &'insert i32>,
+            >,
+            std::option::Option<
+                diesel::dsl::Eq<crate::schema::users::r#name, &'insert String>,
+            >,
+        ) as diesel::insertable::Insertable<crate::schema::users::table>>::Values;
+        fn values(
+            self,
+        ) -> <(
+            std::option::Option<
+                diesel::dsl::Eq<crate::schema::users::r#id, &'insert i32>,
+            >,
+            std::option::Option<
+                diesel::dsl::Eq<crate::schema::users::r#name, &'insert String>,
+            >,
+        ) as diesel::insertable::Insertable<crate::schema::users::table>>::Values {
+            diesel::insertable::Insertable::<
+                crate::schema::users::table,
+            >::values((
+                std::option::Option::Some(
+                    diesel::ExpressionMethods::eq(crate::schema::users::r#id, &self.id),
+                ),
+                std::option::Option::Some(
+                    diesel::ExpressionMethods::eq(
+                        crate::schema::users::r#name,
+                        &self.name,
+                    ),
+                ),
+            ))
+        }
+    }
+    impl diesel::internal::derives::insertable::UndecoratedInsertRecord<
+        crate::schema::users::table,
+    > for User {}
+};


### PR DESCRIPTION
Adds a test example for `#[diesel(table_name)]` attribute in `#[derive(Insertable)]` 
as requested in #4840