### PR TITLE
Fix `#[derive(AsChangeset)]` regression for structs with type or const generics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 ### Fixed
 
 * Fix non-deterministic test failures on PostgreSQL caused by loading rows without `ORDER BY` and assuming insertion order
+* Fix a regression in `#[derive(AsChangeset)]` introduced in 2.3.8 where structs with a type or const generic parameter referenced in a field type failed to compile with `error[E0425]: cannot find type 'T' in this scope`. The diagnostic helper functions added to improve `AsChangeset` error messages now forward all generic parameters of the input struct, not only lifetimes.
 
 ### Changed
 

--- a/diesel_derives/src/as_changeset.rs
+++ b/diesel_derives/src/as_changeset.rs
@@ -170,10 +170,8 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
             super::insertable::filter_bounds(&field_ty_bounds_guard, type_to_check, bound)
         });
 
-    let tpe_lifetimes = item.generics.lifetimes();
-
     let changeset_owned = quote! {
-        fn _check_owned<#(#tpe_lifetimes,)*>()
+        fn _check_owned #impl_generics ()
         where #(#field_ty_bounds,)*
         {}
 
@@ -203,18 +201,21 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
                         bound,
                     )
                 });
-        let tpe_lifetimes = item.generics.lifetimes().map(|lp| {
-            let lt = &lp.lifetime;
-            let bound = lp.bounds.iter();
-            if lp.bounds.is_empty() {
-                quote!(#lt: 'update)
-            } else {
-                quote!(#lt: 'update + #(#bound +)*)
+        let borrowed_check_params = item.generics.params.iter().map(|p| match p {
+            syn::GenericParam::Lifetime(lp) => {
+                let lt = &lp.lifetime;
+                let bounds = lp.bounds.iter();
+                if lp.bounds.is_empty() {
+                    quote!(#lt: 'update)
+                } else {
+                    quote!(#lt: 'update + #(#bounds +)*)
+                }
             }
+            syn::GenericParam::Type(_) | syn::GenericParam::Const(_) => quote!(#p),
         });
         quote! {
             #[allow(clippy::multiple_bound_locations)]
-            fn _check_borrowed<'update, #(#tpe_lifetimes,)*>()
+            fn _check_borrowed<'update, #(#borrowed_check_params,)*>()
             where
                 #(#borrowed_field_ty_bounds,)*
             {}

--- a/diesel_derives/tests/as_changeset.rs
+++ b/diesel_derives/tests/as_changeset.rs
@@ -275,6 +275,104 @@ fn with_lifetime_constraints() {
     assert_eq!(Ok(expected), actual);
 }
 
+// Regression test for the 2.3.8 `_check_owned` / `_check_borrowed` helpers
+// dropping type and const generics. Prior to the fix, the generated
+// diagnostic helper fns forwarded only lifetime params from the struct, so
+// a `where`-clause bound on a field type that mentioned a type param like
+// `T` failed to compile with `error[E0425]: cannot find type 'T' in this
+// scope`. Mirrors the lohi-lib failure shape: a generic wrapper type
+// (`Wrapper<T>`) used as a field type, where the wrapper implements
+// AsExpression independent of T, but the helper fn's where-clause still
+// names `T` via the field type.
+#[test]
+fn with_type_and_const_generics() {
+    #[derive(FromSqlRow, AsExpression)]
+    #[diesel(sql_type = sql_types::Text)]
+    struct Wrapper<T: 'static>(String, std::marker::PhantomData<T>);
+
+    impl<T: 'static> Wrapper<T> {
+        fn new(s: impl Into<String>) -> Self {
+            Wrapper(s.into(), std::marker::PhantomData)
+        }
+    }
+
+    impl<T: 'static> std::fmt::Debug for Wrapper<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_tuple("Wrapper").field(&self.0).finish()
+        }
+    }
+
+    impl<DB, T: 'static> serialize::ToSql<sql_types::Text, DB> for Wrapper<T>
+    where
+        DB: backend::Backend,
+        String: serialize::ToSql<sql_types::Text, DB>,
+    {
+        fn to_sql<'b>(&'b self, out: &mut serialize::Output<'b, '_, DB>) -> serialize::Result {
+            self.0.to_sql(out)
+        }
+    }
+
+    // Type generic referenced in a field type — exercises both the owned
+    // `_check_owned` helper (via `.set(form)`) and the borrowed
+    // `_check_borrowed` helper (via `.set(&form)`).
+    #[derive(AsChangeset)]
+    #[diesel(table_name = users)]
+    struct UserForm<T: 'static> {
+        name: Wrapper<T>,
+        hair_color: String,
+        r#type: String,
+    }
+
+    let connection = &mut connection_with_sean_and_tess_in_users_table();
+
+    update(users::table.find(1))
+        .set(&UserForm::<()> {
+            name: Wrapper::new("Jim"),
+            hair_color: String::from("blue"),
+            r#type: String::from("super"),
+        })
+        .execute(connection)
+        .unwrap();
+
+    update(users::table.find(2))
+        .set(UserForm::<()> {
+            name: Wrapper::new("Tess2"),
+            hair_color: String::from("red"),
+            r#type: String::from("admin"),
+        })
+        .execute(connection)
+        .unwrap();
+
+    let expected = vec![
+        (
+            1,
+            String::from("Jim"),
+            Some(String::from("blue")),
+            Some(String::from("super")),
+        ),
+        (
+            2,
+            String::from("Tess2"),
+            Some(String::from("red")),
+            Some(String::from("admin")),
+        ),
+    ];
+    let actual = users::table.order(users::id).load(connection);
+    assert_eq!(Ok(expected), actual);
+
+    // Lifetime + type + const generics on the same struct. Verifies the
+    // borrowed helper preserves the `'lifetime: 'update` outlives bounds
+    // while also forwarding type and const params.
+    #[derive(AsChangeset)]
+    #[diesel(table_name = users)]
+    #[allow(dead_code)]
+    struct MixedForm<'a, T: 'static, const N: usize> {
+        name: Wrapper<T>,
+        hair_color: &'a str,
+        r#type: Wrapper<[T; N]>,
+    }
+}
+
 #[test]
 fn with_explicit_column_names() {
     #[derive(AsChangeset)]

--- a/diesel_derives/tests/as_changeset.rs
+++ b/diesel_derives/tests/as_changeset.rs
@@ -275,15 +275,8 @@ fn with_lifetime_constraints() {
     assert_eq!(Ok(expected), actual);
 }
 
-// Regression test for the 2.3.8 `_check_owned` / `_check_borrowed` helpers
-// dropping type and const generics. Prior to the fix, the generated
-// diagnostic helper fns forwarded only lifetime params from the struct, so
-// a `where`-clause bound on a field type that mentioned a type param like
-// `T` failed to compile with `error[E0425]: cannot find type 'T' in this
-// scope`. Mirrors the lohi-lib failure shape: a generic wrapper type
-// (`Wrapper<T>`) used as a field type, where the wrapper implements
-// AsExpression independent of T, but the helper fn's where-clause still
-// names `T` via the field type.
+// Regression test: the diagnostic helper fns must forward type and const
+// generics, not only lifetimes.
 #[test]
 fn with_type_and_const_generics() {
     #[derive(FromSqlRow, AsExpression)]
@@ -312,9 +305,6 @@ fn with_type_and_const_generics() {
         }
     }
 
-    // Type generic referenced in a field type — exercises both the owned
-    // `_check_owned` helper (via `.set(form)`) and the borrowed
-    // `_check_borrowed` helper (via `.set(&form)`).
     #[derive(AsChangeset)]
     #[diesel(table_name = users)]
     struct UserForm<T: 'static> {
@@ -360,9 +350,6 @@ fn with_type_and_const_generics() {
     let actual = users::table.order(users::id).load(connection);
     assert_eq!(Ok(expected), actual);
 
-    // Lifetime + type + const generics on the same struct. Verifies the
-    // borrowed helper preserves the `'lifetime: 'update` outlives bounds
-    // while also forwarding type and const params.
     #[derive(AsChangeset)]
     #[diesel(table_name = users)]
     #[allow(dead_code)]


### PR DESCRIPTION
Fixes a regression introduced in 2.3.8 by https://github.com/diesel-rs/diesel/pull/5004. The new `_check_owned` / `_check_borrowed` diagnostic helpers forward only lifetime params, so any `AsChangeset` struct with a type or const generic referenced in a field type fails to compile with `error[E0425]: cannot find type 'T' in this scope`.
  

Fix: forward all generic params, not just lifetimes.

  ## Reproduction

  Minimal repro on 2.3.8:

  ```rust
  use diesel::prelude::*;

  diesel::table! {
      users { id -> Integer, name -> Text }
  }

  #[derive(diesel::expression::AsExpression, diesel::deserialize::FromSqlRow)]
  #[diesel(sql_type = diesel::sql_types::Text)]
  struct Wrapper<T: 'static>(String, std::marker::PhantomData<T>);

  #[derive(AsChangeset)]
  #[diesel(table_name = users)]
  struct UserForm<T: 'static> {
      name: Wrapper<T>,
  }
  ```

  Fails with:

  ```
  error[E0425]: cannot find type `T` in this scope
     |
     |     name: Wrapper<T>,
     |                   ^ not found in this scope
  ```

  Compiles with this PR.