### PR TITLE
Fix reject aggregate select with non aggregate order by

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 ### Fixed
 
 * Raise a compile-time error when mixing aggregate and non-aggregate expressions in an `ORDER BY` clause without a `GROUP BY` clause
+* Calling `.count()` or `.select(aggregate_expr)` on a query that already has a non-aggregate `.order_by()` clause now raises a compile-time error instead of generating invalid SQL that would be rejected by the database at runtime (fixes [#3815](https://github.com/diesel-rs/diesel/issues/3815))
 * Fix non-deterministic test failures on PostgreSQL caused by loading rows without `ORDER BY` and assuming insertion order
 
 ### Changed

--- a/diesel/src/query_builder/order_clause.rs
+++ b/diesel/src/query_builder/order_clause.rs
@@ -1,5 +1,7 @@
 use alloc::boxed::Box;
 
+use crate::expression::{ValidGrouping, is_aggregate};
+
 simple_clause!(
     /// DSL node that represents that no order clause is set
     NoOrderClause,
@@ -25,4 +27,12 @@ where
     fn from(_: NoOrderClause) -> Self {
         None
     }
+}
+
+impl<GB> ValidGrouping<GB> for NoOrderClause {
+    type IsAggregate = is_aggregate::Never;
+}
+
+impl<GB, Expr: ValidGrouping<GB>> ValidGrouping<GB> for OrderClause<Expr> {
+    type IsAggregate = Expr::IsAggregate;
 }

--- a/diesel/src/query_builder/select_statement/dsl_impls.rs
+++ b/diesel/src/query_builder/select_statement/dsl_impls.rs
@@ -131,6 +131,9 @@ where
     Selection: SelectableExpression<F> + ValidGrouping<G::Expressions>,
     SelectStatement<FromClause<F>, SelectClause<Selection>, D, W, O, LOf, G, H, LC>: SelectQuery,
     D: ValidDistinctForGroupBy<Selection, G::Expressions>,
+    O: ValidGrouping<G::Expressions>,
+    <Selection as ValidGrouping<G::Expressions>>::IsAggregate:
+        MixedAggregates<<O as ValidGrouping<G::Expressions>>::IsAggregate>,
 {
     type Output = SelectStatement<FromClause<F>, SelectClause<Selection>, D, W, O, LOf, G, H, LC>;
 

--- a/diesel_compile_tests/tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs
+++ b/diesel_compile_tests/tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs
@@ -27,4 +27,12 @@ fn main() {
         .order_by(max(id))
         .then_order_by(name);
     //~^ ERROR: mixing aggregate and not aggregate expressions is not allowed in SQL
+
+    // non-aggregate ORDER BY first, then aggregate SELECT (issue #3815)
+    let _ = users.order_by(name).select(max(id));
+    //~^ ERROR: mixing aggregate and not aggregate expressions is not allowed in SQL
+
+    // non-aggregate ORDER BY first, then .count() (issue #3815)
+    let _ = users.order_by(name).count();
+    //~^ ERROR: SelectDsl
 }

--- a/diesel_compile_tests/tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.stderr
+++ b/diesel_compile_tests/tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.stderr
@@ -27,8 +27,7 @@ LL |     fn order_by<Expr>(self, expr: Expr) -> OrderBy<Self, Expr>
 ...
 LL |         Self: methods::OrderDsl<Expr>,
     |               ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::order_by`
- 
-    
+
 error[E0277]: mixing aggregate and not aggregate expressions is not allowed in SQL
    --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:21:39
     |
@@ -58,8 +57,7 @@ LL |     fn order_by<Expr>(self, expr: Expr) -> OrderBy<Self, Expr>
 ...
 LL |         Self: methods::OrderDsl<Expr>,
     |               ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::order_by`
- 
-    
+
 error[E0277]: mixing aggregate and not aggregate expressions is not allowed in SQL
    --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:28:24
     |
@@ -89,5 +87,62 @@ LL |     fn then_order_by<Order>(self, order: Order) -> ThenOrderBy<Self, Order>
 LL |     where
 LL |         Self: methods::ThenOrderDsl<Order>,
     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::then_order_by`
- 
+
+error[E0277]: mixing aggregate and not aggregate expressions is not allowed in SQL
+   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:32:41
+    |
+ LL |     let _ = users.order_by(name).select(max(id));
+    |                                  ------ ^^^^^^^ unsatisfied trait bound
+    |                                  |
+    |                                  required by a bound introduced by this call
+    |
+    = help: the trait `MixedAggregates<diesel::expression::is_aggregate::No>` is not implemented for `diesel::expression::is_aggregate::Yes`
+    = note: you tried to combine expressions that aggregate over a certain column with expressions that don't aggregate over that column
+    = note: try to either use aggregate functions like `min`/`max`/… for this column or add the column to your `GROUP BY` clause
+    = note: also there are clauses like `WHERE` or `RETURNING` that does not accept aggregate expressions at all
+help: the following other types implement trait `MixedAggregates<Other>`
+   --> DIESEL/diesel/diesel/src/expression/mod.rs
+    |
+LL |     impl MixedAggregates<Yes> for Yes {
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `diesel::expression::is_aggregate::Yes` implements `MixedAggregates<diesel::expression::is_aggregate::Yes>`
+...
+LL |     impl MixedAggregates<Never> for Yes {
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `diesel::expression::is_aggregate::Yes` implements `MixedAggregates<diesel::expression::is_aggregate::Never>`
+    = note: required for `SelectStatement<..., ..., ..., ..., ...>` to implement `SelectDsl<max<Integer, id>>`
+note: required by a bound in `diesel::QueryDsl::select`
+   --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+    |
+LL |     fn select<Selection>(self, selection: Selection) -> Select<Self, Selection>
+    |        ------ required by a bound in this associated function
+...
+LL |         Self: methods::SelectDsl<Selection>,
+    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::select`
+
+error[E0277]: the trait bound `SelectStatement<..., ..., ..., ..., ...>: SelectDsl<...>` is not satisfied
+   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:36:34
+    |
+ LL |     let _ = users.order_by(name).count();
+    |                                  ^^^^^ the trait `SelectDsl<CountStar>` is not implemented for `SelectStatement<..., ..., ..., ..., ...>`
+    |
+help: the following other types implement trait `SelectDsl<Selection>`
+   --> DIESEL/diesel/diesel/src/query_builder/select_statement/dsl_impls.rs
+    |
+LL | / impl<F, S, D, W, O, LOf, G, H, LC, Selection> SelectDsl<Selection>
+LL | |     for SelectStatement<FromClause<F>, S, D, W, O, LOf, G, H, LC>
+LL | | where
+LL | |     G: ValidGroupByClause,
+...   |
+LL | |     <Selection as ValidGrouping<G::Expressions>>::IsAggregate:
+LL | |         MixedAggregates<<O as ValidGrouping<G::Expressions>>::IsAggregate>,
+    | |___________________________________________________________________________^ `SelectStatement<FromClause<F>, S, D, W, O, LOf, G, H, LC>`
+...
+LL | / impl<S, D, W, O, LOf, G, H, LC, Selection> SelectDsl<Selection>
+LL | |     for SelectStatement<NoFromClause, S, D, W, O, LOf, G, H, LC>
+LL | | where
+LL | |     G: ValidGroupByClause,
+LL | |     Selection: SelectableExpression<NoFromClause> + ValidGrouping<G::Expressions>,
+LL | |     SelectStatement<NoFromClause, SelectClause<Selection>, D, W, O, LOf, G, H, LC>: Selec...
+LL | |     D: ValidDistinctForGroupBy<Selection, G::Expressions>,
+    | |__________________________________________________________^ `SelectStatement<NoFromClause, S, D, W, O, LOf, G, H, LC>`
+
     For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.stderr
+++ b/diesel_compile_tests/tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.stderr
@@ -27,7 +27,8 @@ LL |     fn order_by<Expr>(self, expr: Expr) -> OrderBy<Self, Expr>
 ...
 LL |         Self: methods::OrderDsl<Expr>,
     |               ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::order_by`
-
+ 
+    
 error[E0277]: mixing aggregate and not aggregate expressions is not allowed in SQL
    --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:21:39
     |
@@ -57,7 +58,8 @@ LL |     fn order_by<Expr>(self, expr: Expr) -> OrderBy<Self, Expr>
 ...
 LL |         Self: methods::OrderDsl<Expr>,
     |               ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::order_by`
-
+ 
+    
 error[E0277]: mixing aggregate and not aggregate expressions is not allowed in SQL
    --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:28:24
     |
@@ -87,7 +89,8 @@ LL |     fn then_order_by<Order>(self, order: Order) -> ThenOrderBy<Self, Order>
 LL |     where
 LL |         Self: methods::ThenOrderDsl<Order>,
     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::then_order_by`
-
+ 
+    
 error[E0277]: mixing aggregate and not aggregate expressions is not allowed in SQL
    --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:32:41
     |
@@ -117,13 +120,15 @@ LL |     fn select<Selection>(self, selection: Selection) -> Select<Self, Select
 ...
 LL |         Self: methods::SelectDsl<Selection>,
     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::select`
-
+ 
+    
 error[E0277]: the trait bound `SelectStatement<..., ..., ..., ..., ...>: SelectDsl<...>` is not satisfied
    --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:36:34
     |
  LL |     let _ = users.order_by(name).count();
-    |                                  ^^^^^ the trait `SelectDsl<CountStar>` is not implemented for `SelectStatement<..., ..., ..., ..., ...>`
+    |                                  ^^^^^ unsatisfied trait bound
     |
+    = help: the trait `SelectDsl<diesel::dsl::CountStar>` is not implemented for `SelectStatement<..., ..., ..., ..., ...>`
 help: the following other types implement trait `SelectDsl<Selection>`
    --> DIESEL/diesel/diesel/src/query_builder/select_statement/dsl_impls.rs
     |
@@ -134,7 +139,7 @@ LL | |     G: ValidGroupByClause,
 ...   |
 LL | |     <Selection as ValidGrouping<G::Expressions>>::IsAggregate:
 LL | |         MixedAggregates<<O as ValidGrouping<G::Expressions>>::IsAggregate>,
-    | |___________________________________________________________________________^ `SelectStatement<FromClause<F>, S, D, W, O, LOf, G, H, LC>`
+    | |___________________________________________________________________________^ `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
 ...
 LL | / impl<S, D, W, O, LOf, G, H, LC, Selection> SelectDsl<Selection>
 LL | |     for SelectStatement<NoFromClause, S, D, W, O, LOf, G, H, LC>
@@ -143,6 +148,6 @@ LL | |     G: ValidGroupByClause,
 LL | |     Selection: SelectableExpression<NoFromClause> + ValidGrouping<G::Expressions>,
 LL | |     SelectStatement<NoFromClause, SelectClause<Selection>, D, W, O, LOf, G, H, LC>: Selec...
 LL | |     D: ValidDistinctForGroupBy<Selection, G::Expressions>,
-    | |__________________________________________________________^ `SelectStatement<NoFromClause, S, D, W, O, LOf, G, H, LC>`
-
+    | |__________________________________________________________^ `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
+ 
     For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/cannot_mix_aggregate_and_non_aggregate_selects.stderr
+++ b/diesel_compile_tests/tests/fail/cannot_mix_aggregate_and_non_aggregate_selects.stderr
@@ -66,8 +66,6 @@ note: required for `__Derived<nullable_int_col, max<..., ...>>` to implement `Va
  LL | #[declare_sql_function]
     | ^^^^^^^^^^^^^^^^^^^^^^^ type parameter would need to implement `ValidGrouping<()>`
     = help: consider manually implementing `ValidGrouping<()>` to avoid undesired bounds
-    = note: 1 redundant requirement hidden
-    = note: required for `f<nullable_int_col, max<Nullable<Integer>, ...>>` to implement `ValidGrouping<()>`
     = note: required for `SelectStatement<FromClause<table>>` to implement `SelectDsl<f<nullable_int_col, max<..., ...>>>`
  
         = note: this error originates in the attribute macro `declare_sql_function` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/diesel_compile_tests/tests/fail/derive/has_query.rs
+++ b/diesel_compile_tests/tests/fail/derive/has_query.rs
@@ -23,6 +23,7 @@ struct User1 {
 }
 
 #[derive(HasQuery)]
+//~^ ERROR: the trait bound `SelectStatement<FromClause<table>>: SelectDsl<...>` is not satisfied
 #[diesel(table_name = posts)]
 struct UserMixedUp {
     id: i32,

--- a/diesel_compile_tests/tests/fail/derive/has_query.stderr
+++ b/diesel_compile_tests/tests/fail/derive/has_query.stderr
@@ -1,5 +1,5 @@
 error[E0425]: cannot find type `name` in module `posts`
-  --> tests/fail/derive/has_query.rs:29:5
+  --> tests/fail/derive/has_query.rs:30:5
    |
 LL |     name: String,
    |     ^^^^ not found in `posts`
@@ -10,15 +10,15 @@ help: consider importing this struct through its public re-export
    |
 help: if you import `name`, refer to it directly
    |
-26 - #[diesel(table_name = posts)]
-27 - struct UserMixedUp {
-28 -     id: i32,
-29 -     name: String,
-26 + #[diesel(table_name = name: String,
+27 - #[diesel(table_name = posts)]
+28 - struct UserMixedUp {
+29 -     id: i32,
+30 -     name: String,
+27 + #[diesel(table_name = name: String,
    |
 
 error[E0425]: cannot find value `name` in module `posts`
-  --> tests/fail/derive/has_query.rs:29:5
+  --> tests/fail/derive/has_query.rs:30:5
    |
 LL |     name: String,
    |     ^^^^ not found in `posts`
@@ -29,15 +29,45 @@ help: consider importing this unit struct through its public re-export
    |
 help: if you import `name`, refer to it directly
    |
-26 - #[diesel(table_name = posts)]
-27 - struct UserMixedUp {
-28 -     id: i32,
-29 -     name: String,
-26 + #[diesel(table_name = name: String,
+27 - #[diesel(table_name = posts)]
+28 - struct UserMixedUp {
+29 -     id: i32,
+30 -     name: String,
+27 + #[diesel(table_name = name: String,
    |
 
+error[E0277]: the trait bound `SelectStatement<FromClause<table>>: SelectDsl<...>` is not satisfied
+   --> tests/fail/derive/has_query.rs:25:10
+    |
+ LL | #[derive(HasQuery)]
+    |          ^^^^^^^^ unsatisfied trait bound
+    |
+    = help: the trait `SelectDsl<diesel::expression::select_by::SelectBy<UserMixedUp, __DB>>` is not implemented for `SelectStatement<FromClause<table>>`
+help: the following other types implement trait `SelectDsl<Selection>`
+   --> DIESEL/diesel/diesel/src/query_builder/select_statement/dsl_impls.rs
+    |
+LL | / impl<F, S, D, W, O, LOf, G, H, LC, Selection> SelectDsl<Selection>
+LL | |     for SelectStatement<FromClause<F>, S, D, W, O, LOf, G, H, LC>
+LL | | where
+LL | |     G: ValidGroupByClause,
+...   |
+LL | |     <Selection as ValidGrouping<G::Expressions>>::IsAggregate:
+LL | |         MixedAggregates<<O as ValidGrouping<G::Expressions>>::IsAggregate>,
+    | |___________________________________________________________________________^ `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
+...
+LL | / impl<S, D, W, O, LOf, G, H, LC, Selection> SelectDsl<Selection>
+LL | |     for SelectStatement<NoFromClause, S, D, W, O, LOf, G, H, LC>
+LL | | where
+LL | |     G: ValidGroupByClause,
+LL | |     Selection: SelectableExpression<NoFromClause> + ValidGrouping<G::Expressions>,
+LL | |     SelectStatement<NoFromClause, SelectClause<Selection>, D, W, O, LOf, G, H, LC>: Selec...
+LL | |     D: ValidDistinctForGroupBy<Selection, G::Expressions>,
+    | |__________________________________________________________^ `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
+ 
+        = note: this error originates in the derive macro `HasQuery` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0277]: the trait bound `i32: FromSqlRow<diesel::sql_types::Text, Mysql>` is not satisfied
-  --> tests/fail/derive/has_query.rs:41:11
+  --> tests/fail/derive/has_query.rs:42:11
    |
 LL | #[derive(HasQuery)]
    |          -------- in this derive macro expansion
@@ -69,7 +99,7 @@ LL | impl FromSql<Integer, Mysql> for i32 {
    = note: this error originates in the derive macro `HasQuery` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `i32: FromSqlRow<diesel::sql_types::Text, Sqlite>` is not satisfied
-  --> tests/fail/derive/has_query.rs:41:11
+  --> tests/fail/derive/has_query.rs:42:11
    |
 LL | #[derive(HasQuery)]
    |          -------- in this derive macro expansion
@@ -101,7 +131,7 @@ LL | impl FromSql<Integer, Mysql> for i32 {
    = note: this error originates in the derive macro `HasQuery` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `i32: FromSqlRow<diesel::sql_types::Text, Pg>` is not satisfied
-  --> tests/fail/derive/has_query.rs:41:11
+  --> tests/fail/derive/has_query.rs:42:11
    |
 LL | #[derive(HasQuery)]
    |          -------- in this derive macro expansion
@@ -133,7 +163,7 @@ LL | impl FromSql<Integer, Mysql> for i32 {
    = note: this error originates in the derive macro `HasQuery` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `std::string::String: FromSqlRow<diesel::sql_types::Integer, Mysql>` is not satisfied
-  --> tests/fail/derive/has_query.rs:37:9
+  --> tests/fail/derive/has_query.rs:38:9
    |
 LL | #[derive(HasQuery)]
    |          -------- in this derive macro expansion
@@ -156,7 +186,7 @@ LL |     id: String,
    = note: this error originates in the derive macro `HasQuery` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `String: FromSqlRow<Integer, Sqlite>` is not satisfied
-  --> tests/fail/derive/has_query.rs:37:9
+  --> tests/fail/derive/has_query.rs:38:9
    |
 LL | #[derive(HasQuery)]
    |          -------- in this derive macro expansion
@@ -180,7 +210,7 @@ LL |     id: String,
       = note: this error originates in the derive macro `HasQuery` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `std::string::String: FromSqlRow<diesel::sql_types::Integer, Pg>` is not satisfied
-  --> tests/fail/derive/has_query.rs:37:9
+  --> tests/fail/derive/has_query.rs:38:9
    |
 LL | #[derive(HasQuery)]
    |          -------- in this derive macro expansion
@@ -203,7 +233,7 @@ LL |     id: String,
    = note: this error originates in the derive macro `HasQuery` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `SelectStatement<FromClause<table>>: SelectDsl<...>` is not satisfied
-   --> tests/fail/derive/has_query.rs:47:10
+   --> tests/fail/derive/has_query.rs:48:10
     |
  LL | #[derive(HasQuery)]
     |          ^^^^^^^^ unsatisfied trait bound
@@ -217,9 +247,9 @@ LL | |     for SelectStatement<FromClause<F>, S, D, W, O, LOf, G, H, LC>
 LL | | where
 LL | |     G: ValidGroupByClause,
 ...   |
-LL | |     SelectStatement<FromClause<F>, SelectClause<Selection>, D, W, O, LOf, G, H, LC>: Sele...
-LL | |     D: ValidDistinctForGroupBy<Selection, G::Expressions>,
-    | |__________________________________________________________^ `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
+LL | |     <Selection as ValidGrouping<G::Expressions>>::IsAggregate:
+LL | |         MixedAggregates<<O as ValidGrouping<G::Expressions>>::IsAggregate>,
+    | |___________________________________________________________________________^ `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
 ...
 LL | / impl<S, D, W, O, LOf, G, H, LC, Selection> SelectDsl<Selection>
 LL | |     for SelectStatement<NoFromClause, S, D, W, O, LOf, G, H, LC>
@@ -233,7 +263,7 @@ LL | |     D: ValidDistinctForGroupBy<Selection, G::Expressions>,
         = note: this error originates in the derive macro `HasQuery` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
-   --> tests/fail/derive/has_query.rs:47:10
+   --> tests/fail/derive/has_query.rs:48:10
     |
  LL | #[derive(HasQuery)]
     |          ^^^^^^^^ expected `Once`, found `Never`
@@ -257,7 +287,7 @@ LL |                           + AppearsOnTable<<Self::BaseQuery as AcceptedQuer
     = note: this error originates in the derive macro `HasQuery` which comes from the expansion of the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `users::table: TableNotEqual<posts::table>` is not satisfied
-   --> tests/fail/derive/has_query.rs:47:10
+   --> tests/fail/derive/has_query.rs:48:10
     |
  LL | #[derive(HasQuery)]
     |          ^^^^^^^^ unsatisfied trait bound
@@ -297,7 +327,7 @@ LL |                           + AppearsOnTable<<Self::BaseQuery as AcceptedQuer
     = note: this error originates in the derive macro `HasQuery` which comes from the expansion of the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `SelectStatement<..., ..., ..., ...>: SelectDsl<...>` is not satisfied
-   --> tests/fail/derive/has_query.rs:57:10
+   --> tests/fail/derive/has_query.rs:58:10
     |
  LL | #[derive(HasQuery)]
     |          ^^^^^^^^ unsatisfied trait bound
@@ -311,9 +341,9 @@ LL | |     for SelectStatement<FromClause<F>, S, D, W, O, LOf, G, H, LC>
 LL | | where
 LL | |     G: ValidGroupByClause,
 ...   |
-LL | |     SelectStatement<FromClause<F>, SelectClause<Selection>, D, W, O, LOf, G, H, LC>: Sele...
-LL | |     D: ValidDistinctForGroupBy<Selection, G::Expressions>,
-    | |__________________________________________________________^ `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
+LL | |     <Selection as ValidGrouping<G::Expressions>>::IsAggregate:
+LL | |         MixedAggregates<<O as ValidGrouping<G::Expressions>>::IsAggregate>,
+    | |___________________________________________________________________________^ `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
 ...
 LL | / impl<S, D, W, O, LOf, G, H, LC, Selection> SelectDsl<Selection>
 LL | |     for SelectStatement<NoFromClause, S, D, W, O, LOf, G, H, LC>
@@ -327,7 +357,7 @@ LL | |     D: ValidDistinctForGroupBy<Selection, G::Expressions>,
         = note: this error originates in the derive macro `HasQuery` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
-   --> tests/fail/derive/has_query.rs:57:10
+   --> tests/fail/derive/has_query.rs:58:10
     |
  LL | #[derive(HasQuery)]
     |          ^^^^^^^^ expected `Once`, found `Never`
@@ -351,7 +381,7 @@ LL |                           + AppearsOnTable<<Self::BaseQuery as AcceptedQuer
     = note: this error originates in the derive macro `HasQuery` which comes from the expansion of the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `users::table: TableNotEqual<posts::table>` is not satisfied
-   --> tests/fail/derive/has_query.rs:57:10
+   --> tests/fail/derive/has_query.rs:58:10
     |
  LL | #[derive(HasQuery)]
     |          ^^^^^^^^ unsatisfied trait bound
@@ -391,7 +421,7 @@ LL |                           + AppearsOnTable<<Self::BaseQuery as AcceptedQuer
     = note: this error originates in the derive macro `HasQuery` which comes from the expansion of the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ...>: SelectDsl<...>` is not satisfied
-   --> tests/fail/derive/has_query.rs:67:10
+   --> tests/fail/derive/has_query.rs:68:10
     |
  LL | #[derive(HasQuery)]
     |          ^^^^^^^^ unsatisfied trait bound
@@ -405,9 +435,9 @@ LL | |     for SelectStatement<FromClause<F>, S, D, W, O, LOf, G, H, LC>
 LL | | where
 LL | |     G: ValidGroupByClause,
 ...   |
-LL | |     SelectStatement<FromClause<F>, SelectClause<Selection>, D, W, O, LOf, G, H, LC>: Sele...
-LL | |     D: ValidDistinctForGroupBy<Selection, G::Expressions>,
-    | |__________________________________________________________^ `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
+LL | |     <Selection as ValidGrouping<G::Expressions>>::IsAggregate:
+LL | |         MixedAggregates<<O as ValidGrouping<G::Expressions>>::IsAggregate>,
+    | |___________________________________________________________________________^ `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
 ...
 LL | / impl<S, D, W, O, LOf, G, H, LC, Selection> SelectDsl<Selection>
 LL | |     for SelectStatement<NoFromClause, S, D, W, O, LOf, G, H, LC>
@@ -421,7 +451,7 @@ LL | |     D: ValidDistinctForGroupBy<Selection, G::Expressions>,
         = note: this error originates in the derive macro `HasQuery` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0271]: type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
-   --> tests/fail/derive/has_query.rs:67:10
+   --> tests/fail/derive/has_query.rs:68:10
     |
  LL | #[derive(HasQuery)]
     |          ^^^^^^^^ type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`

--- a/diesel_compile_tests/tests/fail/reject_mixed_aggregates_via_distinct_on_clauses.stderr
+++ b/diesel_compile_tests/tests/fail/reject_mixed_aggregates_via_distinct_on_clauses.stderr
@@ -34,9 +34,9 @@ LL | |     for SelectStatement<FromClause<F>, S, D, W, O, LOf, G, H, LC>
 LL | | where
 LL | |     G: ValidGroupByClause,
 ...   |
-LL | |     SelectStatement<FromClause<F>, SelectClause<Selection>, D, W, O, LOf, G, H, LC>: Sele...
-LL | |     D: ValidDistinctForGroupBy<Selection, G::Expressions>,
-    | |__________________________________________________________^ `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
+LL | |     <Selection as ValidGrouping<G::Expressions>>::IsAggregate:
+LL | |         MixedAggregates<<O as ValidGrouping<G::Expressions>>::IsAggregate>,
+    | |___________________________________________________________________________^ `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
 ...
 LL | / impl<S, D, W, O, LOf, G, H, LC, Selection> SelectDsl<Selection>
 LL | |     for SelectStatement<NoFromClause, S, D, W, O, LOf, G, H, LC>
@@ -128,9 +128,9 @@ LL | |     for SelectStatement<FromClause<F>, S, D, W, O, LOf, G, H, LC>
 LL | | where
 LL | |     G: ValidGroupByClause,
 ...   |
-LL | |     SelectStatement<FromClause<F>, SelectClause<Selection>, D, W, O, LOf, G, H, LC>: Sele...
-LL | |     D: ValidDistinctForGroupBy<Selection, G::Expressions>,
-    | |__________________________________________________________^ `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
+LL | |     <Selection as ValidGrouping<G::Expressions>>::IsAggregate:
+LL | |         MixedAggregates<<O as ValidGrouping<G::Expressions>>::IsAggregate>,
+    | |___________________________________________________________________________^ `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
 ...
 LL | / impl<S, D, W, O, LOf, G, H, LC, Selection> SelectDsl<Selection>
 LL | |     for SelectStatement<NoFromClause, S, D, W, O, LOf, G, H, LC>

--- a/diesel_compile_tests/tests/fail/select_requires_valid_grouping.rs
+++ b/diesel_compile_tests/tests/fail/select_requires_valid_grouping.rs
@@ -89,10 +89,6 @@ fn main() {
         .select(users::id);
     //~^ ERROR: type mismatch resolving `<(name, hair_color) as IsContainedInGroupBy<id>>::Output == Yes`
     let source = users::table
-        .group_by(users::name)
-        .select((users::name, users::id));
-    //~^ ERROR: type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
-    let source = users::table
         .group_by((users::name, users::hair_color))
         .select(users::id);
     //~^ ERROR: type mismatch resolving `<(name, hair_color) as IsContainedInGroupBy<id>>::Output == Yes`
@@ -101,10 +97,4 @@ fn main() {
         .group_by((users::id, posts::title))
         .select((users::all_columns, posts::id));
     //~^ ERROR: type mismatch resolving `<(id, title) as IsContainedInGroupBy<id>>::Output == Yes`
-    let source = users::table
-        .inner_join(posts::table.inner_join(comments::table))
-        .group_by((users::id, posts::id))
-        .select((users::all_columns, posts::all_columns, comments::id));
-    //~^ ERROR: the trait bound `id: IsContainedInGroupBy<id>` is not satisfied
-    //~| ERROR: the trait bound `id: IsContainedInGroupBy<id>` is not satisfied
 }

--- a/diesel_compile_tests/tests/fail/select_requires_valid_grouping.stderr
+++ b/diesel_compile_tests/tests/fail/select_requires_valid_grouping.stderr
@@ -40,36 +40,8 @@ note: required for `users::columns::id` to implement `ValidGrouping<(users::colu
 
       = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0271]: type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
-  --> tests/fail/select_requires_valid_grouping.rs:93:10
-   |
-LL |         .select((users::name, users::id));
-   |          ^^^^^^ type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
-   |
-note: expected this to be `diesel::expression::is_contained_in_group_by::Yes`
-  --> tests/fail/select_requires_valid_grouping.rs:5:1
-   |
- LL | / table! {
- LL | |     users {
- LL | |         id -> Integer,
- LL | |         name -> Text,
-...  |
-LL | | }
-   | |_^
-note: required for `users::columns::id` to implement `ValidGrouping<users::columns::name>`
-  --> tests/fail/select_requires_valid_grouping.rs:7:9
-   |
- LL |         id -> Integer,
-   |         ^^
-   = note: associated types for the current `impl` cannot be restricted in `where` clauses
-   = note: 1 redundant requirement hidden
-   = note: required for `(users::columns::name, users::columns::id)` to implement `ValidGrouping<users::columns::name>`
-   = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ...>` to implement `SelectDsl<(users::columns::name, users::columns::id)>`
-
-      = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
-
 error[E0271]: type mismatch resolving `<(name, hair_color) as IsContainedInGroupBy<id>>::Output == Yes`
-  --> tests/fail/select_requires_valid_grouping.rs:97:10
+  --> tests/fail/select_requires_valid_grouping.rs:93:10
    |
 LL |         .select(users::id);
    |          ^^^^^^ expected `Yes`, found `No`
@@ -85,83 +57,20 @@ note: required for `users::columns::id` to implement `ValidGrouping<(users::colu
       = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0271]: type mismatch resolving `<(id, title) as IsContainedInGroupBy<id>>::Output == Yes`
-   --> tests/fail/select_requires_valid_grouping.rs:102:10
-    |
+  --> tests/fail/select_requires_valid_grouping.rs:98:10
+   |
 LL |         .select((users::all_columns, posts::id));
-    |          ^^^^^^ expected `Yes`, found `No`
-    |
+   |          ^^^^^^ expected `Yes`, found `No`
+   |
 note: required for `posts::columns::id` to implement `ValidGrouping<(users::columns::id, posts::columns::title)>`
-   --> tests/fail/select_requires_valid_grouping.rs:15:9
-    |
- LL |         id -> Integer,
-    |         ^^
-    = note: associated types for the current `impl` cannot be restricted in `where` clauses
-    = note: 1 redundant requirement hidden
-    = note: required for `((id, name, hair_color), id)` to implement `ValidGrouping<(users::columns::id, posts::columns::title)>`
-    = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ...>` to implement `SelectDsl<((id, name, hair_color), id)>`
- 
-        = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+  --> tests/fail/select_requires_valid_grouping.rs:15:9
+   |
+LL |         id -> Integer,
+   |         ^^
+   = note: associated types for the current `impl` cannot be restricted in `where` clauses
+   = note: 1 redundant requirement hidden
+   = note: required for `((id, name, hair_color), id)` to implement `ValidGrouping<(users::columns::id, posts::columns::title)>`
+   = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ...>` to implement `SelectDsl<((id, name, hair_color), id)>`
 
-error[E0277]: the trait bound `id: IsContainedInGroupBy<id>` is not satisfied
-   --> tests/fail/select_requires_valid_grouping.rs:107:10
-    |
-LL |         .select((users::all_columns, posts::all_columns, comments::id));
-    |          ^^^^^^ unsatisfied trait bound
-    |
-help: the trait `diesel::expression::IsContainedInGroupBy<comments::columns::id>` is not implemented for `users::columns::id`
-   --> tests/fail/select_requires_valid_grouping.rs:7:9
-    |
-  LL |         id -> Integer,
-    |         ^^
-    = note: if your query contains columns from several tables in your group by or select clause make sure to call `allow_columns_to_appear_in_same_group_by_clause!` with these columns
-    = help: the following other types implement trait `diesel::expression::IsContainedInGroupBy<T>`:
-              `users::columns::id` implements `diesel::expression::IsContainedInGroupBy<posts::columns::id>`
-              `users::columns::id` implements `diesel::expression::IsContainedInGroupBy<posts::columns::title>`
-              `users::columns::id` implements `diesel::expression::IsContainedInGroupBy<posts::columns::user_id>`
-              `users::columns::id` implements `IsContainedInGroupBy<hair_color>`
-              `users::columns::id` implements `diesel::expression::IsContainedInGroupBy<users::columns::id>`
-              `users::columns::id` implements `diesel::expression::IsContainedInGroupBy<users::columns::name>`
-    = note: required for `(users::columns::id, posts::columns::id)` to implement `diesel::expression::IsContainedInGroupBy<comments::columns::id>`
-note: required for `comments::columns::id` to implement `ValidGrouping<(users::columns::id, posts::columns::id)>`
-   --> tests/fail/select_requires_valid_grouping.rs:23:9
-    |
- LL |         id -> Integer,
-    |         ^^
-    = note: 2 redundant requirements hidden
-    = note: required for `((id, name, hair_color), (id, title, user_id), id)` to implement `ValidGrouping<(users::columns::id, posts::columns::id)>`
-    = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ...>` to implement `SelectDsl<((id, name, hair_color), ..., ...)>`
- 
-        = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the trait bound `id: IsContainedInGroupBy<id>` is not satisfied
-   --> tests/fail/select_requires_valid_grouping.rs:107:10
-    |
-LL |         .select((users::all_columns, posts::all_columns, comments::id));
-    |          ^^^^^^ unsatisfied trait bound
-    |
-help: the trait `diesel::expression::IsContainedInGroupBy<comments::columns::id>` is not implemented for `posts::columns::id`
-   --> tests/fail/select_requires_valid_grouping.rs:15:9
-    |
- LL |         id -> Integer,
-    |         ^^
-    = note: if your query contains columns from several tables in your group by or select clause make sure to call `allow_columns_to_appear_in_same_group_by_clause!` with these columns
-    = help: the following other types implement trait `diesel::expression::IsContainedInGroupBy<T>`:
-              `posts::columns::id` implements `diesel::expression::IsContainedInGroupBy<posts::columns::id>`
-              `posts::columns::id` implements `diesel::expression::IsContainedInGroupBy<posts::columns::title>`
-              `posts::columns::id` implements `diesel::expression::IsContainedInGroupBy<posts::columns::user_id>`
-              `posts::columns::id` implements `IsContainedInGroupBy<hair_color>`
-              `posts::columns::id` implements `diesel::expression::IsContainedInGroupBy<users::columns::id>`
-              `posts::columns::id` implements `diesel::expression::IsContainedInGroupBy<users::columns::name>`
-    = note: required for `(posts::columns::id,)` to implement `diesel::expression::IsContainedInGroupBy<comments::columns::id>`
-    = note: 1 redundant requirement hidden
-    = note: required for `(users::columns::id, posts::columns::id)` to implement `diesel::expression::IsContainedInGroupBy<comments::columns::id>`
-note: required for `comments::columns::id` to implement `ValidGrouping<(users::columns::id, posts::columns::id)>`
-   --> tests/fail/select_requires_valid_grouping.rs:23:9
-    |
- LL |         id -> Integer,
-    |         ^^
-    = note: 2 redundant requirements hidden
-    = note: required for `((id, name, hair_color), (id, title, user_id), id)` to implement `ValidGrouping<(users::columns::id, posts::columns::id)>`
-    = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ...>` to implement `SelectDsl<((id, name, hair_color), ..., ...)>`
- 
-        = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+      = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+For more information about this error, try `rustc --explain E0271`.

--- a/diesel_compile_tests/tests/fail/select_requires_valid_grouping2.rs
+++ b/diesel_compile_tests/tests/fail/select_requires_valid_grouping2.rs
@@ -1,0 +1,54 @@
+extern crate diesel;
+
+use diesel::prelude::*;
+
+table! {
+    users {
+        id -> Integer,
+        name -> Text,
+        hair_color -> Nullable<Text>,
+    }
+}
+
+table! {
+    posts {
+        id -> Integer,
+        title -> Text,
+        user_id -> Integer,
+    }
+}
+
+table! {
+    comments {
+        id -> Integer,
+        text -> Text,
+        post_id -> Integer,
+    }
+}
+
+joinable!(comments -> posts (post_id));
+joinable!(posts -> users (user_id));
+
+allow_tables_to_appear_in_same_query!(users, posts, comments);
+allow_columns_to_appear_in_same_group_by_clause!(
+    posts::title,
+    users::id,
+    posts::user_id,
+    users::name,
+    posts::id,
+    users::hair_color
+);
+
+fn main() {
+    let source = users::table
+        .group_by(users::name)
+        .select((users::name, users::id));
+    //~^ ERROR: type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
+
+    let source = users::table
+        .inner_join(posts::table.inner_join(comments::table))
+        .group_by((users::id, posts::id))
+        .select((users::all_columns, posts::all_columns, comments::id));
+    //~^ ERROR: the trait bound `id: IsContainedInGroupBy<id>` is not satisfied
+    //~| ERROR: the trait bound `id: IsContainedInGroupBy<id>` is not satisfied
+}

--- a/diesel_compile_tests/tests/fail/select_requires_valid_grouping2.stderr
+++ b/diesel_compile_tests/tests/fail/select_requires_valid_grouping2.stderr
@@ -1,0 +1,91 @@
+error[E0271]: type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
+  --> tests/fail/select_requires_valid_grouping2.rs:45:10
+   |
+LL |         .select((users::name, users::id));
+   |          ^^^^^^ type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
+   |
+note: expected this to be `diesel::expression::is_contained_in_group_by::Yes`
+  --> tests/fail/select_requires_valid_grouping2.rs:5:1
+   |
+ LL | / table! {
+ LL | |     users {
+ LL | |         id -> Integer,
+ LL | |         name -> Text,
+...  |
+LL | | }
+   | |_^
+note: required for `users::columns::id` to implement `ValidGrouping<users::columns::name>`
+  --> tests/fail/select_requires_valid_grouping2.rs:7:9
+   |
+ LL |         id -> Integer,
+   |         ^^
+   = note: associated types for the current `impl` cannot be restricted in `where` clauses
+   = note: 1 redundant requirement hidden
+   = note: required for `(users::columns::name, users::columns::id)` to implement `ValidGrouping<users::columns::name>`
+   = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ...>` to implement `SelectDsl<(users::columns::name, users::columns::id)>`
+
+      = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `id: IsContainedInGroupBy<id>` is not satisfied
+  --> tests/fail/select_requires_valid_grouping2.rs:51:10
+   |
+LL |         .select((users::all_columns, posts::all_columns, comments::id));
+   |          ^^^^^^ unsatisfied trait bound
+   |
+help: the trait `diesel::expression::IsContainedInGroupBy<comments::columns::id>` is not implemented for `users::columns::id`
+  --> tests/fail/select_requires_valid_grouping2.rs:7:9
+   |
+ LL |         id -> Integer,
+   |         ^^
+   = note: if your query contains columns from several tables in your group by or select clause make sure to call `allow_columns_to_appear_in_same_group_by_clause!` with these columns
+   = help: the following other types implement trait `diesel::expression::IsContainedInGroupBy<T>`:
+             `users::columns::id` implements `diesel::expression::IsContainedInGroupBy<posts::columns::id>`
+             `users::columns::id` implements `diesel::expression::IsContainedInGroupBy<posts::columns::title>`
+             `users::columns::id` implements `diesel::expression::IsContainedInGroupBy<posts::columns::user_id>`
+             `users::columns::id` implements `IsContainedInGroupBy<hair_color>`
+             `users::columns::id` implements `diesel::expression::IsContainedInGroupBy<users::columns::id>`
+             `users::columns::id` implements `diesel::expression::IsContainedInGroupBy<users::columns::name>`
+   = note: required for `(users::columns::id, posts::columns::id)` to implement `diesel::expression::IsContainedInGroupBy<comments::columns::id>`
+note: required for `comments::columns::id` to implement `ValidGrouping<(users::columns::id, posts::columns::id)>`
+  --> tests/fail/select_requires_valid_grouping2.rs:23:9
+   |
+LL |         id -> Integer,
+   |         ^^
+   = note: 2 redundant requirements hidden
+   = note: required for `((id, name, hair_color), (id, title, user_id), id)` to implement `ValidGrouping<(users::columns::id, posts::columns::id)>`
+   = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ...>` to implement `SelectDsl<((id, name, hair_color), ..., ...)>`
+
+      = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `id: IsContainedInGroupBy<id>` is not satisfied
+  --> tests/fail/select_requires_valid_grouping2.rs:51:10
+   |
+LL |         .select((users::all_columns, posts::all_columns, comments::id));
+   |          ^^^^^^ unsatisfied trait bound
+   |
+help: the trait `diesel::expression::IsContainedInGroupBy<comments::columns::id>` is not implemented for `posts::columns::id`
+  --> tests/fail/select_requires_valid_grouping2.rs:15:9
+   |
+LL |         id -> Integer,
+   |         ^^
+   = note: if your query contains columns from several tables in your group by or select clause make sure to call `allow_columns_to_appear_in_same_group_by_clause!` with these columns
+   = help: the following other types implement trait `diesel::expression::IsContainedInGroupBy<T>`:
+             `posts::columns::id` implements `diesel::expression::IsContainedInGroupBy<posts::columns::id>`
+             `posts::columns::id` implements `diesel::expression::IsContainedInGroupBy<posts::columns::title>`
+             `posts::columns::id` implements `diesel::expression::IsContainedInGroupBy<posts::columns::user_id>`
+             `posts::columns::id` implements `IsContainedInGroupBy<hair_color>`
+             `posts::columns::id` implements `diesel::expression::IsContainedInGroupBy<users::columns::id>`
+             `posts::columns::id` implements `diesel::expression::IsContainedInGroupBy<users::columns::name>`
+   = note: required for `(posts::columns::id,)` to implement `diesel::expression::IsContainedInGroupBy<comments::columns::id>`
+   = note: 1 redundant requirement hidden
+   = note: required for `(users::columns::id, posts::columns::id)` to implement `diesel::expression::IsContainedInGroupBy<comments::columns::id>`
+note: required for `comments::columns::id` to implement `ValidGrouping<(users::columns::id, posts::columns::id)>`
+  --> tests/fail/select_requires_valid_grouping2.rs:23:9
+   |
+LL |         id -> Integer,
+   |         ^^
+   = note: 2 redundant requirements hidden
+   = note: required for `((id, name, hair_color), (id, title, user_id), id)` to implement `ValidGrouping<(users::columns::id, posts::columns::id)>`
+   = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ...>` to implement `SelectDsl<((id, name, hair_color), ..., ...)>`
+
+      = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/diesel_compile_tests/tests/fail/window_functions_expression_requires_window_function.stderr
+++ b/diesel_compile_tests/tests/fail/window_functions_expression_requires_window_function.stderr
@@ -266,10 +266,8 @@ LL |     impl<ST: SingleValue> MultirangeOrRangeMaybeNullable for Multirange<ST>
 ...
 LL |     impl<ST: SingleValue> MultirangeOrRangeMaybeNullable for Nullable<Multirange<ST>> {
      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Nullable<Multirange<ST>>`
-     = note: required for `lower<Text, name>` to implement `Expression`
-     = note: 1 redundant requirement hidden
-     = note: required for `AggregateExpression<..., ..., ..., ...>` to implement `Expression`
-     = note: required for `users::table` to implement `SelectDsl<AggregateExpression<..., ..., ..., ...>>`
+     = note: required for `lower<Text, name>` to implement `ValidGrouping<()>`
+     = note: required for `SelectStatement<FromClause<table>>` to implement `SelectDsl<AggregateExpression<..., ..., ..., ...>>`
   
      
 error[E0277]: `diesel::sql_types::Text` is neither `diesel::sql_types::Range<_>` nor `diesel::sql_types::Multirange<_>`


### PR DESCRIPTION
Reject aggregate SELECT combined with non-aggregate ORDER BY at compile time

Calling `.count()` or `.select(aggregate)` on a query that already has a non-aggregate `.order_by()` clause previously compiled but generated invalid SQL, rejected by PostgreSQL at runtime with:
```
column "x" must appear in the GROUP BY clause or be used in an aggregate function
```

Fix this by implementing `ValidGrouping` for `NoOrderClause` and `OrderClause<Expr>`, then adding the same MixedAggregates` cross-check to `SelectDsl` that already exists in `OrderDsl`. The reverse order  (`.select(aggregate).order_by(non_aggregate)`) was already a compile error; this closes the symmetric gap.

Closes #3815.

- [x] I checked for similar changes and make sure to reference them
- [x] I included a changelog entry for relevant new features or changes
