### PR TITLE
Remove MySQL time serializer debug output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 
 ## Unreleased
 
+## [2.3.9] 2026-04-30
+
+* Removed a `dbg!` statement from the Mysql backend that caused unwanted output
+
 ## [2.3.8] 2026-04-24
 
 * Added support for libsqlite3-sys 0.37.0
@@ -2342,3 +2346,4 @@ queries or set `PIPES_AS_CONCAT` manually.
 [2.3.6]: https://github.com/diesel-rs/diesel/compare/v2.3.5...v2.3.6
 [2.3.7]: https://github.com/diesel-rs/diesel/compare/v2.3.6...v2.3.7
 [2.3.8]: https://github.com/diesel-rs/diesel/compare/v2.3.7...v2.3.8
+[2.3.9]: https://github.com/diesel-rs/diesel/compare/v2.3.8...v2.3.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 ## [2.3.9] 2026-04-30
 
 * Removed a `dbg!` statement from the Mysql backend that caused unwanted output
+* Fix a regression in `#[derive(AsChangeset)]` introduced in 2.3.8 where structs with a type or const generic parameter referenced in a field type failed to compile with `error[E0425]: cannot find type 'T' in this scope`. The diagnostic helper functions added to improve `AsChangeset` error messages now forward all generic parameters of the input struct, not only lifetimes.
 
 ## [2.3.8] 2026-04-24
 
@@ -2346,4 +2347,3 @@ queries or set `PIPES_AS_CONCAT` manually.
 [2.3.6]: https://github.com/diesel-rs/diesel/compare/v2.3.5...v2.3.6
 [2.3.7]: https://github.com/diesel-rs/diesel/compare/v2.3.6...v2.3.7
 [2.3.8]: https://github.com/diesel-rs/diesel/compare/v2.3.7...v2.3.8
-[2.3.9]: https://github.com/diesel-rs/diesel/compare/v2.3.8...v2.3.9

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,10 @@ opt-level = 3
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(diesel_docsrs)'] }
 
+[workspace.lints.clippy]
+dbg_macro = "warn"
+print_stdout = "warn"
+
 # The profile that 'cargo dist' will build with
 [profile.dist]
 inherits = "release"

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diesel"
-version = "2.3.8"
+version = "2.3.9"
 license = "MIT OR Apache-2.0"
 description = "A safe, extensible ORM and Query Builder for PostgreSQL, SQLite, and MySQL"
 readme = "README.md"

--- a/diesel/src/deserialize.rs
+++ b/diesel/src/deserialize.rs
@@ -481,6 +481,7 @@ pub trait FromSql<A, DB: Backend>: Sized {
     feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
 )]
 pub(crate) trait FromSqlRef<'a, A, DB: Backend>: Sized {
+    /// See the trait documentation
     fn from_sql(bytes: DB::RawValue<'a>) -> Result<Self>;
 }
 

--- a/diesel/src/mysql/connection/bind.rs
+++ b/diesel/src/mysql/connection/bind.rs
@@ -816,12 +816,11 @@ mod tests {
         T: FromSql<ST, crate::mysql::Mysql> + std::fmt::Debug,
     {
         let meta = (bind.tpe, bind.flags).into();
-        dbg!(meta);
 
         let value = bind.value().expect("Is not null");
         let value = MysqlValue::new_internal(value.as_bytes(), meta);
 
-        dbg!(T::from_sql(value))
+        T::from_sql(value)
     }
 
     #[cfg(feature = "extras")]

--- a/diesel/src/mysql/types/date_and_time/mod.rs
+++ b/diesel/src/mysql/types/date_and_time/mod.rs
@@ -80,12 +80,12 @@ impl MysqlTime {
         }
     }
 
-    // Serialize a given `MysqlTime` instance to a byte buffer
+    /// Serialize a given `MysqlTime` instance to a byte buffer
     #[diesel_derives::__diesel_public_if(
         feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
     )]
     #[allow(unsafe_code)] // manual serialization of a type to a byte array
-    fn serialize(&self) -> [u8; mem::size_of::<MysqlTime>()] {
+    pub(crate) fn serialize(&self) -> [u8; mem::size_of::<MysqlTime>()] {
         unsafe fn copy_bytes<T>(out: &mut [u8], field_ptr: &T, start: *const MysqlTime)
         where
             T: Copy,

--- a/diesel/src/mysql/types/date_and_time/mod.rs
+++ b/diesel/src/mysql/types/date_and_time/mod.rs
@@ -106,7 +106,7 @@ impl MysqlTime {
                 //   go from bool to u8 that's no problem as 0 and 1 are valid u8 bit patterns
                 ptr::copy::<u8>(
                     field_ptr as *const u8,
-                    dbg!(out_ptr.offset(offset)),
+                    out_ptr.offset(offset),
                     mem::size_of::<T>(),
                 )
             };

--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diesel_cli"
-version = "2.3.8"
+version = "2.3.9"
 license = "MIT OR Apache-2.0"
 description = "Provides the CLI for the Diesel crate"
 readme = "README.md"

--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -89,3 +89,6 @@ name = "tests"
 
 [package.metadata.dist]
 features = ["sqlite-bundled", "postgres-bundled", "mysql-bundled"]
+
+[lints]
+workspace = true

--- a/diesel_cli/src/main.rs
+++ b/diesel_cli/src/main.rs
@@ -10,6 +10,10 @@
     clippy::used_underscore_binding,
     missing_copy_implementations
 )]
+#![allow(
+    clippy::print_stdout,
+    reason = "This is a CLI tool that's expected to output something"
+)]
 #![cfg_attr(not(test), warn(clippy::unwrap_used))]
 
 mod config;

--- a/diesel_cli/src/migrations/diff_schema.rs
+++ b/diesel_cli/src/migrations/diff_schema.rs
@@ -630,7 +630,7 @@ where
 {
     query_builder.push_sql("CREATE TYPE ");
     let record_type_name = format!("{}_RECORD", column_name.to_uppercase());
-    if dbg!(record_type_name.len()) > 64 {
+    if record_type_name.len() > 64 {
         return Err(diesel::result::Error::QueryBuilderError(
             format!(
                 "Failed to construct a suitable name \

--- a/diesel_cli/tests/support/command.rs
+++ b/diesel_cli/tests/support/command.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::print_stdout)]
 use std::fmt::{Debug, Error, Formatter};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};

--- a/diesel_derives/src/as_changeset.rs
+++ b/diesel_derives/src/as_changeset.rs
@@ -170,10 +170,8 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
             super::insertable::filter_bounds(&field_ty_bounds_guard, type_to_check, bound)
         });
 
-    let tpe_lifetimes = item.generics.lifetimes();
-
     let changeset_owned = quote! {
-        fn _check_owned<#(#tpe_lifetimes,)*>()
+        fn _check_owned #impl_generics ()
         where #(#field_ty_bounds,)*
         {}
 
@@ -203,18 +201,21 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
                         bound,
                     )
                 });
-        let tpe_lifetimes = item.generics.lifetimes().map(|lp| {
-            let lt = &lp.lifetime;
-            let bound = lp.bounds.iter();
-            if lp.bounds.is_empty() {
-                quote!(#lt: 'update)
-            } else {
-                quote!(#lt: 'update + #(#bound +)*)
+        let borrowed_check_params = item.generics.params.iter().map(|p| match p {
+            syn::GenericParam::Lifetime(lp) => {
+                let lt = &lp.lifetime;
+                let bounds = lp.bounds.iter();
+                if lp.bounds.is_empty() {
+                    quote!(#lt: 'update)
+                } else {
+                    quote!(#lt: 'update + #(#bounds +)*)
+                }
             }
+            syn::GenericParam::Type(_) | syn::GenericParam::Const(_) => quote!(#p),
         });
         quote! {
             #[allow(clippy::multiple_bound_locations)]
-            fn _check_borrowed<'update, #(#tpe_lifetimes,)*>()
+            fn _check_borrowed<'update, #(#borrowed_check_params,)*>()
             where
                 #(#borrowed_field_ty_bounds,)*
             {}

--- a/diesel_derives/tests/as_changeset.rs
+++ b/diesel_derives/tests/as_changeset.rs
@@ -275,6 +275,91 @@ fn with_lifetime_constraints() {
     assert_eq!(Ok(expected), actual);
 }
 
+// Regression test: the diagnostic helper fns must forward type and const
+// generics, not only lifetimes.
+#[test]
+fn with_type_and_const_generics() {
+    #[derive(FromSqlRow, AsExpression)]
+    #[diesel(sql_type = sql_types::Text)]
+    struct Wrapper<T: 'static>(String, std::marker::PhantomData<T>);
+
+    impl<T: 'static> Wrapper<T> {
+        fn new(s: impl Into<String>) -> Self {
+            Wrapper(s.into(), std::marker::PhantomData)
+        }
+    }
+
+    impl<T: 'static> std::fmt::Debug for Wrapper<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_tuple("Wrapper").field(&self.0).finish()
+        }
+    }
+
+    impl<DB, T: 'static> serialize::ToSql<sql_types::Text, DB> for Wrapper<T>
+    where
+        DB: backend::Backend,
+        String: serialize::ToSql<sql_types::Text, DB>,
+    {
+        fn to_sql<'b>(&'b self, out: &mut serialize::Output<'b, '_, DB>) -> serialize::Result {
+            self.0.to_sql(out)
+        }
+    }
+
+    #[derive(AsChangeset)]
+    #[diesel(table_name = users)]
+    struct UserForm<T: 'static> {
+        name: Wrapper<T>,
+        hair_color: String,
+        r#type: String,
+    }
+
+    let connection = &mut connection_with_sean_and_tess_in_users_table();
+
+    update(users::table.find(1))
+        .set(&UserForm::<()> {
+            name: Wrapper::new("Jim"),
+            hair_color: String::from("blue"),
+            r#type: String::from("super"),
+        })
+        .execute(connection)
+        .unwrap();
+
+    update(users::table.find(2))
+        .set(UserForm::<()> {
+            name: Wrapper::new("Tess2"),
+            hair_color: String::from("red"),
+            r#type: String::from("admin"),
+        })
+        .execute(connection)
+        .unwrap();
+
+    let expected = vec![
+        (
+            1,
+            String::from("Jim"),
+            Some(String::from("blue")),
+            Some(String::from("super")),
+        ),
+        (
+            2,
+            String::from("Tess2"),
+            Some(String::from("red")),
+            Some(String::from("admin")),
+        ),
+    ];
+    let actual = users::table.order(users::id).load(connection);
+    assert_eq!(Ok(expected), actual);
+
+    #[derive(AsChangeset)]
+    #[diesel(table_name = users)]
+    #[allow(dead_code)]
+    struct MixedForm<'a, T: 'static, const N: usize> {
+        name: Wrapper<T>,
+        hair_color: &'a str,
+        r#type: Wrapper<[T; N]>,
+    }
+}
+
 #[test]
 fn with_explicit_column_names() {
     #[derive(AsChangeset)]

--- a/diesel_dynamic_schema/Cargo.toml
+++ b/diesel_dynamic_schema/Cargo.toml
@@ -46,3 +46,6 @@ default = []
 postgres = ["diesel/postgres_backend"]
 sqlite = ["diesel/sqlite"]
 mysql = ["diesel/mysql_backend"]
+
+[lints]
+workspace = true

--- a/diesel_dynamic_schema/examples/columns_used_in_where_clause.rs
+++ b/diesel_dynamic_schema/examples/columns_used_in_where_clause.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::print_stdout)]
 //! Example: columns used in where clause
 //!
 //! To run this:

--- a/diesel_dynamic_schema/examples/querying_basic_schemas.rs
+++ b/diesel_dynamic_schema/examples/querying_basic_schemas.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::print_stdout)]
 //! Example: querying basic schemas
 //!
 //! To run this:

--- a/diesel_dynamic_schema/examples/querying_multiple_types.rs
+++ b/diesel_dynamic_schema/examples/querying_multiple_types.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::print_stdout)]
 //! Example: querying multiple types
 //!
 //! To run this:

--- a/diesel_migrations/Cargo.toml
+++ b/diesel_migrations/Cargo.toml
@@ -34,3 +34,6 @@ default = []
 sqlite = []
 postgres = []
 mysql = []
+
+[lints]
+workspace = true

--- a/diesel_migrations/migrations_internals/Cargo.toml
+++ b/diesel_migrations/migrations_internals/Cargo.toml
@@ -13,3 +13,6 @@ keywords = ["diesel", "internal"]
 [dependencies]
 serde = {version = "1.0.0", features = ["derive"]}
 toml = { version = "1.0.0", default-features = false, features = ["parse", "serde"] }
+
+[lints]
+workspace = true

--- a/diesel_migrations/migrations_macros/Cargo.toml
+++ b/diesel_migrations/migrations_macros/Cargo.toml
@@ -38,3 +38,6 @@ default = []
 sqlite = []
 postgres = []
 mysql = []
+
+[lints]
+workspace = true

--- a/diesel_table_macro_syntax/Cargo.toml
+++ b/diesel_table_macro_syntax/Cargo.toml
@@ -16,3 +16,6 @@ edition = "2021"
 
 [dependencies]
 syn = {version = "2", features = ["full"]}
+
+[lints]
+workspace = true

--- a/dsl_auto_type/Cargo.toml
+++ b/dsl_auto_type/Cargo.toml
@@ -19,3 +19,6 @@ syn = { version = "2", features = ["extra-traits", "full", "derive", "parsing", 
 
 [dev-dependencies]
 diesel = { path = "../diesel" }
+
+[lints]
+workspace = true


### PR DESCRIPTION
## Summary
- remove an accidental `dbg!` wrapper from the MySQL `MysqlTime` serializer

## Details
The serializer only needs the pointer returned by `out_ptr.offset(offset)`. The debug wrapper prints that pointer to stderr whenever this path is used.

This does not change which pointer is passed to `ptr::copy`; it removes only the stderr side effect.

Follow-up to https://github.com/diesel-rs/diesel/discussions/5043.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo check -p diesel --no-default-features --features mysql_backend`
- `cargo check -p diesel --no-default-features --features mysql`
- `cargo check -p diesel --no-default-features --features 'mysql chrono time'`
- `cargo test -p diesel --no-default-features --features mysql --lib`
- `cargo test -p diesel --no-default-features --features 'mysql chrono time' --lib`

The MySQL library test commands were run against a local MySQL 8.4 database.