### PR TITLE
Fix typos in comments and example README

### DIFF
--- a/diesel_compile_tests/tests/fail/select_requires_valid_grouping.rs
+++ b/diesel_compile_tests/tests/fail/select_requires_valid_grouping.rs
@@ -41,7 +41,7 @@ allow_columns_to_appear_in_same_group_by_clause!(
 
 fn main() {
     use diesel::dsl;
-    // cases thas should compile
+    // cases that should compile
 
     // A column appearing in the group by clause should be considered valid for the select clause
     let source = users::table.group_by(users::name).select(users::name);

--- a/diesel_infer_query/src/query_source.rs
+++ b/diesel_infer_query/src/query_source.rs
@@ -142,7 +142,7 @@ impl<'a> QuerySource<'a> {
                         ObjectNamePart::Identifier(schema),
                         ObjectNamePart::Identifier(name),
                     ] => (&name.value, Some(schema.value.as_str())),
-                    // for now anythinge else is not supported, but that should be fine
+                    // for now anything else is not supported, but that should be fine
                     _ => {
                         return Err(Error::UnsupportedSql {
                             msg: format!("Unsupported name: `{name}`"),

--- a/examples/postgres/custom_arrays/README.md
+++ b/examples/postgres/custom_arrays/README.md
@@ -521,7 +521,7 @@ impl ToSql<crate::schema::smdb::sql_types::ServiceEndpoint, Pg> for Endpoint {
 
 I cannot stress enough that it is paramount that the tuple type signature must match exactly the Postgres type signature
 defined in your up.sql.
-Ideally, you want to use the split view function in your IDE to have the up.sql in one pane and the the ToSql
+Ideally, you want to use the split view function in your IDE to have the up.sql in one pane and the ToSql
 implementation in another pane, both side by side, to double check
 that the number and types match.
 If the type or number of types mismatch, you will get a compiler error telling you that somehow either


### PR DESCRIPTION

**Repo:** diesel-rs/diesel (⭐ 12000)
**Type:** docs
**Files changed:** 3
**Lines:** +3/-3

## What
Fixes three small typos: "the the ToSql" → "the ToSql" in the custom_arrays example README, "anythinge" → "anything" in a `diesel_infer_query` source comment, and "cases thas should compile" → "cases that should compile" in a compile-test fixture comment.

## Why
Pure documentation/comment cleanup that improves readability without affecting any behavior, generated code, or test expectations. The compile-test file change is in a `// cases thas...` comment, not in a `.stderr` snapshot, so test output is unaffected.

## Testing
No code paths changed; no tests required. `git diff` confirms only comments and prose were touched. The compile-test `.stderr` snapshots do not reference the edited comment line.

## Risk
Low — comment/prose-only edits across three files, three lines total.
