### PR TITLE
Send bpchar OID for CHAR(N) bind parameters on PostgreSQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 
 ### Fixed
 
+* `Bpchar` is now a distinct PostgreSQL SQL type (previously a hidden alias for `Varchar`). Binds on `CHAR(N)` / `BPCHAR` columns are now sent with OID 1042, allowing PostgreSQL to use the column's index instead of casting it to text.
 * Fix non-deterministic test failures on PostgreSQL caused by loading rows without `ORDER BY` and assuming insertion order
 
 ### Changed

--- a/diesel/src/pg/types/mod.rs
+++ b/diesel/src/pg/types/mod.rs
@@ -337,7 +337,10 @@ pub mod sql_types {
     pub type Bytea = crate::sql_types::Binary;
 
     #[doc(hidden)]
-    pub type Bpchar = crate::sql_types::VarChar;
+    #[cfg(feature = "postgres_backend")]
+    #[derive(Debug, Clone, Copy, Default, QueryId, SqlType)]
+    #[diesel(postgres_type(oid = 1042, array_oid = 1014))]
+    pub struct Bpchar;
 
     /// The PostgreSQL [Money](https://www.postgresql.org/docs/current/static/datatype-money.html) type.
     ///

--- a/diesel/src/pg/types/primitives.rs
+++ b/diesel/src/pg/types/primitives.rs
@@ -101,6 +101,27 @@ impl FromSql<sql_types::Citext, Pg> for String {
     }
 }
 
+#[cfg(feature = "postgres_backend")]
+impl ToSql<crate::pg::sql_types::Bpchar, Pg> for str {
+    fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, Pg>) -> serialize::Result {
+        <str as ToSql<sql_types::Text, Pg>>::to_sql(self, out)
+    }
+}
+
+#[cfg(feature = "postgres_backend")]
+impl ToSql<crate::pg::sql_types::Bpchar, Pg> for String {
+    fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, Pg>) -> serialize::Result {
+        <String as ToSql<sql_types::Text, Pg>>::to_sql(self, out)
+    }
+}
+
+#[cfg(feature = "postgres_backend")]
+impl<'a> FromSqlRef<'a, crate::pg::sql_types::Bpchar, Pg> for &'a str {
+    fn from_sql(value: &'a mut PgValue<'_>) -> deserialize::Result<Self> {
+        Ok(core::str::from_utf8(value.as_bytes())?)
+    }
+}
+
 /// The returned pointer is *only* valid for the lifetime to the argument of
 /// `from_sql`. This impl is intended for uses where you want to write a new
 /// impl in terms of `Vec<u8>`, but don't want to allocate. We have to return a

--- a/diesel/src/type_impls/primitives.rs
+++ b/diesel/src/type_impls/primitives.rs
@@ -95,6 +95,7 @@ mod foreign_impls {
     #[cfg_attr(feature = "__sqlite-shared", diesel(sql_type = crate::sql_types::Time))]
     #[cfg_attr(feature = "__sqlite-shared", diesel(sql_type = crate::sql_types::Timestamp))]
     #[cfg_attr(feature = "postgres_backend", diesel(sql_type = crate::sql_types::Citext))]
+    #[cfg_attr(feature = "postgres_backend", diesel(sql_type = crate::pg::sql_types::Bpchar))]
     struct StringProxy(String);
 
     #[derive(AsExpression)]
@@ -104,6 +105,7 @@ mod foreign_impls {
     #[cfg_attr(feature = "__sqlite-shared", diesel(sql_type = crate::sql_types::Time))]
     #[cfg_attr(feature = "__sqlite-shared", diesel(sql_type = crate::sql_types::Timestamp))]
     #[cfg_attr(feature = "postgres_backend", diesel(sql_type = crate::sql_types::Citext))]
+    #[cfg_attr(feature = "postgres_backend", diesel(sql_type = crate::pg::sql_types::Bpchar))]
     struct StrProxy(str);
 
     #[derive(FromSqlRow)]

--- a/diesel_compile_tests/tests/fail/derive/bad_insertable.stderr
+++ b/diesel_compile_tests/tests/fail/derive/bad_insertable.stderr
@@ -30,13 +30,13 @@ LL |     id: String,
    |
    = help: the following other types implement trait `AsExpression<T>`:
              `&std::string::String` implements `AsExpression<Citext>`
+             `&std::string::String` implements `AsExpression<diesel::sql_types::Bpchar>`
              `&std::string::String` implements `AsExpression<diesel::sql_types::Date>`
              `&std::string::String` implements `AsExpression<diesel::sql_types::Text>`
              `&std::string::String` implements `AsExpression<diesel::sql_types::Time>`
              `&std::string::String` implements `AsExpression<diesel::sql_types::Timestamp>`
              `std::string::String` implements `AsExpression<Citext>`
              `std::string::String` implements `AsExpression<Nullable<Citext>>`
-             `std::string::String` implements `AsExpression<Nullable<diesel::sql_types::Date>>`
            and N others
    = help: see issue #48214
    = note: this error originates in the derive macro `Insertable` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/diesel_compile_tests/tests/fail/expressions_can_only_be_compared_for_equality_to_expressions_of_same_type.stderr
+++ b/diesel_compile_tests/tests/fail/expressions_can_only_be_compared_for_equality_to_expressions_of_same_type.stderr
@@ -6,6 +6,7 @@ LL |     let pred = id.eq("string");
    |
    = help: the following other types implement trait `AsExpression<T>`:
              `&str` implements `AsExpression<Citext>`
+             `&str` implements `AsExpression<diesel::sql_types::Bpchar>`
              `&str` implements `AsExpression<diesel::sql_types::Date>`
              `&str` implements `AsExpression<diesel::sql_types::Text>`
              `&str` implements `AsExpression<diesel::sql_types::Time>`

--- a/diesel_tests/tests/find.rs
+++ b/diesel_tests/tests/find.rs
@@ -1,6 +1,156 @@
 use crate::schema::*;
 use diesel::*;
 
+#[cfg(feature = "postgres")]
+table! {
+    bpchar_pk_table (id) {
+        id -> diesel::pg::sql_types::Bpchar,
+        value -> Integer,
+    }
+}
+
+#[cfg(feature = "postgres")]
+table! {
+    bpchar_col_table (id) {
+        id -> Integer,
+        code -> diesel::pg::sql_types::Bpchar,
+    }
+}
+
+#[cfg(feature = "postgres")]
+#[derive(diesel::QueryableByName)]
+struct ExplainRow {
+    #[diesel(sql_type = diesel::sql_types::Text, column_name = "QUERY PLAN")]
+    query_plan: String,
+}
+
+#[cfg(feature = "postgres")]
+fn explain(query: &str, conn: &mut diesel::PgConnection) -> String {
+    let rows: Vec<ExplainRow> = diesel::sql_query(format!("EXPLAIN {query}"))
+        .load(conn)
+        .unwrap();
+    rows.iter()
+        .map(|r| r.query_plan.as_str())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[diesel_test_helper::test]
+#[cfg(feature = "postgres")]
+fn find_by_bpchar_pk() {
+    use self::bpchar_pk_table::dsl::*;
+    let conn = &mut connection();
+    diesel::sql_query(
+        "CREATE TABLE bpchar_pk_table (id CHAR(11) PRIMARY KEY, value INTEGER NOT NULL)",
+    )
+    .execute(conn)
+    .unwrap();
+    diesel::sql_query("INSERT INTO bpchar_pk_table (id, value) VALUES ('00005000000', 42)")
+        .execute(conn)
+        .unwrap();
+
+    let result = bpchar_pk_table
+        .find("00005000000")
+        .first::<(String, i32)>(conn);
+    assert_eq!(Ok(("00005000000".to_string(), 42)), result);
+}
+
+#[diesel_test_helper::test]
+#[cfg(feature = "postgres")]
+fn filter_by_bpchar_column() {
+    use self::bpchar_pk_table::dsl::*;
+    let conn = &mut connection();
+    diesel::sql_query(
+        "CREATE TABLE bpchar_pk_table (id CHAR(11) PRIMARY KEY, value INTEGER NOT NULL)",
+    )
+    .execute(conn)
+    .unwrap();
+    diesel::sql_query(
+        "INSERT INTO bpchar_pk_table (id, value) VALUES ('00005000000', 42), ('00001000000', 7)",
+    )
+    .execute(conn)
+    .unwrap();
+
+    let result = bpchar_pk_table
+        .filter(id.eq("00005000000"))
+        .first::<(String, i32)>(conn);
+    assert_eq!(Ok(("00005000000".to_string(), 42)), result);
+}
+
+#[diesel_test_helper::test]
+#[cfg(feature = "postgres")]
+fn bpchar_bind_uses_index() {
+    let conn = &mut connection();
+    diesel::sql_query(
+        "CREATE TABLE bpchar_pk_table (id CHAR(11) PRIMARY KEY, value INTEGER NOT NULL)",
+    )
+    .execute(conn)
+    .unwrap();
+    diesel::sql_query("INSERT INTO bpchar_pk_table (id, value) VALUES ('00005000000', 42)")
+        .execute(conn)
+        .unwrap();
+
+    let plan = explain(
+        "SELECT * FROM bpchar_pk_table WHERE id = '00005000000'",
+        conn,
+    );
+    assert!(
+        plan.contains("Index Scan using bpchar_pk_table_pkey on bpchar_pk_table"),
+        "expected primary key index scan, got:\n{plan}",
+    );
+}
+
+#[diesel_test_helper::test]
+#[cfg(feature = "postgres")]
+fn filter_by_non_pk_bpchar_column() {
+    use self::bpchar_col_table::dsl::*;
+    let conn = &mut connection();
+    diesel::sql_query(
+        "CREATE TABLE bpchar_col_table (id INTEGER PRIMARY KEY, code CHAR(11) NOT NULL)",
+    )
+    .execute(conn)
+    .unwrap();
+    diesel::sql_query("CREATE INDEX ON bpchar_col_table (code)")
+        .execute(conn)
+        .unwrap();
+    diesel::sql_query(
+        "INSERT INTO bpchar_col_table (id, code) VALUES (1, '00005000000'), (2, '00001000000')",
+    )
+    .execute(conn)
+    .unwrap();
+
+    let result = bpchar_col_table
+        .filter(code.eq("00005000000"))
+        .first::<(i32, String)>(conn);
+    assert_eq!(Ok((1, "00005000000".to_string())), result);
+}
+
+#[diesel_test_helper::test]
+#[cfg(feature = "postgres")]
+fn non_pk_bpchar_column_uses_index() {
+    let conn = &mut connection();
+    diesel::sql_query(
+        "CREATE TABLE bpchar_col_table (id INTEGER PRIMARY KEY, code CHAR(11) NOT NULL)",
+    )
+    .execute(conn)
+    .unwrap();
+    diesel::sql_query("CREATE INDEX ON bpchar_col_table (code)")
+        .execute(conn)
+        .unwrap();
+    diesel::sql_query("INSERT INTO bpchar_col_table (id, code) VALUES (1, '00005000000')")
+        .execute(conn)
+        .unwrap();
+
+    let plan = explain(
+        "SELECT * FROM bpchar_col_table WHERE code = '00005000000'",
+        conn,
+    );
+    assert!(
+        plan.contains("Bitmap Index Scan on bpchar_col_table_code_idx"),
+        "expected bitmap index scan on bpchar_col_table_code_idx, got:\n{plan}",
+    );
+}
+
 #[diesel_test_helper::test]
 fn find() {
     use crate::schema::users::table as users;


### PR DESCRIPTION
`Bpchar` was a hidden type alias for `Varchar`. When Diesel sent a bind parameter for a `CHAR(N)` / `bpchar` column, it used OID 25 (text), causing PostgreSQL to cast the column to text for comparison. This prevented index scans, turning indexed lookups into sequential scans.

Fix by promoting `Bpchar` to a distinct SQL type with OID 1042 (the PostgreSQL bpchar OID). Bind parameters for `CHAR(N)` columns are now annotated with the correct OID, allowing PostgreSQL to compare them directly against the column without a cast and enabling index scans.

Closes #1912

- [x] I checked for similar changes and make sure to reference them
- [x] I included a changelog entry for relevant new features or changes
