### PR TITLE
Fix several UB instances and other probematic behaviour

### DIFF
--- a/diesel/src/deserialize.rs
+++ b/diesel/src/deserialize.rs
@@ -474,6 +474,16 @@ pub trait FromSql<A, DB: Backend>: Sized {
     }
 }
 
+/// A helper trait for deserializing data in a borrowed variant
+///
+/// This is mostly useful for getting a `&str` or `&[u8]` in your code
+#[diesel_derives::__diesel_public_if(
+    feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
+)]
+pub(crate) trait FromSqlRef<'a, A, DB: Backend>: Sized {
+    fn from_sql(bytes: DB::RawValue<'a>) -> Result<Self>;
+}
+
 /// Deserialize a database row into a rust data structure
 ///
 /// Diesel provides wild card implementations of this trait for all types

--- a/diesel/src/mysql/connection/bind.rs
+++ b/diesel/src/mysql/connection/bind.rs
@@ -1,4 +1,5 @@
 #![allow(unsafe_code)] // module uses ffi
+use core::cmp;
 use core::ffi as libc;
 use core::mem::MaybeUninit;
 use core::mem::{self, ManuallyDrop};
@@ -178,6 +179,13 @@ pub(super) struct BindData {
 // instead of just copying the pointer
 impl Clone for BindData {
     fn clone(&self) -> Self {
+        // we just make sure here that we never create a
+        // slice larger than the allocation
+        let length = cmp::min(
+            self.capacity,
+            self.length.try_into().expect("usize fits the length"),
+        );
+
         let (ptr, len, capacity) = if let Some(ptr) = self.bytes {
             let slice = unsafe {
                 // We know that this points to a slice and the pointer is not null at this
@@ -187,10 +195,7 @@ impl Clone for BindData {
                 // written. At the time of writing this comment, the `BindData::bind_for_truncated_data`
                 // function is only called by `Binds::populate_dynamic_buffers` which ensures the corresponding
                 // invariant.
-                core::slice::from_raw_parts(
-                    ptr.as_ptr(),
-                    self.length.try_into().expect("usize is at least 32bit"),
-                )
+                core::slice::from_raw_parts(ptr.as_ptr(), length)
             };
             bind_buffer(slice.to_owned())
         } else {
@@ -521,10 +526,9 @@ impl BindData {
     /// this function is unsafe unless the binds are immediately rebound.
     unsafe fn bind_for_truncated_data(&mut self) -> Option<(ffi::MYSQL_BIND, usize)> {
         if self.is_truncated() {
-            if let Some(bytes) = self.bytes {
+            if let Some(bytes) = self.bytes.take() {
                 let mut bytes =
                     unsafe { Vec::from_raw_parts(bytes.as_ptr(), self.capacity, self.capacity) };
-                self.bytes = None;
 
                 let offset = self.capacity;
                 let length = usize::try_from(self.length).expect("Usize is at least 32 bit");

--- a/diesel/src/mysql/types/date_and_time/mod.rs
+++ b/diesel/src/mysql/types/date_and_time/mod.rs
@@ -1,5 +1,6 @@
 use core::ffi as libc;
-use core::{mem, slice};
+use core::mem;
+use core::ptr;
 use std::io::Write;
 
 use crate::deserialize::{self, FromSql, FromSqlRow};
@@ -53,7 +54,7 @@ pub struct MysqlTime {
 impl MysqlTime {
     /// Construct a new instance of [MysqlTime]
     #[allow(clippy::too_many_arguments)]
-    pub fn new(
+    pub const fn new(
         year: libc::c_uint,
         month: libc::c_uint,
         day: libc::c_uint,
@@ -77,6 +78,77 @@ impl MysqlTime {
             time_type,
             time_zone_displacement,
         }
+    }
+
+    // Serialize a given `MysqlTime` instance to a byte buffer
+    #[diesel_derives::__diesel_public_if(
+        feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
+    )]
+    #[allow(unsafe_code)] // manual serialization of a type to a byte array
+    fn serialize(&self) -> [u8; core::mem::size_of::<Self>()] {
+        unsafe fn copy_bytes<T>(out: &mut [u8], field_ptr: &T, start: *const MysqlTime)
+        where
+            T: Copy,
+        {
+            let field_ptr = ptr::from_ref(field_ptr);
+            let offset = unsafe {
+                // SAFETY:
+                // * The inner function is only called with non-zero sized fields of the same struct
+                (field_ptr as *const u8).offset_from(start as *const u8)
+            };
+            let out_ptr = out.as_mut_ptr();
+            unsafe {
+                // SAFETY:
+                // * The inner function ensures that we have a pointer to `T` so it's valid to copy size_of<T>` bytes
+                // * The outer function only calls the inner function for primitive types with a defined layout
+                //   For integers (any field beside `neg`) any bit pattern is valid
+                //   For bools (the `neg` field) only 0 and 1 are valid pattern, but given that we
+                //   go from bool to u8 that's no problem as 0 and 1 are valid u8 bit patterns
+                ptr::copy::<u8>(
+                    field_ptr as *const u8,
+                    dbg!(out_ptr.offset(offset)),
+                    mem::size_of::<T>(),
+                )
+            };
+        }
+        // Start with an empty buffer here
+        let mut buffer = [0_u8; mem::size_of::<MysqlTime>()];
+
+        // we are allowed to have several shared references to self (and it's fields)
+        let start = ptr::from_ref(self);
+
+        // full destructing here to make sure we don't miss a field
+        let MysqlTime {
+            year,
+            month,
+            day,
+            hour,
+            minute,
+            second,
+            second_part,
+            neg,
+            time_type,
+            time_zone_displacement,
+        } = self;
+        // we manually write out each field to an intermediate buffer here
+        // to make sure we don't touch the padding bytes contained in `MysqlTime`
+        // touching the padding bytes would be undefined behaviour
+        unsafe {
+            // SAFETY:
+            // * We only call copy_bytes on fields of the struct
+            // * All struct fields are primitive types
+            copy_bytes(&mut buffer, year, start);
+            copy_bytes(&mut buffer, month, start);
+            copy_bytes(&mut buffer, day, start);
+            copy_bytes(&mut buffer, hour, start);
+            copy_bytes(&mut buffer, minute, start);
+            copy_bytes(&mut buffer, second, start);
+            copy_bytes(&mut buffer, second_part, start);
+            copy_bytes(&mut buffer, neg, start);
+            copy_bytes(&mut buffer, time_type, start);
+            copy_bytes(&mut buffer, time_zone_displacement, start);
+        }
+        buffer
     }
 }
 
@@ -115,13 +187,10 @@ macro_rules! mysql_time_impls {
     ($ty:ty) => {
         #[cfg(feature = "mysql_backend")]
         impl ToSql<$ty, Mysql> for MysqlTime {
-            #[allow(unsafe_code)] // pointer cast
             fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, Mysql>) -> serialize::Result {
-                let bytes = unsafe {
-                    let bytes_ptr = self as *const MysqlTime as *const u8;
-                    slice::from_raw_parts(bytes_ptr, mem::size_of::<MysqlTime>())
-                };
-                out.write_all(bytes)?;
+                let buffer = self.serialize();
+
+                out.write_all(&buffer)?;
                 Ok(IsNull::No)
             }
         }

--- a/diesel/src/mysql/types/primitives.rs
+++ b/diesel/src/mysql/types/primitives.rs
@@ -1,4 +1,6 @@
 use crate::Queryable;
+#[cfg(feature = "mysql_backend")]
+use crate::deserialize::FromSqlRef;
 use crate::deserialize::{self, FromSql};
 use crate::mysql::{Mysql, MysqlValue, NumericRepresentation};
 use crate::result::Error::DeserializationError;
@@ -167,6 +169,14 @@ impl FromSql<Text, Mysql> for *const str {
 }
 
 #[cfg(feature = "mysql_backend")]
+impl<'a> FromSqlRef<'a, Text, Mysql> for &'a str {
+    fn from_sql(bytes: MysqlValue<'a>) -> deserialize::Result<Self> {
+        let string = str::from_utf8(bytes.as_bytes())?;
+        Ok(string)
+    }
+}
+
+#[cfg(feature = "mysql_backend")]
 impl Queryable<Text, Mysql> for *const str {
     type Row = Self;
 
@@ -184,6 +194,13 @@ impl Queryable<Text, Mysql> for *const str {
 impl FromSql<Binary, Mysql> for *const [u8] {
     fn from_sql(value: MysqlValue<'_>) -> deserialize::Result<Self> {
         Ok(value.as_bytes() as *const [u8])
+    }
+}
+
+#[cfg(feature = "mysql_backend")]
+impl<'a> FromSqlRef<'a, Binary, Mysql> for &'a [u8] {
+    fn from_sql(bytes: MysqlValue<'a>) -> deserialize::Result<Self> {
+        Ok(bytes.as_bytes())
     }
 }
 

--- a/diesel/src/mysql/value.rs
+++ b/diesel/src/mysql/value.rs
@@ -26,7 +26,7 @@ impl<'a> MysqlValue<'a> {
     }
 
     /// Get the underlying raw byte representation
-    pub fn as_bytes(&self) -> &[u8] {
+    pub fn as_bytes(&self) -> &'a [u8] {
         self.raw
     }
 

--- a/diesel/src/pg/connection/mod.rs
+++ b/diesel/src/pg/connection/mod.rs
@@ -212,7 +212,7 @@ impl Connection for PgConnection {
                 &mut |query, params, conn, _source| {
                     let res = query
                         .execute(&mut conn.raw_connection, &params, false)
-                        .map(|r| r.rows_affected());
+                        .and_then(|r| r.rows_affected());
                     // according to https://www.postgresql.org/docs/current/libpq-async.html
                     // `PQgetResult` needs to be called till a null pointer is returned
                     while conn.raw_connection.get_next_result()?.is_some() {}
@@ -468,7 +468,7 @@ impl PgConnection {
                     let rows = next_res.rows_affected();
                     while let Some(_r) = conn.raw_connection.get_next_result()? {}
                     r?;
-                    Ok(rows)
+                    rows.map_err(Into::into)
                 }
 
                 let rows = inner_copy_in::<S, T>(stmt, conn, binds, &*source);

--- a/diesel/src/pg/connection/raw.rs
+++ b/diesel/src/pg/connection/raw.rs
@@ -351,9 +351,20 @@ fn last_error_message(conn: *const PGconn) -> String {
 #[allow(missing_debug_implementations)]
 pub(super) struct RawResult(NonNull<PGresult>);
 
+// SAFETY:
+// https://www.postgresql.org/docs/current/libpq-threading.html
+//
+// PGresult objects are normally read-only after creation,
+// and so can be passed around freely between threads. However,
+// if you use any of the PGresult-modifying functions described in
+// Section 31.12 or Section 31.14, it's up to you to avoid concurrent operations on the same PGresult, too.
+//
+// The type doesn't expose the raw pointer
+// and we don't call such Pgresult-modifying below
 unsafe impl Send for RawResult {}
 unsafe impl Sync for RawResult {}
 
+// Make sure to only call non-modifying functions here
 impl RawResult {
     #[allow(clippy::new_ret_no_self)]
     fn new(ptr: *mut PGresult, conn: &RawConnection) -> QueryResult<Self> {
@@ -365,14 +376,104 @@ impl RawResult {
         })
     }
 
-    pub(super) fn as_ptr(&self) -> *mut PGresult {
-        self.0.as_ptr()
-    }
-
     pub(super) fn error_message(&self) -> &str {
         let ptr = unsafe { PQresultErrorMessage(self.0.as_ptr()) };
         let cstr = unsafe { CStr::from_ptr(ptr) };
         cstr.to_str().unwrap_or_default()
+    }
+
+    pub(super) fn get_result_field(&self, field: ResultField) -> Option<&str> {
+        let ptr = unsafe { PQresultErrorField(self.0.as_ptr(), field as libc::c_int) };
+        if ptr.is_null() {
+            return None;
+        }
+
+        let c_str = unsafe { CStr::from_ptr(ptr) };
+        c_str.to_str().ok()
+    }
+
+    pub(super) fn result_status(&self) -> pq_sys::ExecStatusType {
+        unsafe {
+            // SAFETY:
+            // We have a unique not null pointer here
+            PQresultStatus(self.0.as_ptr())
+        }
+    }
+
+    pub(super) fn column_count(&self) -> libc::c_int {
+        unsafe {
+            // SAFETY:
+            // We have a unique not null pointer here
+            PQnfields(self.0.as_ptr())
+        }
+    }
+
+    pub(super) fn row_count(&self) -> libc::c_int {
+        unsafe {
+            // SAFETY:
+            // We have a unique not null pointer here
+            PQntuples(self.0.as_ptr())
+        }
+    }
+
+    pub(super) fn rows_affected(&self) -> &CStr {
+        unsafe {
+            // SAFETY:
+            // We have a unique not null pointer here
+            let count_char_ptr = PQcmdTuples(self.0.as_ptr());
+            CStr::from_ptr(count_char_ptr)
+        }
+    }
+
+    pub(super) fn get_bytes(&self, row_idx: i32, col_idx: i32) -> &[u8] {
+        unsafe {
+            // SAFETY:
+            // We have a unique not null pointer here
+            let value_ptr = PQgetvalue(self.0.as_ptr(), row_idx, col_idx) as *const u8;
+            let num_bytes = PQgetlength(self.0.as_ptr(), row_idx, col_idx);
+            if value_ptr.is_null() {
+                &[]
+            } else {
+                // SAFETY:
+                // * we rely on correct information from libpq here, if the provided length and pointer are invalid
+                core::slice::from_raw_parts(
+                    value_ptr,
+                    num_bytes
+                        .try_into()
+                        .expect("Diesel expects at least a 32 bit operating system"),
+                )
+            }
+        }
+    }
+
+    pub(super) fn is_null(&self, row_idx: libc::c_int, col_idx: libc::c_int) -> libc::c_int {
+        unsafe {
+            // SAFETY:
+            // We have a unique not null pointer here
+            PQgetisnull(self.0.as_ptr(), row_idx, col_idx)
+        }
+    }
+
+    pub(super) fn column_type(&self, col_idx: libc::c_int) -> pq_sys::Oid {
+        unsafe {
+            // SAFETY:
+            // We have a unique not null pointer here
+            PQftype(self.0.as_ptr(), col_idx)
+        }
+    }
+
+    pub(super) fn column_name(&self, col_idx: libc::c_int) -> Option<&CStr> {
+        unsafe {
+            // https://www.postgresql.org/docs/13/libpq-exec.html#LIBPQ-PQFNAME
+            // states that the returned ptr is valid till the underlying result is freed
+            // That means we can couple the lifetime to self
+            let ptr = PQfname(self.0.as_ptr(), col_idx);
+            if ptr.is_null() {
+                None
+            } else {
+                Some(CStr::from_ptr(ptr))
+            }
+        }
     }
 }
 
@@ -380,4 +481,20 @@ impl Drop for RawResult {
     fn drop(&mut self) {
         unsafe { PQclear(self.0.as_ptr()) }
     }
+}
+
+/// Represents valid options to
+/// [`PQresultErrorField`](https://www.postgresql.org/docs/current/static/libpq-exec.html#LIBPQ-PQRESULTERRORFIELD)
+/// Their values are defined as C preprocessor macros, and therefore are not exported by libpq-sys.
+/// Their values can be found in `postgres_ext.h`
+#[repr(i32)]
+pub(super) enum ResultField {
+    SqlState = 'C' as i32,
+    MessagePrimary = 'M' as i32,
+    MessageDetail = 'D' as i32,
+    MessageHint = 'H' as i32,
+    TableName = 't' as i32,
+    ColumnName = 'c' as i32,
+    ConstraintName = 'n' as i32,
+    StatementPosition = 'P' as i32,
 }

--- a/diesel/src/pg/connection/result.rs
+++ b/diesel/src/pg/connection/result.rs
@@ -4,11 +4,10 @@ extern crate pq_sys;
 use self::pq_sys::*;
 use alloc::rc::Rc;
 use core::ffi as libc;
-use core::ffi::CStr;
 use core::num::NonZeroU32;
-use core::{slice, str};
+use core::str;
 
-use super::raw::{RawConnection, RawResult};
+use super::raw::{RawConnection, RawResult, ResultField};
 use super::row::PgRow;
 use crate::result::{DatabaseErrorInformation, DatabaseErrorKind, Error, QueryResult};
 use core::cell::OnceCell;
@@ -27,15 +26,14 @@ pub struct PgResult {
 impl PgResult {
     #[allow(clippy::new_ret_no_self)]
     pub(super) fn new(internal_result: RawResult, conn: &RawConnection) -> QueryResult<Self> {
-        let result_status = unsafe { PQresultStatus(internal_result.as_ptr()) };
-        match result_status {
+        match internal_result.result_status() {
             ExecStatusType::PGRES_SINGLE_TUPLE
             | ExecStatusType::PGRES_COMMAND_OK
             | ExecStatusType::PGRES_COPY_IN
             | ExecStatusType::PGRES_COPY_OUT
             | ExecStatusType::PGRES_TUPLES_OK => {
-                let column_count = unsafe { PQnfields(internal_result.as_ptr()) };
-                let row_count = unsafe { PQntuples(internal_result.as_ptr()) };
+                let column_count = internal_result.column_count();
+                let row_count = internal_result.row_count();
                 Ok(PgResult {
                     internal_result,
                     column_count,
@@ -57,37 +55,32 @@ impl PgResult {
                 // https://www.postgresql.org/docs/current/libpq-async.html
                 while conn.get_next_result().map_or(true, |r| r.is_some()) {}
 
-                let mut error_kind =
-                    match get_result_field(internal_result.as_ptr(), ResultField::SqlState) {
-                        Some(error_codes::UNIQUE_VIOLATION) => DatabaseErrorKind::UniqueViolation,
-                        Some(error_codes::FOREIGN_KEY_VIOLATION) => {
-                            DatabaseErrorKind::ForeignKeyViolation
-                        }
-                        Some(error_codes::SERIALIZATION_FAILURE) => {
-                            DatabaseErrorKind::SerializationFailure
-                        }
-                        Some(error_codes::READ_ONLY_TRANSACTION) => {
-                            DatabaseErrorKind::ReadOnlyTransaction
-                        }
-                        Some(error_codes::NOT_NULL_VIOLATION) => {
-                            DatabaseErrorKind::NotNullViolation
-                        }
-                        Some(error_codes::CHECK_VIOLATION) => DatabaseErrorKind::CheckViolation,
-                        Some(error_codes::RESTRICT_VIOLATION) => {
-                            DatabaseErrorKind::RestrictViolation
-                        }
-                        Some(error_codes::EXCLUSION_VIOLATION) => {
-                            DatabaseErrorKind::ExclusionViolation
-                        }
-                        Some(error_codes::CONNECTION_EXCEPTION)
-                        | Some(error_codes::CONNECTION_FAILURE)
-                        | Some(error_codes::SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION)
-                        | Some(error_codes::SQLSERVER_REJECTED_ESTABLISHMENT_OF_SQLCONNECTION) => {
-                            DatabaseErrorKind::ClosedConnection
-                        }
-                        _ => DatabaseErrorKind::Unknown,
-                    };
-                let error_information = Box::new(PgErrorInformation(internal_result));
+                let mut error_kind = match internal_result.get_result_field(ResultField::SqlState) {
+                    Some(error_codes::UNIQUE_VIOLATION) => DatabaseErrorKind::UniqueViolation,
+                    Some(error_codes::FOREIGN_KEY_VIOLATION) => {
+                        DatabaseErrorKind::ForeignKeyViolation
+                    }
+                    Some(error_codes::SERIALIZATION_FAILURE) => {
+                        DatabaseErrorKind::SerializationFailure
+                    }
+                    Some(error_codes::READ_ONLY_TRANSACTION) => {
+                        DatabaseErrorKind::ReadOnlyTransaction
+                    }
+                    Some(error_codes::NOT_NULL_VIOLATION) => DatabaseErrorKind::NotNullViolation,
+                    Some(error_codes::CHECK_VIOLATION) => DatabaseErrorKind::CheckViolation,
+                    Some(error_codes::RESTRICT_VIOLATION) => DatabaseErrorKind::RestrictViolation,
+                    Some(error_codes::EXCLUSION_VIOLATION) => DatabaseErrorKind::ExclusionViolation,
+                    Some(error_codes::CONNECTION_EXCEPTION)
+                    | Some(error_codes::CONNECTION_FAILURE)
+                    | Some(error_codes::SQLCLIENT_UNABLE_TO_ESTABLISH_SQLCONNECTION)
+                    | Some(error_codes::SQLSERVER_REJECTED_ESTABLISHMENT_OF_SQLCONNECTION) => {
+                        DatabaseErrorKind::ClosedConnection
+                    }
+                    _ => DatabaseErrorKind::Unknown,
+                };
+                let error_information = Box::new(PgErrorInformation {
+                    result: internal_result,
+                });
                 let conn_status = conn.get_status();
                 if conn_status == ConnStatusType::CONNECTION_BAD {
                     error_kind = DatabaseErrorKind::ClosedConnection;
@@ -97,19 +90,16 @@ impl PgResult {
         }
     }
 
-    pub(super) fn rows_affected(&self) -> usize {
-        unsafe {
-            let count_char_ptr = PQcmdTuples(self.internal_result.as_ptr());
-            let count_bytes = CStr::from_ptr(count_char_ptr).to_bytes();
-            // Using from_utf8_unchecked is ok here because, we've set the
-            // client encoding to utf8
-            let count_str = str::from_utf8_unchecked(count_bytes);
-            match count_str {
-                "" => 0,
-                _ => count_str
-                    .parse()
-                    .expect("Error parsing `rows_affected` as integer value"),
-            }
+    pub(super) fn rows_affected(&self) -> QueryResult<usize> {
+        let rows = self.internal_result.rows_affected();
+        let count_str = rows
+            .to_str()
+            .map_err(|e| Error::DeserializationError(Box::new(e)))?;
+        match count_str {
+            "" => Ok(0),
+            _ => count_str
+                .parse()
+                .map_err(|e| Error::DeserializationError(Box::new(e))),
         }
     }
 
@@ -130,17 +120,7 @@ impl PgResult {
         } else {
             let row_idx = row_idx.try_into().ok()?;
             let col_idx = col_idx.try_into().ok()?;
-            unsafe {
-                let value_ptr =
-                    PQgetvalue(self.internal_result.as_ptr(), row_idx, col_idx) as *const u8;
-                let num_bytes = PQgetlength(self.internal_result.as_ptr(), row_idx, col_idx);
-                Some(slice::from_raw_parts(
-                    value_ptr,
-                    num_bytes
-                        .try_into()
-                        .expect("Diesel expects at least a 32 bit operating system"),
-                ))
-            }
+            Some(self.internal_result.get_bytes(row_idx, col_idx))
         }
     }
 
@@ -152,14 +132,14 @@ impl PgResult {
             .try_into()
             .expect("Column indices are expected to fit into 32 bit");
 
-        unsafe { 0 != PQgetisnull(self.internal_result.as_ptr(), row_idx, col_idx) }
+        self.internal_result.is_null(row_idx, col_idx) != 0
     }
 
     pub(in crate::pg) fn column_type(&self, col_idx: usize) -> NonZeroU32 {
         let col_idx: i32 = col_idx
             .try_into()
             .expect("Column indices are expected to fit into 32 bit");
-        let type_oid = unsafe { PQftype(self.internal_result.as_ptr(), col_idx) };
+        let type_oid = self.internal_result.column_type(col_idx);
         NonZeroU32::new(type_oid).expect(
             "Got a zero oid from postgres. If you see this error message \
              please report it as issue on the diesel github bug tracker.",
@@ -171,19 +151,15 @@ impl PgResult {
         self.column_name_map
             .get_or_init(|| {
                 (0..self.column_count)
-                    .map(|idx| unsafe {
-                        // https://www.postgresql.org/docs/13/libpq-exec.html#LIBPQ-PQFNAME
-                        // states that the returned ptr is valid till the underlying result is freed
-                        // That means we can couple the lifetime to self
-                        let ptr = PQfname(self.internal_result.as_ptr(), idx as libc::c_int);
-                        if ptr.is_null() {
-                            None
-                        } else {
-                            Some(CStr::from_ptr(ptr).to_str().expect(
-                                "Expect postgres field names to be UTF-8, because we \
-                     requested UTF-8 encoding on connection setup",
-                            ) as *const str)
-                        }
+                    .map(|idx| {
+                        self.internal_result
+                            .column_name(idx as libc::c_int)
+                            .map(|name| {
+                                name.to_str().expect(
+                                    "Expect postgres field names to be UTF-8, because we \
+-                     requested UTF-8 encoding on connection setup",
+                                ) as *const str
+                            })
                     })
                     .collect()
             })
@@ -205,64 +181,43 @@ impl PgResult {
     }
 }
 
-struct PgErrorInformation(RawResult);
+struct PgErrorInformation {
+    result: RawResult,
+}
 
 impl DatabaseErrorInformation for PgErrorInformation {
     fn message(&self) -> &str {
-        get_result_field(self.0.as_ptr(), ResultField::MessagePrimary)
-            .unwrap_or_else(|| self.0.error_message())
+        self.result
+            .get_result_field(ResultField::MessagePrimary)
+            .unwrap_or_else(|| self.result.error_message())
     }
 
     fn details(&self) -> Option<&str> {
-        get_result_field(self.0.as_ptr(), ResultField::MessageDetail)
+        self.result.get_result_field(ResultField::MessageDetail)
     }
 
     fn hint(&self) -> Option<&str> {
-        get_result_field(self.0.as_ptr(), ResultField::MessageHint)
+        self.result.get_result_field(ResultField::MessageHint)
     }
 
     fn table_name(&self) -> Option<&str> {
-        get_result_field(self.0.as_ptr(), ResultField::TableName)
+        self.result.get_result_field(ResultField::TableName)
     }
 
     fn column_name(&self) -> Option<&str> {
-        get_result_field(self.0.as_ptr(), ResultField::ColumnName)
+        self.result.get_result_field(ResultField::ColumnName)
     }
 
     fn constraint_name(&self) -> Option<&str> {
-        get_result_field(self.0.as_ptr(), ResultField::ConstraintName)
+        self.result.get_result_field(ResultField::ConstraintName)
     }
 
     fn statement_position(&self) -> Option<i32> {
-        let str_pos = get_result_field(self.0.as_ptr(), ResultField::StatementPosition)?;
+        let str_pos = self
+            .result
+            .get_result_field(ResultField::StatementPosition)?;
         str_pos.parse::<i32>().ok()
     }
-}
-
-/// Represents valid options to
-/// [`PQresultErrorField`](https://www.postgresql.org/docs/current/static/libpq-exec.html#LIBPQ-PQRESULTERRORFIELD)
-/// Their values are defined as C preprocessor macros, and therefore are not exported by libpq-sys.
-/// Their values can be found in `postgres_ext.h`
-#[repr(i32)]
-enum ResultField {
-    SqlState = 'C' as i32,
-    MessagePrimary = 'M' as i32,
-    MessageDetail = 'D' as i32,
-    MessageHint = 'H' as i32,
-    TableName = 't' as i32,
-    ColumnName = 'c' as i32,
-    ConstraintName = 'n' as i32,
-    StatementPosition = 'P' as i32,
-}
-
-fn get_result_field<'a>(res: *mut PGresult, field: ResultField) -> Option<&'a str> {
-    let ptr = unsafe { PQresultErrorField(res, field as libc::c_int) };
-    if ptr.is_null() {
-        return None;
-    }
-
-    let c_str = unsafe { CStr::from_ptr(ptr) };
-    c_str.to_str().ok()
 }
 
 mod error_codes {

--- a/diesel/src/pg/query_builder/copy/copy_from.rs
+++ b/diesel/src/pg/query_builder/copy/copy_from.rs
@@ -55,8 +55,11 @@ impl QueryFragment<Pg> for CopyFromOptions {
                 pass.push_sql(comma);
                 comma = ", ";
                 pass.push_sql("DEFAULT '");
-                // cannot use binds here :(
-                pass.push_sql(default);
+                // we cannot use binds here
+                // so we need to make sure quotes in
+                // the input are handled correctly
+                let default = default.replace('\'', "''");
+                pass.push_sql(&default);
                 pass.push_sql("'");
             }
             if let Some(ref header) = self.header {

--- a/diesel/src/pg/query_builder/copy/mod.rs
+++ b/diesel/src/pg/query_builder/copy/mod.rs
@@ -85,22 +85,43 @@ impl CommonOptions {
             *comma = ", ";
         }
         if let Some(delimiter) = self.delimiter {
+            // we need to take care for the quoting character here
+            let delimiter = if delimiter == '\'' {
+                "''".into()
+            } else {
+                String::from(delimiter)
+            };
             pass.push_sql(&format!("{comma}DELIMITER '{delimiter}'"));
             *comma = ", ";
         }
         if let Some(ref null) = self.null {
             pass.push_sql(comma);
             *comma = ", ";
+            // we cannot use binds here
+            // so we need to make sure quotes in
+            // the input are handled correctly
+            let null = null.replace('\'', "''");
             pass.push_sql("NULL '");
-            // we cannot use binds here :(
-            pass.push_sql(null);
+            pass.push_sql(&null);
             pass.push_sql("'");
         }
         if let Some(quote) = self.quote {
+            // we need to take care for the quoting character here
+            let quote = if quote == '\'' {
+                "''".into()
+            } else {
+                String::from(quote)
+            };
             pass.push_sql(&format!("{comma}QUOTE '{quote}'"));
             *comma = ", ";
         }
         if let Some(escape) = self.escape {
+            // we need to take care for the quoting character here
+            let escape = if escape == '\'' {
+                "''".into()
+            } else {
+                String::from(escape)
+            };
             pass.push_sql(&format!("{comma}ESCAPE '{escape}'"));
             *comma = ", ";
         }

--- a/diesel/src/pg/types/primitives.rs
+++ b/diesel/src/pg/types/primitives.rs
@@ -1,5 +1,7 @@
 use std::io::prelude::*;
 
+#[cfg(feature = "postgres_backend")]
+use crate::deserialize::FromSqlRef;
 use crate::deserialize::{self, FromSql, Queryable};
 use crate::pg::{Pg, PgValue};
 use crate::serialize::{self, IsNull, Output, ToSql};
@@ -52,6 +54,13 @@ impl FromSql<sql_types::Text, Pg> for *const str {
 }
 
 #[cfg(feature = "postgres_backend")]
+impl<'a> FromSqlRef<'a, sql_types::Text, Pg> for &'a str {
+    fn from_sql(value: PgValue<'a>) -> deserialize::Result<Self> {
+        Ok(core::str::from_utf8(value.as_bytes())?)
+    }
+}
+
+#[cfg(feature = "postgres_backend")]
 impl Queryable<sql_types::VarChar, Pg> for *const str {
     type Row = Self;
 
@@ -93,6 +102,12 @@ impl FromSql<sql_types::Citext, Pg> for String {
 impl FromSql<sql_types::Binary, Pg> for *const [u8] {
     fn from_sql(value: PgValue<'_>) -> deserialize::Result<Self> {
         Ok(value.as_bytes() as *const _)
+    }
+}
+
+impl<'a> FromSqlRef<'a, sql_types::Binary, Pg> for &'a [u8] {
+    fn from_sql(bytes: PgValue<'a>) -> deserialize::Result<Self> {
+        Ok(bytes.as_bytes())
     }
 }
 

--- a/diesel/src/pg/value.rs
+++ b/diesel/src/pg/value.rs
@@ -81,7 +81,7 @@ impl<'a> PgValue<'a> {
     }
 
     /// Get the underlying raw byte representation
-    pub fn as_bytes(&self) -> &[u8] {
+    pub fn as_bytes(&self) -> &'a [u8] {
         self.raw_value
     }
 

--- a/diesel/src/query_builder/debug_query.rs
+++ b/diesel/src/query_builder/debug_query.rs
@@ -41,23 +41,37 @@ where
     Ok(query_builder.finish())
 }
 
-fn display<DB>(query: &dyn QueryFragment<DB>, f: &mut fmt::Formatter<'_>) -> fmt::Result
+fn fmt_query<DB>(
+    query: &dyn QueryFragment<DB>,
+    f: &mut fmt::Formatter<'_>,
+    formatter: fn(String, &DebugBinds<'_>, f: &mut fmt::Formatter<'_>) -> fmt::Result,
+) -> fmt::Result
 where
     DB: Backend + Default,
     DB::QueryBuilder: Default,
 {
-    let debug_binds = DebugBinds::<DB>::new(query);
+    let backend = DB::default();
+    let mut buffer = Vec::new();
+    let ast_pass = AstPass::debug_binds(&mut buffer, &backend);
+    query.walk_ast(ast_pass).map_err(|_| fmt::Error)?;
+    let debug_binds = DebugBinds::new(&buffer);
     let query = serialize_query(query)?;
+    formatter(query, &debug_binds, f)
+}
+
+pub(crate) fn display(
+    query: String,
+    debug_binds: &DebugBinds<'_>,
+    f: &mut fmt::Formatter<'_>,
+) -> fmt::Result {
     write!(f, "{query} -- binds: {debug_binds:?}")
 }
 
-fn debug<DB>(query: &dyn QueryFragment<DB>, f: &mut fmt::Formatter<'_>) -> fmt::Result
-where
-    DB: Backend + Default,
-    DB::QueryBuilder: Default,
-{
-    let debug_binds = DebugBinds::<DB>::new(query);
-    let query = serialize_query(query)?;
+pub(crate) fn debug(
+    query: String,
+    debug_binds: &DebugBinds<'_>,
+    f: &mut fmt::Formatter<'_>,
+) -> fmt::Result {
     f.debug_struct("Query")
         .field("sql", &query)
         .field("binds", &debug_binds)
@@ -71,7 +85,7 @@ where
     T: QueryFragment<DB>,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        display(self.query, f)
+        fmt_query(self.query, f, display)
     }
 }
 
@@ -82,35 +96,25 @@ where
     T: QueryFragment<DB>,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        debug(self.query, f)
+        fmt_query(self.query, f, debug)
     }
 }
 
 /// A struct that implements `fmt::Debug` by walking the given AST and writing
 /// the `fmt::Debug` implementation of each bind parameter.
-pub(crate) struct DebugBinds<'a, DB> {
-    query: &'a dyn QueryFragment<DB>,
+pub(crate) struct DebugBinds<'a> {
+    binds: &'a [Box<dyn Debug + 'a>],
 }
 
-impl<'a, DB> DebugBinds<'a, DB>
-where
-    DB: Backend,
-{
-    fn new(query: &'a dyn QueryFragment<DB>) -> Self {
-        DebugBinds { query }
+impl<'a> DebugBinds<'a> {
+    pub(crate) fn new(binds: &'a [Box<dyn Debug + 'a>]) -> Self {
+        DebugBinds { binds }
     }
 }
 
-impl<DB> Debug for DebugBinds<'_, DB>
-where
-    DB: Backend + Default,
-{
+impl Debug for DebugBinds<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let backend = DB::default();
-        let mut buffer = Vec::new();
-        let ast_pass = AstPass::debug_binds(&mut buffer, &backend);
-        self.query.walk_ast(ast_pass).map_err(|_| fmt::Error)?;
-        format_list(f, &buffer)
+        format_list(f, self.binds)
     }
 }
 

--- a/diesel/src/query_builder/insert_statement/insert_with_default_for_sqlite.rs
+++ b/diesel/src/query_builder/insert_statement/insert_with_default_for_sqlite.rs
@@ -2,11 +2,12 @@ use super::{BatchInsert, InsertStatement};
 use crate::insertable::InsertValues;
 use crate::insertable::{CanInsertInSingleQuery, ColumnInsertValue, DefaultableColumnInsertValue};
 use crate::prelude::*;
+use crate::query_builder::debug_query::DebugBinds;
 use crate::query_builder::upsert::on_conflict_clause::OnConflictValues;
-use crate::query_builder::{AstPass, QueryId, ValuesClause};
+use crate::query_builder::{AstPass, QueryBuilder, QueryId, ValuesClause};
 use crate::query_builder::{DebugQuery, QueryFragment};
 use crate::query_dsl::{LoadQuery, methods::ExecuteDsl};
-use crate::sqlite::Sqlite;
+use crate::sqlite::{Sqlite, SqliteQueryBuilder};
 use alloc::string::String;
 use alloc::string::ToString;
 use alloc::vec::Vec;
@@ -65,50 +66,93 @@ where
     }
 }
 
-#[allow(unsafe_code)] // cast to transparent wrapper type
 impl<'a, T, V, QId, Op, const STATIC_QUERY_ID: bool> DebugQueryHelper<No>
-    for DebugQuery<'a, InsertStatement<T, BatchInsert<V, T, QId, STATIC_QUERY_ID>, Op>, Sqlite>
-where
-    T: Copy + QuerySource,
-    Op: Copy,
-    DebugQuery<
+    for DebugQuery<
         'a,
-        InsertStatement<T, SqliteBatchInsertWrapper<V, T, QId, STATIC_QUERY_ID>, Op>,
+        InsertStatement<T, BatchInsert<Vec<ValuesClause<V, T>>, T, QId, STATIC_QUERY_ID>, Op>,
         Sqlite,
-    >: Debug + Display,
+    >
+where
+    T: Copy + Table,
+    Op: Copy + QueryFragment<Sqlite>,
+    SqliteBatchInsertWrapper<Vec<ValuesClause<V, T>>, T, QId, STATIC_QUERY_ID>:
+        QueryFragment<Sqlite>,
+    V: CanInsertInSingleQuery<Sqlite>,
+    T::FromClause: QueryFragment<Sqlite>,
 {
     fn fmt_debug(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let value = unsafe {
-            // This cast is safe as `SqliteBatchInsertWrapper` is #[repr(transparent)]
-            &*(self as *const DebugQuery<
-                'a,
-                InsertStatement<T, BatchInsert<V, T, QId, STATIC_QUERY_ID>, Op>,
-                Sqlite,
-            >
-                as *const DebugQuery<
-                    'a,
-                    InsertStatement<T, SqliteBatchInsertWrapper<V, T, QId, STATIC_QUERY_ID>, Op>,
-                    Sqlite,
-                >)
-        };
-        <_ as Debug>::fmt(value, f)
+        self.fmt_helper(f, crate::query_builder::debug_query::debug)
     }
 
     fn fmt_display(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let value = unsafe {
-            // This cast is safe as `SqliteBatchInsertWrapper` is #[repr(transparent)]
-            &*(self as *const DebugQuery<
-                'a,
-                InsertStatement<T, BatchInsert<V, T, QId, STATIC_QUERY_ID>, Op>,
-                Sqlite,
-            >
-                as *const DebugQuery<
-                    'a,
-                    InsertStatement<T, SqliteBatchInsertWrapper<V, T, QId, STATIC_QUERY_ID>, Op>,
-                    Sqlite,
+        self.fmt_helper(f, crate::query_builder::debug_query::display)
+    }
+}
+
+#[allow(unsafe_code)] // cast to transparent wrapper type
+impl<'a, T, V, QId, Op, const STATIC_QUERY_ID: bool>
+    DebugQuery<
+        'a,
+        InsertStatement<T, BatchInsert<Vec<ValuesClause<V, T>>, T, QId, STATIC_QUERY_ID>, Op>,
+        Sqlite,
+    >
+where
+    T: Copy + Table,
+    Op: Copy + QueryFragment<Sqlite>,
+    SqliteBatchInsertWrapper<Vec<ValuesClause<V, T>>, T, QId, STATIC_QUERY_ID>:
+        QueryFragment<Sqlite>,
+    V: CanInsertInSingleQuery<Sqlite>,
+    T::FromClause: QueryFragment<Sqlite>,
+{
+    fn fmt_helper(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+        formatter: fn(String, &DebugBinds<'_>, &mut fmt::Formatter<'_>) -> fmt::Result,
+    ) -> fmt::Result {
+        // explicit destruct to make sure we use all  the fields
+        let InsertStatement {
+            operator,
+            target: _,
+            records,
+            returning,
+            into_clause,
+        } = self.query;
+        let records = unsafe {
+            // SAFETY:
+            // * SqliteBatchInsertWrapper is `#[repr(transparent)]` so this cast
+            // is allowed
+            &*(records as *const _
+                as *const SqliteBatchInsertWrapper<
+                    Vec<ValuesClause<V, T>>,
+                    T,
+                    QId,
+                    STATIC_QUERY_ID,
                 >)
         };
-        <_ as Display>::fmt(value, f)
+        let mut buffer = Vec::new();
+        let ast_pass = AstPass::debug_binds(&mut buffer, &Sqlite);
+        super::insert_statement::walk_ast_intern::<T, _, _, _, Sqlite>(
+            ast_pass,
+            records,
+            into_clause,
+            operator,
+            returning,
+        )
+        .map_err(|_| fmt::Error)?;
+        let mut query_builder = SqliteQueryBuilder::default();
+        let mut ast_pass_to_sql_options = Default::default();
+        let sql_pass = AstPass::to_sql(&mut query_builder, &mut ast_pass_to_sql_options, &Sqlite);
+        super::insert_statement::walk_ast_intern::<T, _, _, _, Sqlite>(
+            sql_pass,
+            records,
+            into_clause,
+            operator,
+            returning,
+        )
+        .map_err(|_| fmt::Error)?;
+        let query = query_builder.finish();
+        let debug_binds = crate::query_builder::debug_query::DebugBinds::new(&buffer);
+        formatter(query, &debug_binds, f)
     }
 }
 

--- a/diesel/src/query_builder/insert_statement/mod.rs
+++ b/diesel/src/query_builder/insert_statement/mod.rs
@@ -228,6 +228,40 @@ impl<T: QuerySource, U, C, Op, Ret> InsertStatement<T, InsertFromSelect<U, C>, O
     }
 }
 
+// This is a separate free standing function
+// so that the debug impl for sqlite can use it with
+// slightly adjusted types
+pub(super) fn walk_ast_intern<'b, T, U, Op, Ret, DB>(
+    mut out: AstPass<'_, 'b, DB>,
+    records: &'b U,
+    into_clause: &'b T::FromClause,
+    operator: &'b Op,
+    returning: &'b Ret,
+) -> QueryResult<()>
+where
+    DB: Backend + DieselReserveSpecialization,
+    T: Table,
+    T::FromClause: QueryFragment<DB>,
+    U: QueryFragment<DB> + CanInsertInSingleQuery<DB>,
+    Op: QueryFragment<DB>,
+    Ret: QueryFragment<DB>,
+{
+    if records.rows_to_insert() == Some(0) {
+        out.push_sql("SELECT 1 FROM ");
+        into_clause.walk_ast(out.reborrow())?;
+        out.push_sql(" WHERE 1=0");
+        return Ok(());
+    }
+
+    operator.walk_ast(out.reborrow())?;
+    out.push_sql(" INTO ");
+    into_clause.walk_ast(out.reborrow())?;
+    out.push_sql(" ");
+    records.walk_ast(out.reborrow())?;
+    returning.walk_ast(out.reborrow())?;
+    Ok(())
+}
+
 impl<T, U, Op, Ret, DB> QueryFragment<DB> for InsertStatement<T, U, Op, Ret>
 where
     DB: Backend + DieselReserveSpecialization,
@@ -237,21 +271,14 @@ where
     Op: QueryFragment<DB>,
     Ret: QueryFragment<DB>,
 {
-    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
-        if self.records.rows_to_insert() == Some(0) {
-            out.push_sql("SELECT 1 FROM ");
-            self.into_clause.walk_ast(out.reborrow())?;
-            out.push_sql(" WHERE 1=0");
-            return Ok(());
-        }
-
-        self.operator.walk_ast(out.reborrow())?;
-        out.push_sql(" INTO ");
-        self.into_clause.walk_ast(out.reborrow())?;
-        out.push_sql(" ");
-        self.records.walk_ast(out.reborrow())?;
-        self.returning.walk_ast(out.reborrow())?;
-        Ok(())
+    fn walk_ast<'b>(&'b self, out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
+        walk_ast_intern::<T, U, Op, Ret, DB>(
+            out,
+            &self.records,
+            &self.into_clause,
+            &self.operator,
+            &self.returning,
+        )
     }
 }
 

--- a/diesel/src/sqlite/connection/functions.rs
+++ b/diesel/src/sqlite/connection/functions.rs
@@ -5,7 +5,6 @@ extern crate libsqlite3_sys as ffi;
 use sqlite_wasm_rs as ffi;
 
 use super::raw::RawConnection;
-use super::row::PrivateSqliteRow;
 use super::{Sqlite, SqliteAggregateFunction, SqliteBindValue};
 use crate::backend::Backend;
 use crate::deserialize::{FromSqlRow, StaticallySizedRow};
@@ -17,13 +16,7 @@ use crate::sqlite::SqliteValue;
 use crate::sqlite::connection::bind_collector::InternalSqliteBindValue;
 use crate::sqlite::connection::sqlite_value::OwnedSqliteValue;
 use alloc::boxed::Box;
-use alloc::rc::Rc;
 use alloc::string::ToString;
-use alloc::vec::Vec;
-use core::cell::{Ref, RefCell};
-use core::marker::PhantomData;
-use core::mem::ManuallyDrop;
-use core::ops::DerefMut;
 
 pub(super) fn register<ArgsSqlType, RetSqlType, Args, Ret, F>(
     conn: &RawConnection,
@@ -129,26 +122,8 @@ where
 }
 
 struct FunctionRow<'a> {
-    // we use `ManuallyDrop` to prevent dropping the content of the internal vector
-    // as this buffer is owned by sqlite not by diesel
-    args: Rc<RefCell<ManuallyDrop<PrivateSqliteRow<'a, 'static>>>>,
+    args: &'a [Option<OwnedSqliteValue>],
     field_count: usize,
-    marker: PhantomData<&'a ffi::sqlite3_value>,
-}
-
-impl Drop for FunctionRow<'_> {
-    #[allow(unsafe_code)] // manual drop calls
-    fn drop(&mut self) {
-        if let Some(args) = Rc::get_mut(&mut self.args)
-            && let PrivateSqliteRow::Duplicated { column_names, .. } =
-                DerefMut::deref_mut(RefCell::get_mut(args))
-            && Rc::strong_count(column_names) == 1
-        {
-            // According the https://doc.rust-lang.org/std/mem/struct.ManuallyDrop.html#method.drop
-            // it's fine to just drop the values here
-            unsafe { core::ptr::drop_in_place(column_names as *mut _) }
-        }
-    }
 }
 
 impl FunctionRow<'_> {
@@ -156,7 +131,7 @@ impl FunctionRow<'_> {
     fn new(args: &mut [*mut ffi::sqlite3_value]) -> Self {
         let lengths = args.len();
         let args = unsafe {
-            Vec::from_raw_parts(
+            core::slice::from_raw_parts(
                 // This cast is safe because:
                 // * Casting from a pointer to an array to a pointer to the first array
                 // element is safe
@@ -169,25 +144,15 @@ impl FunctionRow<'_> {
                 // Option<NonNull<T>> has the same size as *mut T"
                 // * The last point remains true for `OwnedSqliteValue` as `#[repr(transparent)]
                 // guarantees the same layout as the inner type
-                // * It's unsafe to drop the vector (and the vector elements)
-                // because of this we wrap the vector (or better the Row)
-                // Into `ManualDrop` to prevent the dropping
                 args as *mut [*mut ffi::sqlite3_value] as *mut ffi::sqlite3_value
                     as *mut Option<OwnedSqliteValue>,
-                lengths,
                 lengths,
             )
         };
 
         Self {
             field_count: lengths,
-            args: Rc::new(RefCell::new(ManuallyDrop::new(
-                PrivateSqliteRow::Duplicated {
-                    values: args,
-                    column_names: Rc::from(alloc::vec![None; lengths]),
-                },
-            ))),
-            marker: PhantomData,
+            args,
         }
     }
 }
@@ -213,7 +178,7 @@ impl<'a> Row<'a, Sqlite> for FunctionRow<'a> {
     {
         let col_idx = self.idx(idx)?;
         Some(FunctionArgument {
-            args: self.args.borrow(),
+            args: self.args,
             col_idx,
         })
     }
@@ -240,7 +205,7 @@ impl<'a> RowIndex<&'a str> for FunctionRow<'_> {
 }
 
 struct FunctionArgument<'a> {
-    args: Ref<'a, ManuallyDrop<PrivateSqliteRow<'a, 'static>>>,
+    args: &'a [Option<OwnedSqliteValue>],
     col_idx: usize,
 }
 
@@ -254,9 +219,6 @@ impl<'a> Field<'a, Sqlite> for FunctionArgument<'a> {
     }
 
     fn value(&self) -> Option<<Sqlite as Backend>::RawValue<'_>> {
-        SqliteValue::new(
-            Ref::map(Ref::clone(&self.args), |drop| core::ops::Deref::deref(drop)),
-            self.col_idx,
-        )
+        SqliteValue::from_function_row(self.args, self.col_idx)
     }
 }

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -1741,4 +1741,37 @@ mod tests {
         data.read_to_end(&mut buf).unwrap();
         assert_eq!(buf, b"abc");
     }
+
+    #[diesel_test_helper::test]
+    fn aggregate_function_works_with_aligned_data() {
+        #[derive(Debug, Default)]
+        #[repr(align(64))]
+        struct OverAligned;
+
+        impl SqliteAggregateFunction<i32> for OverAligned {
+            type Output = i64;
+
+            fn step(&mut self, _value: i32) {
+                let need = core::mem::align_of::<Self>();
+                let got = core::mem::align_of_val(self);
+                assert_eq!(need, got);
+            }
+
+            fn finalize(_agg: Option<Self>) -> i64 {
+                0
+            }
+        }
+        #[declare_sql_function]
+        extern "SQL" {
+            #[aggregate]
+            fn over_aligned_sum(x: Integer) -> diesel::sql_types::BigInt;
+        }
+
+        let mut conn = SqliteConnection::establish(":memory:").unwrap();
+        over_aligned_sum_utils::register_impl::<OverAligned, _>(&mut conn).unwrap();
+
+        diesel::select(over_aligned_sum(1))
+            .execute(&mut conn)
+            .unwrap();
+    }
 }

--- a/diesel/src/sqlite/connection/raw.rs
+++ b/diesel/src/sqlite/connection/raw.rs
@@ -119,20 +119,22 @@ impl RawConnection {
         Ret: ToSql<RetSqlType, Sqlite>,
         Sqlite: HasSqlType<RetSqlType>,
     {
-        let callback_fn = Box::into_raw(Box::new(CustomFunctionUserPtr {
-            callback: f,
-            function_name: fn_name.to_owned(),
-        }));
-        let fn_name = Self::get_fn_name(fn_name)?;
+        let c_fn_name = Self::get_fn_name(fn_name)?;
         let flags = Self::get_flags(deterministic);
         let num_args = num_args
             .try_into()
             .map_err(|e| Error::SerializationError(Box::new(e)))?;
+        // only create the pointer as last step here
+        // as we can otherwise leak memory
+        let callback_fn = Box::into_raw(Box::new(CustomFunctionUserPtr {
+            callback: f,
+            function_name: fn_name.to_owned(),
+        }));
 
         let result = unsafe {
             ffi::sqlite3_create_function_v2(
                 self.internal_connection.as_ptr(),
-                fn_name.as_ptr(),
+                c_fn_name.as_ptr(),
                 num_args,
                 flags,
                 callback_fn as *mut _,
@@ -163,17 +165,25 @@ impl RawConnection {
             .try_into()
             .map_err(|e| Error::SerializationError(Box::new(e)))?;
 
+        // we pass in the aggregate instance as a user pointer
+        // instead of relying on `sqlite3_aggregate_context` to have
+        // control about the allocation. Specifically allocating
+        // on the rust side will make sure the alignment of the
+        // aggregate instance is correct
+        // Any potential failing code is happening above so we don't leak this memory
+        let ctx_ptr = Box::into_raw(Box::new(None::<A>));
+
         let result = unsafe {
             ffi::sqlite3_create_function_v2(
                 self.internal_connection.as_ptr(),
                 fn_name.as_ptr(),
                 num_args,
                 flags,
-                ptr::null_mut(),
+                ctx_ptr.cast(),
                 None,
                 Some(run_aggregator_step_function::<_, _, _, _, A>),
                 Some(run_aggregator_final_function::<_, _, _, _, A>),
-                None,
+                Some(destroy_boxed::<Option<A>>),
             )
         };
 
@@ -188,16 +198,17 @@ impl RawConnection {
     where
         F: Fn(&str, &str) -> core::cmp::Ordering + core::panic::UnwindSafe + Send + 'static,
     {
+        let c_collation_name = Self::get_fn_name(collation_name)?;
+        // only create the pointer as last step here as we otherwise could leak memory
         let callback_fn = Box::into_raw(Box::new(CollationUserPtr {
             callback: collation,
             collation_name: collation_name.to_owned(),
         }));
-        let collation_name = Self::get_fn_name(collation_name)?;
 
         let result = unsafe {
             ffi::sqlite3_create_collation_v2(
                 self.internal_connection.as_ptr(),
-                collation_name.as_ptr(),
+                c_collation_name.as_ptr(),
                 ffi::SQLITE_UTF8,
                 callback_fn as *mut _,
                 Some(run_collation_function::<F>),
@@ -436,15 +447,6 @@ extern "C" fn run_custom_function<F, Ret, RetSqlType>(
     }
 }
 
-// Need a custom option type here, because the std lib one does not have guarantees about the discriminate values
-// See: https://github.com/rust-lang/rfcs/blob/master/text/2195-really-tagged-unions.md#opaque-tags
-#[repr(u8)]
-enum OptionalAggregator<A> {
-    // Discriminant is 0
-    None,
-    Some(A),
-}
-
 #[allow(warnings)]
 extern "C" fn run_aggregator_step_function<ArgsSqlType, RetSqlType, Args, Ret, A>(
     ctx: *mut ffi::sqlite3_context,
@@ -481,54 +483,27 @@ where
     A: SqliteAggregateFunction<Args>,
     Args: FromSqlRow<ArgsSqlType, Sqlite>,
 {
-    static NULL_AG_CTX_ERR: &str = "An unknown error occurred. sqlite3_aggregate_context returned a null pointer. This should never happen.";
     static NULL_CTX_ERR: &str =
-        "We've written the aggregator to the aggregate context, but it could not be retrieved.";
+        "We've written the aggregator to the user data, but it could not be retrieved.";
 
-    let n_bytes: i32 = core::mem::size_of::<OptionalAggregator<A>>()
-        .try_into()
-        .expect("Aggregate context should be larger than 2^32");
-    let aggregate_context = unsafe {
-        // This block of unsafe code makes the following assumptions:
-        //
-        // * sqlite3_aggregate_context allocates sizeof::<OptionalAggregator<A>>
-        //   bytes of zeroed memory as documented here:
-        //   https://www.sqlite.org/c3ref/aggregate_context.html
-        //   A null pointer is returned for negative or zero sized types,
-        //   which should be impossible in theory. We check that nevertheless
-        //
-        // * OptionalAggregator::None has a discriminant of 0 as specified by
-        //   #[repr(u8)] + RFC 2195
-        //
-        // * If all bytes are zero, the discriminant is also zero, so we can
-        //   assume that we get OptionalAggregator::None in this case. This is
-        //   not UB as we only access the discriminant here, so we do not try
-        //   to read any other zeroed memory. After that we initialize our enum
-        //   by writing a correct value at this location via ptr::write_unaligned
-        //
-        // * We use ptr::write_unaligned as we did not found any guarantees that
-        //   the memory will have a correct alignment.
-        //   (Note I(weiznich): would assume that it is aligned correctly, but we
-        //    we cannot guarantee it, so better be safe than sorry)
-        ffi::sqlite3_aggregate_context(ctx, n_bytes)
-    };
-    let aggregate_context = NonNull::new(aggregate_context as *mut OptionalAggregator<A>);
     let aggregator = unsafe {
-        match aggregate_context.map(|a| &mut *a.as_ptr()) {
-            Some(&mut OptionalAggregator::Some(ref mut agg)) => agg,
-            Some(a_ptr @ &mut OptionalAggregator::None) => {
-                ptr::write_unaligned(a_ptr as *mut _, OptionalAggregator::Some(A::default()));
-                if let OptionalAggregator::Some(agg) = a_ptr {
-                    agg
-                } else {
-                    return Err(SqliteCallbackError::Abort(NULL_CTX_ERR));
-                }
+        // SAFETY:
+        // * We set the corresponding data in `register_aggregate_function` above
+        // * It has the correct type
+        let aggregate_context = ffi::sqlite3_user_data(ctx) as *mut Option<A>;
+        // SAFETY:
+        // * The layout is correct as we allocated the value on the rust side
+        // * The alignment is correct as we allocated the value on the rust side
+        match aggregate_context.as_mut() {
+            Some(Some(agg)) => agg,
+            Some(r) => {
+                *r = Some(A::default());
+                r.as_mut().expect("Initialised literally above")
             }
-            None => {
-                return Err(SqliteCallbackError::Abort(NULL_AG_CTX_ERR));
-            }
+            None => return Err(SqliteCallbackError::Abort(NULL_CTX_ERR)),
         }
     };
+
     let args = build_sql_function_args::<ArgsSqlType, Args>(args)?;
 
     aggregator.step(args);
@@ -543,31 +518,18 @@ extern "C" fn run_aggregator_final_function<ArgsSqlType, RetSqlType, Args, Ret, 
     Ret: ToSql<RetSqlType, Sqlite>,
     Sqlite: HasSqlType<RetSqlType>,
 {
-    static NO_AGGREGATOR_FOUND: &str = "We've written to the aggregator in the xStep callback. If xStep was never called, then ffi::sqlite_aggregate_context() would have returned a NULL pointer.";
-    let aggregate_context = unsafe {
-        // Within the xFinal callback, it is customary to set nBytes to 0 so no pointless memory
-        // allocations occur, a null pointer is returned in this case
-        // See: https://www.sqlite.org/c3ref/aggregate_context.html
-        //
-        // For the reasoning about the safety of the OptionalAggregator handling
-        // see the comment in run_aggregator_step_function.
-        ffi::sqlite3_aggregate_context(ctx, 0)
-    };
-
     let result = crate::util::std_compat::catch_unwind(|| {
-        let mut aggregate_context = NonNull::new(aggregate_context as *mut OptionalAggregator<A>);
-
-        let aggregator = if let Some(a) = aggregate_context.as_mut() {
-            let a = unsafe { a.as_mut() };
-            match core::mem::replace(a, OptionalAggregator::None) {
-                OptionalAggregator::None => {
-                    return Err(SqliteCallbackError::Abort(NO_AGGREGATOR_FOUND));
-                }
-                OptionalAggregator::Some(a) => Some(a),
-            }
-        } else {
-            None
-        };
+        let aggregator = unsafe {
+            // SAFETY:
+            // * We set the corresponding data in `register_aggregate_function` above
+            // * It has the correct type
+            let aggregate_context = ffi::sqlite3_user_data(ctx) as *mut Option<A>;
+            // SAFETY:
+            // * The value has the correct layout as we initialised it on the rust side
+            // * The value has the correct alignment as we initialised it on the rust side
+            aggregate_context.as_mut()
+        }
+        .and_then(|a| a.take());
 
         let res = A::finalize(aggregator);
         let value = process_sql_function_result(&res)?;
@@ -590,10 +552,7 @@ extern "C" fn run_aggregator_final_function<ArgsSqlType, RetSqlType, Args, Ret, 
 }
 
 unsafe fn context_error_str(ctx: *mut ffi::sqlite3_context, error: &str) {
-    let len: i32 = error
-        .len()
-        .try_into()
-        .expect("Trying to set a error message with more than 2^32 byte is not supported");
+    let len: i32 = error.len().try_into().unwrap_or(i32::MAX);
     unsafe {
         ffi::sqlite3_result_error(ctx, error.as_ptr() as *const _, len);
     }

--- a/diesel/src/sqlite/connection/sqlite_value.rs
+++ b/diesel/src/sqlite/connection/sqlite_value.rs
@@ -33,6 +33,14 @@ pub struct SqliteValue<'row, 'stmt, 'query> {
     // while holding this value. We ensure this by including
     // a reference to the row above.
     value: NonNull<ffi::sqlite3_value>,
+    // An optional storage for a string that is
+    // created from an non-utf8 blob value via `read_str`
+    // This field mostly exists for as we cannot
+    // return an error in that case as the API is
+    // stable and doesn't return a `Result`. We instead
+    // use `String::from_utf8_lossy` there and need
+    // to store the potential owned result here
+    string_ref: Option<alloc::boxed::Box<str>>,
 }
 
 #[derive(Debug)]
@@ -70,6 +78,7 @@ impl<'row, 'stmt, 'query> SqliteValue<'row, 'stmt, 'query> {
         let ret = Self {
             _row: Some(row),
             value,
+            string_ref: None,
         };
         if ret.value_type().is_none() {
             None
@@ -83,7 +92,11 @@ impl<'row, 'stmt, 'query> SqliteValue<'row, 'stmt, 'query> {
         col_idx: usize,
     ) -> Option<SqliteValue<'row, 'stmt, 'query>> {
         let value = row.values.get(col_idx).and_then(|v| v.as_ref())?.value;
-        let ret = Self { _row: None, value };
+        let ret = Self {
+            _row: None,
+            value,
+            string_ref: None,
+        };
         if ret.value_type().is_none() {
             None
         } else {
@@ -91,18 +104,57 @@ impl<'row, 'stmt, 'query> SqliteValue<'row, 'stmt, 'query> {
         }
     }
 
-    pub(crate) fn parse_string<'value, R>(&'value mut self, f: impl FnOnce(&'value str) -> R) -> R {
-        let s = unsafe {
-            let ptr = ffi::sqlite3_value_text(self.value.as_ptr());
+    pub(super) fn from_function_row(
+        row: &'row [Option<OwnedSqliteValue>],
+        col_idx: usize,
+    ) -> Option<SqliteValue<'row, 'stmt, 'query>> {
+        let value = row.get(col_idx).and_then(|v| v.as_ref())?.value;
+        let ret = Self {
+            _row: None,
+            value,
+            string_ref: None,
+        };
+        if ret.value_type().is_none() {
+            None
+        } else {
+            Some(ret)
+        }
+    }
+
+    pub(crate) fn as_byte_string(&mut self) -> &'row [u8] {
+        unsafe {
+            // https://sqlite.org/c3ref/value_blob.html
+            // Please pay particular attention to the fact that the pointer returned
+            // from sqlite3_value_blob(), sqlite3_value_text(), or sqlite3_value_text16()
+            // can be invalidated by a subsequent call to sqlite3_value_bytes(), sqlite3_value_bytes16(),
+            // sqlite3_value_text(), or sqlite3_value_text16().
             let len = ffi::sqlite3_value_bytes(self.value.as_ptr());
-            let bytes = slice::from_raw_parts(
+            let ptr = ffi::sqlite3_value_text(self.value.as_ptr());
+            slice::from_raw_parts(
                 ptr,
                 len.try_into()
                     .expect("Diesel expects to run at least on a 32 bit platform"),
-            );
-            // The string is guaranteed to be utf8 according to
-            // https://www.sqlite.org/c3ref/value_blob.html
-            str::from_utf8_unchecked(bytes)
+            )
+        }
+    }
+
+    pub(crate) fn as_utf8_str(&mut self) -> Result<&'row str, core::str::Utf8Error> {
+        str::from_utf8(self.as_byte_string())
+    }
+
+    pub(crate) fn parse_string<'value, R>(&'value mut self, f: impl FnOnce(&'value str) -> R) -> R {
+        let bytes = self.as_byte_string();
+        // For blobs this might return non-utf values
+        //
+        // The sqlite documentation there seems to be at least inaccurate
+        let s = match alloc::string::String::from_utf8_lossy(bytes) {
+            alloc::borrow::Cow::Borrowed(s) => s,
+            alloc::borrow::Cow::Owned(b) => {
+                self.string_ref = Some(b.into_boxed_str());
+                self.string_ref
+                    .as_deref()
+                    .expect("We initialised it literally above")
+            }
         };
         f(s)
     }
@@ -129,10 +181,15 @@ impl<'row, 'stmt, 'query> SqliteValue<'row, 'stmt, 'query> {
     /// type of the value.
     ///
     /// See <https://www.sqlite.org/c3ref/value_blob.html> for details
-    pub fn read_blob(&mut self) -> &[u8] {
+    pub fn read_blob(&mut self) -> &'row [u8] {
         unsafe {
-            let ptr = ffi::sqlite3_value_blob(self.value.as_ptr());
+            // https://sqlite.org/c3ref/value_blob.html
+            // Please pay particular attention to the fact that the pointer returned
+            // from sqlite3_value_blob(), sqlite3_value_text(), or sqlite3_value_text16()
+            // can be invalidated by a subsequent call to sqlite3_value_bytes(), sqlite3_value_bytes16(),
+            // sqlite3_value_text(), or sqlite3_value_text16().
             let len = ffi::sqlite3_value_bytes(self.value.as_ptr());
+            let ptr = ffi::sqlite3_value_blob(self.value.as_ptr());
             if len == 0 {
                 // rusts std-lib has an debug_assert that prevents creating
                 // slices without elements from a pointer
@@ -248,7 +305,7 @@ mod tests {
         diesel::sql_query("INSERT INTO tests(int, text, blob, float) VALUES(?, ?, ?, ?)")
             .bind::<Int4, _>(42)
             .bind::<Text, _>("foo")
-            .bind::<Blob, _>(b"foo")
+            .bind::<Blob, _>([0xFF_u8, 0xFE, 0xFD])
             .bind::<Double, _>(3.14)
             .execute(&mut conn)
             .unwrap();
@@ -293,9 +350,9 @@ mod tests {
         let mut blob_value = blob_field.value().unwrap();
         assert_eq!(blob_value.read_double(), 0.0);
         let mut blob_value = blob_field.value().unwrap();
-        assert_eq!(blob_value.read_text(), "foo");
+        assert_eq!(blob_value.read_text(), "\u{fffd}\u{fffd}\u{fffd}"); // ���
         let mut blob_value = blob_field.value().unwrap();
-        assert_eq!(blob_value.read_blob(), b"foo");
+        assert_eq!(blob_value.read_blob(), [0xFF, 0xFE, 0xFD]);
 
         let mut float_value = float_field.value().unwrap();
         assert_eq!(float_value.read_integer(), 3);

--- a/diesel/src/sqlite/connection/stmt.rs
+++ b/diesel/src/sqlite/connection/stmt.rs
@@ -443,6 +443,27 @@ impl Drop for BoundStatement<'_, '_> {
 #[allow(missing_debug_implementations)]
 pub struct StatementUse<'stmt, 'query> {
     statement: BoundStatement<'stmt, 'query>,
+    // SAFETY:
+    // https://sqlite.org/c3ref/column_name.html
+    // This pointer is valid as long as:
+    // The returned string pointer is valid until either
+    // the prepared statement is destroyed by sqlite3_finalize()
+    // or until the statement is automatically reprepared by the first
+    // call to sqlite3_step() for a particular run or until the next call
+    // to sqlite3_column_name() or sqlite3_column_name16() on the same column.
+    //
+    // Step has an explicit `first` flag that resets this field
+    // in this case
+    // The `OnceCell` ensure that we never call
+    // `sqlite3_column_name` again after populating this field
+    //
+    // We also assume that we are the owner of `statement` and the
+    // inner pointer is not exposed anywhere else. This ensures
+    // no one else can call the functions mentioned above
+    //
+    // We use `*const str` instead of `&str`
+    // as this is essentially a self referential struct
+    // as we borrow into `statement`
     column_names: OnceCell<Vec<*const str>>,
 }
 

--- a/diesel/src/sqlite/types/mod.rs
+++ b/diesel/src/sqlite/types/mod.rs
@@ -5,7 +5,7 @@ mod numeric;
 
 use super::Sqlite;
 use super::connection::SqliteValue;
-use crate::deserialize::{self, FromSql, Queryable};
+use crate::deserialize::{self, FromSql, FromSqlRef, Queryable};
 use crate::expression::AsExpression;
 use crate::query_builder::QueryId;
 use crate::serialize::{self, IsNull, Output, ToSql};
@@ -22,6 +22,13 @@ impl FromSql<sql_types::VarChar, Sqlite> for *const str {
     fn from_sql(mut value: SqliteValue<'_, '_, '_>) -> deserialize::Result<Self> {
         let text = value.read_text();
         Ok(text as *const _)
+    }
+}
+
+#[cfg(feature = "__sqlite-shared")]
+impl<'a> FromSqlRef<'a, sql_types::VarChar, Sqlite> for &'a str {
+    fn from_sql(mut value: SqliteValue<'a, 'a, 'a>) -> deserialize::Result<Self> {
+        Ok(value.as_utf8_str()?)
     }
 }
 
@@ -44,6 +51,13 @@ impl FromSql<sql_types::Binary, Sqlite> for *const [u8] {
     fn from_sql(mut bytes: SqliteValue<'_, '_, '_>) -> deserialize::Result<Self> {
         let bytes = bytes.read_blob();
         Ok(bytes as *const _)
+    }
+}
+
+#[cfg(feature = "__sqlite-shared")]
+impl<'a> FromSqlRef<'a, sql_types::Binary, Sqlite> for &'a [u8] {
+    fn from_sql(mut value: SqliteValue<'a, 'a, 'a>) -> deserialize::Result<Self> {
+        Ok(value.read_blob())
     }
 }
 

--- a/diesel/src/type_impls/primitives.rs
+++ b/diesel/src/type_impls/primitives.rs
@@ -1,5 +1,5 @@
 use crate::backend::Backend;
-use crate::deserialize::{self, FromSql, Queryable};
+use crate::deserialize::{self, FromSql, FromSqlRef, Queryable};
 #[cfg(feature = "std")]
 use crate::query_builder::bind_collector::RawBytesBindCollector;
 use crate::serialize::{self, Output, ToSql};
@@ -130,14 +130,10 @@ mod foreign_impls {
 impl<ST, DB> FromSql<ST, DB> for String
 where
     DB: Backend,
-    *const str: FromSql<ST, DB>,
+    for<'a> &'a str: FromSqlRef<'a, ST, DB>,
 {
-    #[allow(unsafe_code)] // ptr dereferencing
     fn from_sql(bytes: DB::RawValue<'_>) -> deserialize::Result<Self> {
-        let str_ptr = <*const str as FromSql<ST, DB>>::from_sql(bytes)?;
-        // We know that the pointer impl will never return null
-        let string = unsafe { &*str_ptr };
-        Ok(string.to_owned())
+        <&str as FromSqlRef<'_, ST, DB>>::from_sql(bytes).map(|v| v.to_owned())
     }
 }
 
@@ -169,14 +165,10 @@ where
 impl<ST, DB> FromSql<ST, DB> for Vec<u8>
 where
     DB: Backend,
-    *const [u8]: FromSql<ST, DB>,
+    for<'a> &'a [u8]: FromSqlRef<'a, ST, DB>,
 {
-    #[allow(unsafe_code)] // ptr dereferencing
     fn from_sql(bytes: DB::RawValue<'_>) -> deserialize::Result<Self> {
-        let slice_ptr = <*const [u8] as FromSql<ST, DB>>::from_sql(bytes)?;
-        // We know that the pointer impl will never return null
-        let bytes = unsafe { &*slice_ptr };
-        Ok(bytes.to_owned())
+        <&[u8] as FromSqlRef<'_, ST, DB>>::from_sql(bytes).map(|v| v.to_owned())
     }
 }
 

--- a/diesel_compile_tests/tests/fail/eq_any_is_nullable.stderr
+++ b/diesel_compile_tests/tests/fail/eq_any_is_nullable.stderr
@@ -16,7 +16,7 @@ help: the following other types implement trait `FromSql<A, DB>`
      |
     ::: DIESEL/diesel/diesel/src/pg/types/primitives.rs
      |
-   LL | impl FromSql<sql_types::Bool, Pg> for bool {
+  LL | impl FromSql<sql_types::Bool, Pg> for bool {
      | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `bool` implements `FromSql<diesel::sql_types::Bool, Pg>`
      |
     ::: DIESEL/diesel/diesel/src/mysql/types/mod.rs

--- a/diesel_tests/tests/copy.rs
+++ b/diesel_tests/tests/copy.rs
@@ -339,3 +339,70 @@ fn copy_to_queryable() {
         .unwrap();
     assert_eq!(name, "Sean");
 }
+
+#[diesel_test_helper::test]
+fn copy_with_null_injection() {
+    let conn = &mut connection_with_sean_and_tess_in_users_table();
+
+    let mut buf = diesel::copy_to(users::table)
+        .with_format(CopyFormat::Csv)
+        .with_null("abc ' efg")
+        .load_raw(conn)
+        .unwrap();
+    let mut out = String::new();
+    buf.read_to_string(&mut out).unwrap();
+    assert_eq!(out, "1,Sean,abc ' efg\n2,Tess,abc ' efg\n");
+}
+
+#[diesel_test_helper::test]
+fn copy_with_delimiter_injection() {
+    let conn = &mut connection_with_sean_and_tess_in_users_table();
+    let mut buf = diesel::copy_to(users::table)
+        .with_format(CopyFormat::Csv)
+        .with_delimiter('\'')
+        .load_raw(conn)
+        .unwrap();
+    let mut out = String::new();
+    buf.read_to_string(&mut out).unwrap();
+    assert_eq!(out, "1'Sean'\n2'Tess'\n");
+}
+
+#[diesel_test_helper::test]
+fn copy_with_delimiter_injection2() {
+    let conn = &mut connection_with_sean_and_tess_in_users_table();
+    let mut buf = diesel::copy_to(users::table)
+        .with_format(CopyFormat::Csv)
+        .with_delimiter('\\')
+        .load_raw(conn)
+        .unwrap();
+    let mut out = String::new();
+    buf.read_to_string(&mut out).unwrap();
+    assert_eq!(out, "1\\Sean\\\n2\\Tess\\\n");
+}
+
+#[diesel_test_helper::test]
+fn copy_with_escape_injection() {
+    let conn = &mut connection_with_sean_and_tess_in_users_table();
+
+    let mut buf = diesel::copy_to(users::table)
+        .with_format(CopyFormat::Csv)
+        .with_escape('\'')
+        .load_raw(conn)
+        .unwrap();
+    let mut out = String::new();
+    buf.read_to_string(&mut out).unwrap();
+    assert_eq!(out, "1,Sean,\n2,Tess,\n");
+}
+
+#[diesel_test_helper::test]
+fn copy_with_quote_injection() {
+    let conn = &mut connection_with_sean_and_tess_in_users_table();
+    let mut buf = diesel::copy_to(users::table)
+        .with_format(CopyFormat::Csv)
+        .with_quote('\'')
+        .load_raw(conn)
+        .unwrap();
+    let mut out = String::new();
+    buf.read_to_string(&mut out).unwrap();
+    assert_eq!(out, "1,Sean,\n2,Tess,\n");
+}


### PR DESCRIPTION

This commit fixes a larger number of undefined behaviour usage, API misuses and otherwise security related bugs. Most of these issues where detected using LLM's (mostly Github copilot, various models), all of them were verified and fixed manually. The following list describes each issue and the relevant fix in detail:

# Unsound construction of a rust String with non-utf8 bytes in `SqliteValue::read_text`

The `SqliteValue::read_text` function (and any way to deserialize a `String` value from `Sqlite` constructed strings via the unsafe `str::from_utf8_unchecked` function, relying on the sqlite documentation stating that `sqlite3_value_text` returns a UTF-8 string. It turns out that this is not guranteed if you call this function on a byte column, which in turn can result in the construction of a rust String/str containing non-utf-8 bytes, which in turn is violating the safety contract of these types. This is fixed in two ways: Whereever possible we now return UTF-8 error if we encounter such a case. For `SqliteValue::read_text` that wouldn't be possible without an API breaking change, so I opted to use `String::from_ut8_lossy` there combined with caching the allocated result inside of `SqliteValue`.
Any user that might load values from a field with blob storage as `String` via diesel can be affected from this if the data contained non-utf8 data.

# Invalid assumption about aggregator alignment in the implementation of custom SQLite aggregate functions

We relied on the `sqlite3_aggregate_context` function to allocate an instance of the user provided aggregator type for the implementation of custom SQLite aggregate functions. While the code already noted correctly that the `sqlite3_aggregate_context` function doesn't give any gurantee about alignment it did fail to understand that already creating a reference to unaligned data is undefined behaviour in Rust. This is now corrected by not relying on `sqlite3_aggregate_context`, but rather use the user data pointer instead and allocating the corresponding value in Rust with the correct alignment. 
Any user implementing `SqliteAggregateContext` for a type with a custom aligment would have been affected by this.

# Potential memory leaks while registering custom SQLite functions and collations

We discovered that while registering custom SQLite functions and collations we first create a raw pointer for the callback by leaking the allocation, then convert the function name and arguments to the corresponding representation by using failable methods and finally passing everything to the relevant SQLite API function. This can result in a memory leak as the allocation is not freed if any of the conversion steps fails. The fix just reordered the operations to perform the failable steps first and creating the corresponding raw pointer only as final step.
Any user that tries to registered a SQLite function containing a null byte in the name or with more than `i32::MAX` arguments would be affected by this bug.

# Reading of padding while serializing date/time related types in the Mysql backend

The Mysql backend provides a `MysqlTime` type to describe the binary format of the underlying byte buffer. This type is marked as `#[repr(C)]`, but contains padding bytes. The existing serialization code just casted a given struct instance to an slice of bytes via a pointer cast. This touches the padding bytes, which is undefined behaviour in rust. The bytes were then passed directly into libmysqlclient, which in turn reconstructed the `MysqlTime` struct, containing the same padding bytes. To fix this we wrote a manual serialization routine that copies the data values manually to the byte buffer without touching the byte buffers.
Any user serializing date/time values using the Mysql backend is affected by this, although this doesn't have any practical impact yet.

# Debug/Display implementations of batch inserts for the SQLite backend relied on unstable type layout

The Display/Debug implementation for batch insert queries for the SQLite backend performed a pointer cast between `#[repr(Rust)]` types relying on unspecified type layout there. This is corrected in favour of a pointer cast between `#[repr(transparent)]` types with a specified semantic.
This affects any user relying on the Display/Debug implementation for this kind of query, although in practice the layout of the involved types was the same with the currently supported rust compiler versions.

# Invalid call order of `sqlite3_value_blob`/`sqlite3_value_text` and `sqlite3_value_bytes`

The deserialization layer in the SQLite backend relyed on an invalid calling order of these function, while the SQLite documentation explicitly documented a to call these functions the other way around to prevent internally changing the result. This is fixed by changing the order as suggested by the documentation.
This potentially affects any user that deserializes `Vec<u8>` and `String` values using the SQLite backend, although you also would need to trigger an internal data conversion in SQLite to be affected by this bug. At the time of writing we are not aware of any practical way to cause a corruption there.

# Unsound pointer usage in `FromSql` implementations for `String`/`Vec<u8>`
for third party backends providing a `FromSql<Text/Binary, > for *const str/u8` implementation

A `FromSql` implementation for `String` and `Vec<u8>` provided by diesel relies on a raw pointer provided by another `FromSql` implementation. As the relevant functions are safe functions and a custom implementation might return an invalid pointer this could lead to data corruption or other crashes in these impls. Any in tree backend provided a correct pointer there, but a third party backend is not required to do that.
As fixs this mechanism is replaced by a custom `FromSqlRef` trait that allows to operate on references instead. Custom backends relying on the existance of these `FromSql` impls for pointers must be updated to use the new trait instead.
This affects any user of a third party backend that might return an invalid pointer.

# Option injection in the PostgreSQL `COPY FROM/TO` interface

The provided interface for `COPY FROM/TO` in the PostgreSQL backend allows to configure various options as String and char values. Due to how this is implementid in the PostgreSQL wire protocol it is not possible to send these options as bind parameters, but they need to be directly embedded in the query string. These functios allowed a malicous  user to include quote characters `'`, which in turn would have allowed to  modify the query construction. Fortunally the scope of this injection is restricted to the very same `COPY FROM/TO` statement, so the worst impact such an injection can have is changing options for the same statement, which would result in the acceptance/return of an unexpected data format. As a fix we now correctly escape any included quote character.
Any user using the `COPY FROM/TO` interface in combination with user controlled options for any configuration method accepting a `String` or `char` is affected by this issue. 

Beside these specific issues this commit also contains various smaller  improvements to make several unsafe code instances more robust:

* We improved some pointer handling in the mysql bind code
* For the sqlite function argument deserialization we removed the usage of `ManuallyDrop` in favour of a simpler solution based on slices
* We added/improved various SAFETY comments to describe the relevant invariants in more details
* For the PostgreSQL backend we refactored the `RawResult` related  pointer handling to not expose the pointer outside of the raw module anymore. This wraps all necessary unsafe code to interact with this type in one place, which makes it easier to verify and uphold any necessary invariants
* We replaced several other instances of `str::from_utf8_unchecked` with their checked equivalent to make sure not to rely again on invalid assumptions.

<!-- 
Please provide a short brief summary description of your change here. 
Also make sure that your code passes all tests and style checks. 
Checkout the `CONTRIBUTING.md` file in the root of the repository for running these checks locally.
It's also fine to use the CI setup for running these tests, but in this case please indicate that your PR 
is not ready for review yet by marking it as DRAFT until it is ready.

If you submit a notable change please ensure to include it into the CHANGELOG.md file in
the root of the repository.

Also make sure to follow the projects guide lines about the usage of LLM's and AI agents as outlined
in the CONTRIBUTING.md file in the root of the repository.
-->

- [x] I checked for similar changes and make sure to reference them
- [x] I included a changelog entry for relevant new features or changes
