### PR TITLE
Add support for PostgreSQL's RETURNING old.column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 * Added `SqliteConnection::get_read_only_blob` method to stream blob's from a SQLite database to Rust via `std::io::Read`
 * Added support for casting to `REAL` in SQLite.
 * Added `ToSql`, `FromSql`, `Queryable`, and `AsExpression` impls for `Rc<T>`, `Arc<T>`, and `Box<T>` (including `Rc/Arc<dyn BoxableExpression>` for cloneable dynamic query fragments and the `<str>` / `<[u8]>` unsized variants).
+* Added `diesel::pg::returning::old` to refer to a column's pre-update value using the `RETURNING old.col` syntax in a PostgreSQL `UPDATE` or `INSERT ... ON CONFLICT ... DO UPDATE` statement (requires PostgreSQL >=18).
 
 ### Fixed
 

--- a/diesel/src/backend.rs
+++ b/diesel/src/backend.rs
@@ -146,7 +146,7 @@ pub trait SqlDialect: self::private::TrustedBackend {
     /// provide a custom [`QueryFragment`](crate::query_builder::QueryFragment)
     #[cfg_attr(
         feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes",
-        doc = "implementation for [`ReturningClause`](crate::query_builder::ReturningClause)"
+        doc = "implementation for [`ReturningClause`](crate::query_builder::returning::ReturningClause)"
     )]
     #[cfg_attr(
         not(feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"),

--- a/diesel/src/internal/derives.rs
+++ b/diesel/src/internal/derives.rs
@@ -31,7 +31,7 @@ pub mod multiconnection {
         BoxedLimitOffsetClause, LimitOffsetClause,
     };
     #[doc(hidden)]
-    pub use crate::query_builder::returning_clause::ReturningClause;
+    pub use crate::query_builder::returning::ReturningClause;
     #[doc(hidden)]
     pub use crate::query_builder::select_statement::SelectStatement;
     #[doc(hidden)]

--- a/diesel/src/internal/table_macro.rs
+++ b/diesel/src/internal/table_macro.rs
@@ -10,6 +10,11 @@ pub use crate::query_builder::nodes::{
     Identifier, InfixNode, StaticQueryFragment, StaticQueryFragmentInstance,
 };
 #[doc(hidden)]
+pub mod returning {
+    #[doc(hidden)]
+    pub use crate::query_builder::returning::*;
+}
+#[doc(hidden)]
 pub use crate::query_builder::select_statement::SelectStatement;
 #[doc(hidden)]
 pub use crate::query_builder::select_statement::boxed::BoxedSelectStatement;

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -779,7 +779,7 @@ pub mod helper_types {
     /// [`UpdateStatement::returning`] and
     /// [`DeleteStatement::returning`](crate::query_builder::DeleteStatement::returning)
     pub type Returning<Q, S> =
-        <Q as crate::query_builder::returning_clause::ReturningClauseHelper<S>>::WithReturning;
+        <Q as crate::query_builder::returning::ReturningClauseHelper<S>>::WithReturning;
 
     #[doc(hidden)] // used for `QueryDsl::count`
     pub type Count<Q> = Select<Q, CountStar>;

--- a/diesel/src/pg/expression/helper_types.rs
+++ b/diesel/src/pg/expression/helper_types.rs
@@ -4,8 +4,7 @@ use crate::expression::grouped::Grouped;
 use crate::expression_methods::JsonIndex;
 use crate::pg::expression::expression_methods::private::JsonRemoveIndex;
 use crate::pg::types::sql_types::Array;
-use crate::sql_types::Nullable;
-use crate::sql_types::{Inet, Integer, VarChar};
+use crate::sql_types::{Inet, Integer, Nullable, VarChar};
 
 /// The return type of [`lhs.ilike(rhs)`](super::expression_methods::PgTextExpressionMethods::ilike)
 #[cfg(feature = "postgres_backend")]

--- a/diesel/src/pg/expression/mod.rs
+++ b/diesel/src/pg/expression/mod.rs
@@ -19,6 +19,10 @@ mod return_type_helpers {
     #[allow(unused_imports)]
     #[doc(inline)]
     pub use super::functions::return_type_helpers_reexported::*;
+
+    #[allow(unused_imports)]
+    #[doc(inline)]
+    pub use super::super::returning::return_type_helpers_reexported::*;
 }
 
 /// PostgreSQL specific expression DSL methods.

--- a/diesel/src/pg/mod.rs
+++ b/diesel/src/pg/mod.rs
@@ -12,6 +12,7 @@ pub(crate) mod backend;
 pub(crate) mod connection;
 mod metadata_lookup;
 pub(crate) mod query_builder;
+pub mod returning;
 pub(crate) mod serialize;
 mod transaction;
 mod value;

--- a/diesel/src/pg/returning/mod.rs
+++ b/diesel/src/pg/returning/mod.rs
@@ -1,0 +1,12 @@
+//! PostgreSQL-specific `RETURNING` clause helpers.
+//!
+//! This module exposes [`old()`], the wrapper used to refer to the
+//! pre-modification value of a column in a PostgreSQL `RETURNING` clause —
+//! the `RETURNING old.col` syntax introduced in PostgreSQL 18.
+
+// Naming: we suffix with `_impl` to avoid name conflicts with the `old` re-export below.
+mod old_impl;
+
+pub use self::old_impl::old;
+
+pub(crate) use self::old_impl::return_type_helpers_reexported;

--- a/diesel/src/pg/returning/old_impl.rs
+++ b/diesel/src/pg/returning/old_impl.rs
@@ -1,0 +1,175 @@
+//! `RETURNING old.col` support for PostgreSQL 18 and later.
+
+use crate::backend::{Backend, sql_dialect};
+use crate::expression::{
+    AppearsOnTable, Expression, SelectableExpression, ValidGrouping, is_aggregate,
+};
+use crate::query_builder::returning::{
+    InsertStmtWithOnConflictDoUpdate, ReturningQuerySource, UpdateStmt,
+};
+use crate::query_builder::{AstPass, QueryFragment, QueryId};
+use crate::query_source::Column;
+use crate::result::QueryResult;
+
+/// Wraps a column to refer to its pre-modification value in the `RETURNING`
+/// clause of a PostgreSQL `UPDATE` or `INSERT ... ON CONFLICT ... DO UPDATE`
+/// statement.
+///
+/// This is the type returned by [`old()`](old()).
+#[derive(Debug, Clone, Copy)]
+pub struct Old<C> {
+    _column: C,
+}
+
+impl<C> Old<C> {
+    pub(crate) fn new(c: C) -> Self {
+        Old { _column: c }
+    }
+}
+
+/// Refer to the pre-modification value of `col` in a PostgreSQL `RETURNING`
+/// clause.
+///
+/// This corresponds to the SQL `RETURNING old.col` syntax introduced in
+/// PostgreSQL 18.
+///
+/// # Requires PostgreSQL 18 or newer
+///
+/// Diesel emits `old.col` in the SQL it sends to the database. Earlier
+/// versions of PostgreSQL will reject the query at execution time.
+///
+/// # Statement compatibility
+///
+/// `old(col)` is valid inside the `RETURNING` clause of:
+///
+/// * an `UPDATE` statement, where it has the same Rust SQL type as `col`
+///   (since every returned row necessarily came from a pre-existing row).
+/// * an `INSERT ... ON CONFLICT ... DO UPDATE` statement, **but only when
+///   wrapped in [`.nullable()`]**: rows that were freshly inserted (rather
+///   than updated) have no `old` row, and `old.col` is `NULL` for them, so
+///   for type-safe deserialization you must opt into a nullable Rust SQL
+///   type. Writing `old(col)` directly (without `.nullable()`) in this
+///   context is rejected at compile time.
+///
+/// Use of `old(col)` in plain `INSERT` (without `ON CONFLICT ... DO UPDATE`)
+/// or `DELETE` `RETURNING` is rejected at compile time, because it is not useful
+/// there. (Note that `ON CONFLICT DO NOTHING` never returns untouched rows.)
+///
+/// [`.nullable()`]: crate::NullableExpressionMethods::nullable
+///
+/// # Example
+///
+/// ```rust
+/// # include!("../../doctest_setup.rs");
+/// #
+/// # #[cfg(feature = "postgres")]
+/// # fn main() {
+/// #     use schema::users::dsl::*;
+/// #     use diesel::pg::returning::old;
+/// #     let connection = &mut establish_connection();
+/// #     // `RETURNING old.col` requires PostgreSQL 18+
+/// #     let pg_version: i32 = diesel::dsl::sql::<diesel::sql_types::Integer>(
+/// #         "SELECT current_setting('server_version_num')::int",
+/// #     ).get_result(connection).unwrap();
+/// #     if pg_version < 180000 { return; }
+/// let was_and_now = diesel::update(users.find(1))
+///     .set(name.eq("Updated"))
+///     .returning((old(name), name))
+///     .get_result::<(String, String)>(connection);
+/// assert_eq!(Ok(("Sean".to_string(), "Updated".to_string())), was_and_now);
+/// # }
+/// # #[cfg(not(feature = "postgres"))]
+/// # fn main() {}
+/// ```
+pub fn old<C: Column>(col: C) -> Old<C> {
+    Old::new(col)
+}
+
+impl<C> QueryId for Old<C> {
+    type QueryId = ();
+
+    const HAS_STATIC_QUERY_ID: bool = false;
+}
+
+impl<C> Expression for Old<C>
+where
+    C: Column + Expression,
+{
+    type SqlType = <C as Expression>::SqlType;
+}
+
+impl<C> ValidGrouping<()> for Old<C>
+where
+    C: Column,
+{
+    type IsAggregate = is_aggregate::No;
+}
+
+// `Old<C>` is selectable on a `RETURNING` clause whose statement-kind marker
+// is `UpdateStmt`. It is deliberately *not* selectable on
+// `ReturningQuerySource<InsertStmtWithOnConflictDoUpdate, _>` directly — only
+// `Nullable<Old<C>>` is, via the existing `Nullable` machinery and the
+// `ToInnerJoin` mapping in `returning_query_source` (which makes
+// `InsertStmtWithOnConflictDoUpdate`'s inner-join "fall back" to `UpdateStmt`).
+// That's how we force users to write `old(col).nullable()` in an
+// `INSERT ... ON CONFLICT ... DO UPDATE RETURNING` and reject `old(col)`
+// alone at compile time.
+impl<C> AppearsOnTable<ReturningQuerySource<UpdateStmt, C::Table>> for Old<C>
+where
+    C: Column,
+    Self: Expression,
+{
+}
+
+impl<C> AppearsOnTable<ReturningQuerySource<InsertStmtWithOnConflictDoUpdate, C::Table>> for Old<C>
+where
+    C: Column,
+    Self: Expression,
+{
+}
+
+// We intentionally did not add implementations for use of `old(col)` in plain `INSERT`
+// (without `ON CONFLICT ... DO UPDATE`) or `DELETE` `RETURNING`, because it is not useful
+// there as one can just use `RETURNING column_name`. (`ON CONFLICT DO NOTHING` never returns
+// untouched rows, so allowing `ON CONFLICT DO NOTHING ... RETURNING` might be misleading to
+// users on that regard - I, the author, have seen bugs caused by not being aware of this
+// PG behavior.)
+
+impl<C> SelectableExpression<ReturningQuerySource<UpdateStmt, C::Table>> for Old<C>
+where
+    C: Column,
+    Self: AppearsOnTable<ReturningQuerySource<UpdateStmt, C::Table>>,
+{
+}
+
+impl<C, DB> QueryFragment<DB> for Old<C>
+where
+    DB: Backend,
+    Self: QueryFragment<DB, DB::ReturningClause>,
+{
+    fn walk_ast<'b>(&'b self, pass: AstPass<'_, 'b, DB>) -> QueryResult<()> {
+        <Self as QueryFragment<DB, DB::ReturningClause>>::walk_ast(self, pass)
+    }
+}
+
+impl<C, DB> QueryFragment<DB, sql_dialect::returning_clause::PgLikeReturningClause> for Old<C>
+where
+    DB: Backend<ReturningClause = sql_dialect::returning_clause::PgLikeReturningClause>,
+    C: Column,
+{
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
+        out.push_sql("old.");
+        out.push_identifier(C::NAME)?;
+        Ok(())
+    }
+}
+
+pub use return_type_helpers_reexported::*;
+
+pub(crate) mod return_type_helpers_reexported {
+    use super::Old;
+
+    /// The return type of [`old(col)`](super::old()).
+    #[allow(non_camel_case_types)]
+    pub type old<C> = Old<C>;
+}

--- a/diesel/src/query_builder/delete_statement/mod.rs
+++ b/diesel/src/query_builder/delete_statement/mod.rs
@@ -1,7 +1,9 @@
 use crate::backend::DieselReserveSpecialization;
 use crate::dsl::{Filter, IntoBoxed, OrFilter};
-use crate::expression::{AppearsOnTable, SelectableExpression};
-use crate::query_builder::returning_clause::*;
+use crate::expression::{AppearsOnTable, Expression, SelectableExpression};
+use crate::query_builder::returning::{
+    DeleteStmt, NoReturningClause, ReturningClause, ReturningQuerySource,
+};
 use crate::query_builder::where_clause::*;
 use crate::query_builder::*;
 use crate::query_dsl::RunQueryDsl;
@@ -269,8 +271,8 @@ where
 impl<T, U> AsQuery for DeleteStatement<T, U, NoReturningClause>
 where
     T: Table,
-    T::AllColumns: SelectableExpression<T>,
     DeleteStatement<T, U, ReturningClause<T::AllColumns>>: Query,
+    T::AllColumns: SelectableExpression<ReturningQuerySource<DeleteStmt, T>>,
 {
     type SqlType = <Self::Query as Query>::SqlType;
     type Query = DeleteStatement<T, U, ReturningClause<T::AllColumns>>;
@@ -283,9 +285,9 @@ where
 impl<T, U, Ret> Query for DeleteStatement<T, U, ReturningClause<Ret>>
 where
     T: Table,
-    Ret: SelectableExpression<T>,
+    Ret: SelectableExpression<ReturningQuerySource<DeleteStmt, T>>,
 {
-    type SqlType = Ret::SqlType;
+    type SqlType = <Ret as Expression>::SqlType;
 }
 
 impl<T, U, Ret, Conn> RunQueryDsl<Conn> for DeleteStatement<T, U, Ret> where T: QuerySource {}
@@ -314,7 +316,6 @@ impl<T: QuerySource, U> DeleteStatement<T, U, NoReturningClause> {
     /// ```
     pub fn returning<E>(self, returns: E) -> DeleteStatement<T, U, ReturningClause<E>>
     where
-        E: SelectableExpression<T>,
         DeleteStatement<T, U, ReturningClause<E>>: Query,
     {
         DeleteStatement {

--- a/diesel/src/query_builder/insert_statement/insert_with_default_for_sqlite.rs
+++ b/diesel/src/query_builder/insert_statement/insert_with_default_for_sqlite.rs
@@ -1,15 +1,17 @@
 use super::{BatchInsert, InsertStatement};
-use crate::insertable::InsertValues;
-use crate::insertable::{CanInsertInSingleQuery, ColumnInsertValue, DefaultableColumnInsertValue};
+use crate::insertable::{
+    CanInsertInSingleQuery, ColumnInsertValue, DefaultableColumnInsertValue, InsertValues,
+};
 use crate::prelude::*;
 use crate::query_builder::debug_query::DebugBinds;
 use crate::query_builder::upsert::on_conflict_clause::OnConflictValues;
-use crate::query_builder::{AstPass, QueryBuilder, QueryId, ValuesClause};
-use crate::query_builder::{DebugQuery, QueryFragment};
-use crate::query_dsl::{LoadQuery, methods::ExecuteDsl};
+use crate::query_builder::{
+    AstPass, DebugQuery, QueryBuilder, QueryFragment, QueryId, ValuesClause,
+};
+use crate::query_dsl::LoadQuery;
+use crate::query_dsl::methods::ExecuteDsl;
 use crate::sqlite::{Sqlite, SqliteQueryBuilder};
-use alloc::string::String;
-use alloc::string::ToString;
+use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use core::fmt::{self, Debug, Display};
 
@@ -527,6 +529,12 @@ where
 pub struct SqliteBatchInsertWrapper<V, T, QId, const STATIC_QUERY_ID: bool>(
     BatchInsert<V, T, QId, STATIC_QUERY_ID>,
 );
+
+impl<V, T, QId, const STATIC_QUERY_ID: bool> crate::query_builder::returning::InsertStmtKind
+    for SqliteBatchInsertWrapper<V, T, QId, STATIC_QUERY_ID>
+{
+    type StmtKind = crate::query_builder::returning::InsertStmtWithoutOnConflictDoUpdate;
+}
 
 impl<V, Tab, QId, const STATIC_QUERY_ID: bool> QueryFragment<Sqlite>
     for SqliteBatchInsertWrapper<Vec<ValuesClause<V, Tab>>, Tab, QId, STATIC_QUERY_ID>

--- a/diesel/src/query_builder/insert_statement/mod.rs
+++ b/diesel/src/query_builder/insert_statement/mod.rs
@@ -11,11 +11,13 @@ pub(crate) use self::private::Insert;
 )]
 pub(crate) use self::private::{InsertOrIgnore, Replace};
 
-use super::returning_clause::*;
 use crate::backend::{DieselReserveSpecialization, SqlDialect, sql_dialect};
 use crate::expression::grouped::Grouped;
 use crate::expression::operators::Eq;
 use crate::expression::{Expression, NonAggregate, SelectableExpression};
+use crate::query_builder::returning::{
+    InsertStmtKind, NoReturningClause, ReturningClause, ReturningQuerySource,
+};
 use crate::query_builder::*;
 use crate::query_dsl::RunQueryDsl;
 use crate::query_source::{Column, Table};
@@ -285,7 +287,9 @@ where
 impl<T, U, Op> AsQuery for InsertStatement<T, U, Op, NoReturningClause>
 where
     T: Table,
+    U: InsertStmtKind,
     InsertStatement<T, U, Op, ReturningClause<T::AllColumns>>: Query,
+    T::AllColumns: SelectableExpression<ReturningQuerySource<U::StmtKind, T>>,
 {
     type SqlType = <Self::Query as Query>::SqlType;
     type Query = InsertStatement<T, U, Op, ReturningClause<T::AllColumns>>;
@@ -298,9 +302,10 @@ where
 impl<T, U, Op, Ret> Query for InsertStatement<T, U, Op, ReturningClause<Ret>>
 where
     T: QuerySource,
-    Ret: Expression + SelectableExpression<T> + NonAggregate,
+    U: InsertStmtKind,
+    Ret: SelectableExpression<ReturningQuerySource<U::StmtKind, T>> + NonAggregate,
 {
-    type SqlType = Ret::SqlType;
+    type SqlType = <Ret as Expression>::SqlType;
 }
 
 impl<T: QuerySource, U, Op, Ret, Conn> RunQueryDsl<Conn> for InsertStatement<T, U, Op, Ret> {}
@@ -593,7 +598,7 @@ mod private {
         type Table = T;
         type Op = Op;
         type Values = ();
-        type Ret = crate::query_builder::returning_clause::NoReturningClause;
+        type Ret = crate::query_builder::returning::NoReturningClause;
     }
 
     impl<T, U, Op, Ret> InsertAutoTypeHelper for InsertStatement<T, U, Op, Ret>

--- a/diesel/src/query_builder/mod.rs
+++ b/diesel/src/query_builder/mod.rs
@@ -27,7 +27,6 @@ pub(crate) mod locking_clause;
 pub(crate) mod nodes;
 pub(crate) mod offset_clause;
 pub(crate) mod order_clause;
-pub(crate) mod returning_clause;
 pub(crate) mod select_clause;
 pub(crate) mod select_statement;
 mod sql_query;
@@ -95,9 +94,10 @@ pub(crate) use self::insert_statement::{UndecoratedInsertRecord, ValuesClause};
 #[doc(inline)]
 pub use self::insert_statement::{DefaultValues, InsertOrIgnore, Replace};
 
+#[cfg(not(feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"))]
+pub(crate) mod returning;
 #[cfg(feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes")]
-#[doc(inline)]
-pub use self::returning_clause::ReturningClause;
+pub mod returning;
 
 #[doc(inline)]
 #[diesel_derives::__diesel_public_if(

--- a/diesel/src/query_builder/returning/mod.rs
+++ b/diesel/src/query_builder/returning/mod.rs
@@ -1,0 +1,9 @@
+//! Types involved in type-checking and emitting SQL `RETURNING` clauses.
+
+pub(crate) mod returning_clause;
+pub(crate) mod returning_query_source;
+
+#[doc(inline)]
+pub use self::returning_clause::*;
+#[doc(inline)]
+pub use self::returning_query_source::*;

--- a/diesel/src/query_builder/returning/returning_clause.rs
+++ b/diesel/src/query_builder/returning/returning_clause.rs
@@ -1,12 +1,16 @@
-use super::DeleteStatement;
-use super::InsertStatement;
-use super::UpdateStatement;
-use super::{AstPass, QueryFragment};
 use crate::QuerySource;
 use crate::backend::{Backend, DieselReserveSpecialization};
-use crate::query_builder::QueryId;
+use crate::query_builder::{
+    AstPass, DeleteStatement, InsertStatement, QueryFragment, QueryId, UpdateStatement,
+};
 use crate::result::QueryResult;
 
+/// Marker type for `INSERT`/`UPDATE`/`DELETE` ASTs that do not have a
+/// `RETURNING` clause attached yet.
+///
+/// This is the default `Ret` parameter of [`InsertStatement`],
+/// [`UpdateStatement`] and [`DeleteStatement`]. Calling `.returning(...)` on
+/// such a statement swaps it out for a [`ReturningClause`].
 #[derive(Debug, Clone, Copy, QueryId)]
 pub struct NoReturningClause;
 
@@ -57,7 +61,13 @@ where
     }
 }
 
+/// Helper trait that maps an `INSERT`/`UPDATE`/`DELETE` statement type to
+/// the same statement type with an explicit [`ReturningClause<S>`] attached.
+///
+/// This is used to spell the return type of `.returning(...)` in the `dsl`
+/// module without naming each individual statement type.
 pub trait ReturningClauseHelper<S> {
+    /// `Self` with a `RETURNING S` clause attached.
     type WithReturning;
 }
 

--- a/diesel/src/query_builder/returning/returning_query_source.rs
+++ b/diesel/src/query_builder/returning/returning_query_source.rs
@@ -1,0 +1,133 @@
+//! The `ReturningQuerySource<StmtKind, T>` wrapper used to type-check `RETURNING`
+//! clauses, the statement-kind markers it is parameterized over, and the
+//! [`InsertStmtKind`] dispatch trait.
+//!
+//! This module holds the items needed to type-check `RETURNING` clauses that are not specific
+//! to a particular backend.
+
+use crate::query_source::joins::ToInnerJoin;
+use crate::query_source::{AppearsInFromClause, Once};
+use core::marker::PhantomData;
+
+/// Statement-kind marker
+#[derive(Debug, Copy, Clone)]
+pub struct InsertStmtWithoutOnConflictDoUpdate;
+
+/// Statement-kind marker
+#[derive(Debug, Copy, Clone)]
+pub struct UpdateStmt;
+
+/// Statement-kind marker
+#[derive(Debug, Copy, Clone)]
+pub struct DeleteStmt;
+
+/// Statement-kind marker
+#[derive(Debug, Copy, Clone)]
+pub struct InsertStmtWithOnConflictDoUpdate;
+
+/// Synthetic query source used as the `QS` parameter of
+/// [`SelectableExpression`](crate::expression::SelectableExpression) /
+/// [`AppearsOnTable`](crate::expression::AppearsOnTable) when type-checking
+/// `RETURNING` clauses.
+///
+/// `StmtKind` is one of the marker structs above; `T` is the table that the
+/// `INSERT`/`UPDATE`/`DELETE` is acting on.
+#[derive(Debug, Clone, Copy)]
+pub struct ReturningQuerySource<StmtKind, T>(PhantomData<(StmtKind, T)>);
+
+impl<StmtKind, T> AppearsInFromClause<T> for ReturningQuerySource<StmtKind, T> {
+    type Count = Once;
+}
+
+// For typechecking of `old(column).nullable()`
+
+impl<T> ToInnerJoin for ReturningQuerySource<UpdateStmt, T> {
+    type InnerJoin = Self;
+}
+
+impl<T> ToInnerJoin for ReturningQuerySource<DeleteStmt, T> {
+    type InnerJoin = Self;
+}
+
+impl<T> ToInnerJoin for ReturningQuerySource<InsertStmtWithoutOnConflictDoUpdate, T> {
+    type InnerJoin = Self;
+}
+
+// `InsertStmtWithOnConflictDoUpdate` maps to `UpdateStmt`. This is what makes
+// `Nullable<Old<C>>: SelectableExpression<ReturningQuerySource<InsertStmtWithOnConflictDoUpdate, _>>`
+// resolve through the existing
+// `impl<T, QS> SelectableExpression<QS> for Nullable<T>
+//     where QS: ToInnerJoin, T: SelectableExpression<QS::InnerJoin>` impl
+// (see `crate::expression::nullable::Nullable`): that bound reduces to
+// `Old<C>: SelectableExpression<ReturningQuerySource<UpdateStmt, _>>`, which
+// holds, while the bare `Old<C>: SelectableExpression<ReturningQuerySource<InsertStmtWithOnConflictDoUpdate, _>>`
+// is intentionally *not* implemented — forcing users to write
+// `old(col).nullable()` in `ON CONFLICT ... DO UPDATE` for type safety.
+impl<T> ToInnerJoin for ReturningQuerySource<InsertStmtWithOnConflictDoUpdate, T> {
+    type InnerJoin = ReturningQuerySource<UpdateStmt, T>;
+}
+
+/// Maps an `InsertStatement` `Values` shape to the statement-kind marker that
+/// should be used when type-checking that statement's `RETURNING` clause.
+///
+/// This is what makes `RETURNING old(col)` accept `INSERT ... ON CONFLICT
+/// ... DO UPDATE` (where the marker is [`InsertStmtWithOnConflictDoUpdate`], for
+/// which `Nullable<Old<C>>` is a valid `RETURNING` element) but reject plain
+/// `INSERT` (where the marker is [`InsertStmtWithoutOnConflictDoUpdate`], for which `Old<C>` does not
+/// implement `SelectableExpression`).
+///
+/// The trait is sealed in spirit — it only has impls for the values shapes
+/// `diesel` itself produces — but it is exposed publicly under the
+/// `i-implement-a-third-party-backend-and-opt-into-breaking-changes` feature
+/// so third-party backends that introduce new values shapes can add their own
+/// impls.
+pub trait InsertStmtKind {
+    /// The statement-kind marker (see e.g. [`InsertStmtWithoutOnConflictDoUpdate`],
+    /// [`InsertStmtWithOnConflictDoUpdate`]) used as the `StmtKind` parameter of
+    /// [`ReturningQuerySource`] for `INSERT` statements with this `Values`
+    /// shape.
+    type StmtKind;
+}
+
+impl<T, Tab> InsertStmtKind for crate::query_builder::ValuesClause<T, Tab> {
+    type StmtKind = InsertStmtWithoutOnConflictDoUpdate;
+}
+
+impl<V, Tab, QId, const STABLE_QUERY_ID: bool> InsertStmtKind
+    for crate::query_builder::BatchInsert<V, Tab, QId, STABLE_QUERY_ID>
+{
+    type StmtKind = InsertStmtWithoutOnConflictDoUpdate;
+}
+
+impl InsertStmtKind for crate::query_builder::insert_statement::DefaultValues {
+    type StmtKind = InsertStmtWithoutOnConflictDoUpdate;
+}
+
+impl<S, C> InsertStmtKind for crate::query_builder::insert_statement::InsertFromSelect<S, C> {
+    type StmtKind = InsertStmtWithoutOnConflictDoUpdate;
+}
+
+impl<V, Target, T, WhereClause> InsertStmtKind
+    for crate::query_builder::upsert::on_conflict_clause::OnConflictValues<
+        V,
+        Target,
+        crate::query_builder::upsert::on_conflict_actions::DoNothing<T>,
+        WhereClause,
+    >
+{
+    // ON CONFLICT DO NOTHING does not return the lines that conflicted if using RETURNING
+    // so it's unnecessary (and would even be misleading) to allow RETURNING old.xxx
+    // in this case.
+    type StmtKind = InsertStmtWithoutOnConflictDoUpdate;
+}
+
+impl<V, Target, Changeset, Tab, WhereClause> InsertStmtKind
+    for crate::query_builder::upsert::on_conflict_clause::OnConflictValues<
+        V,
+        Target,
+        crate::query_builder::upsert::on_conflict_actions::DoUpdate<Changeset, Tab>,
+        WhereClause,
+    >
+{
+    type StmtKind = InsertStmtWithOnConflictDoUpdate;
+}

--- a/diesel/src/query_builder/update_statement/mod.rs
+++ b/diesel/src/query_builder/update_statement/mod.rs
@@ -1,19 +1,22 @@
 pub(crate) mod changeset;
 pub(super) mod target;
 
+use crate::QuerySource;
 use crate::backend::DieselReserveSpecialization;
 use crate::dsl::{Filter, IntoBoxed};
 use crate::expression::{
     AppearsOnTable, Expression, MixedAggregates, SelectableExpression, ValidGrouping, is_aggregate,
 };
-use crate::query_builder::returning_clause::*;
+use crate::query_builder::returning::{
+    NoReturningClause, ReturningClause, ReturningQuerySource, UpdateStmt,
+};
 use crate::query_builder::where_clause::*;
+use crate::query_builder::*;
 use crate::query_dsl::RunQueryDsl;
 use crate::query_dsl::methods::{BoxedDsl, FilterDsl};
 use crate::query_source::Table;
 use crate::result::EmptyChangeset;
 use crate::result::Error::QueryBuilderError;
-use crate::{QuerySource, query_builder::*};
 
 pub(crate) use self::private::SetAutoTypeHelper;
 
@@ -224,7 +227,7 @@ impl<T, U, V> AsQuery for UpdateStatement<T, U, V, NoReturningClause>
 where
     T: Table,
     UpdateStatement<T, U, V, ReturningClause<T::AllColumns>>: Query,
-    T::AllColumns: ValidGrouping<()>,
+    T::AllColumns: SelectableExpression<ReturningQuerySource<UpdateStmt, T>> + ValidGrouping<()>,
     <T::AllColumns as ValidGrouping<()>>::IsAggregate:
         MixedAggregates<is_aggregate::No, Output = is_aggregate::No>,
 {
@@ -239,10 +242,10 @@ where
 impl<T, U, V, Ret> Query for UpdateStatement<T, U, V, ReturningClause<Ret>>
 where
     T: Table,
-    Ret: Expression + SelectableExpression<T> + ValidGrouping<()>,
+    Ret: SelectableExpression<ReturningQuerySource<UpdateStmt, T>> + ValidGrouping<()>,
     Ret::IsAggregate: MixedAggregates<is_aggregate::No, Output = is_aggregate::No>,
 {
-    type SqlType = Ret::SqlType;
+    type SqlType = <Ret as Expression>::SqlType;
 }
 
 impl<T: QuerySource, U, V, Ret, Conn> RunQueryDsl<Conn> for UpdateStatement<T, U, V, Ret> {}
@@ -265,6 +268,35 @@ impl<T: QuerySource, U, V> UpdateStatement<T, U, V, NoReturningClause> {
     ///     .returning(name)
     ///     .get_result(connection);
     /// assert_eq!(Ok("Dean".to_string()), updated_name);
+    /// # }
+    /// # #[cfg(not(feature = "postgres"))]
+    /// # fn main() {}
+    /// ```
+    ///
+    /// ### Returning the pre-update value (PostgreSQL 18+):
+    ///
+    /// `RETURNING old.col` — exposed via [`diesel::pg::returning::old()`] —
+    /// returns the value of the column **before** the update was applied.
+    /// This requires PostgreSQL 18 or newer.
+    ///
+    /// ```rust
+    /// # include!("../../doctest_setup.rs");
+    /// #
+    /// # #[cfg(feature = "postgres")]
+    /// # fn main() {
+    /// #     use schema::users::dsl::*;
+    /// #     use diesel::pg::returning::old;
+    /// #     let connection = &mut establish_connection();
+    /// #     // `RETURNING old.col` requires PostgreSQL 18+
+    /// #     let pg_version: i32 = diesel::dsl::sql::<diesel::sql_types::Integer>(
+    /// #         "SELECT current_setting('server_version_num')::int",
+    /// #     ).get_result(connection).unwrap();
+    /// #     if pg_version < 180000 { return; }
+    /// let was_and_now = diesel::update(users.filter(id.eq(1)))
+    ///     .set(name.eq("Dean"))
+    ///     .returning((old(name), name))
+    ///     .get_result::<(String, String)>(connection);
+    /// assert_eq!(Ok(("Sean".to_string(), "Dean".to_string())), was_and_now);
     /// # }
     /// # #[cfg(not(feature = "postgres"))]
     /// # fn main() {}

--- a/diesel/src/query_dsl/save_changes_dsl.rs
+++ b/diesel/src/query_dsl/save_changes_dsl.rs
@@ -40,7 +40,13 @@ impl<'b, Changes, Output> UpdateAndFetchResults<Changes, Output> for PgConnectio
 where
     Changes: Copy + AsChangeset<Target = <Changes as HasTable>::Table> + IntoUpdateTarget,
     Update<Changes, Changes>: LoadQuery<'b, PgConnection, Output>,
-    <Changes::Table as Table>::AllColumns: ValidGrouping<()>,
+    <Changes::Table as Table>::AllColumns: ValidGrouping<()>
+        + crate::expression::SelectableExpression<
+            crate::query_builder::returning::ReturningQuerySource<
+                crate::query_builder::returning::UpdateStmt,
+                Changes::Table,
+            >,
+        >,
     <<Changes::Table as Table>::AllColumns as ValidGrouping<()>>::IsAggregate:
         MixedAggregates<is_aggregate::No, Output = is_aggregate::No>,
 {
@@ -60,7 +66,13 @@ where
     Changes::Table: FindDsl<Changes::Id>,
     Update<Changes, Changes>: ExecuteDsl<SqliteConnection>,
     Find<Changes::Table, Changes::Id>: LoadQuery<'b, SqliteConnection, Output>,
-    <Changes::Table as Table>::AllColumns: ValidGrouping<()>,
+    <Changes::Table as Table>::AllColumns: ValidGrouping<()>
+        + crate::expression::SelectableExpression<
+            crate::query_builder::returning::ReturningQuerySource<
+                crate::query_builder::returning::UpdateStmt,
+                Changes::Table,
+            >,
+        >,
     <<Changes::Table as Table>::AllColumns as ValidGrouping<()>>::IsAggregate:
         MixedAggregates<is_aggregate::No, Output = is_aggregate::No>,
 {
@@ -81,7 +93,13 @@ where
     Changes::Table: FindDsl<Changes::Id>,
     Update<Changes, Changes>: ExecuteDsl<MysqlConnection>,
     Find<Changes::Table, Changes::Id>: LoadQuery<'b, MysqlConnection, Output>,
-    <Changes::Table as Table>::AllColumns: ValidGrouping<()>,
+    <Changes::Table as Table>::AllColumns: ValidGrouping<()>
+        + crate::expression::SelectableExpression<
+            crate::query_builder::returning::ReturningQuerySource<
+                crate::query_builder::returning::UpdateStmt,
+                Changes::Table,
+            >,
+        >,
     <<Changes::Table as Table>::AllColumns as ValidGrouping<()>>::IsAggregate:
         MixedAggregates<is_aggregate::No, Output = is_aggregate::No>,
 {

--- a/diesel/src/sqlite/query_builder/returning.rs
+++ b/diesel/src/sqlite/query_builder/returning.rs
@@ -1,5 +1,5 @@
 use crate::backend::Backend;
-use crate::query_builder::returning_clause::ReturningClause;
+use crate::query_builder::returning::ReturningClause;
 use crate::query_builder::{AstPass, QueryFragment};
 use crate::result::QueryResult;
 use crate::sqlite::backend::SqliteReturningClause;

--- a/diesel_compile_tests/tests/fail/aggregate_expression_requires_column_from_same_table.stderr
+++ b/diesel_compile_tests/tests/fail/aggregate_expression_requires_column_from_same_table.stderr
@@ -13,6 +13,7 @@ LL |         id -> Integer,
    = help: the following other types implement trait `SelectableExpression<QS>`:
              `posts::columns::id` implements `SelectableExpression<Only<posts::table>>`
              `posts::columns::id` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
+             `posts::columns::id` implements `SelectableExpression<ReturningQuerySource<..., ...>>`
              `posts::columns::id` implements `SelectableExpression<SelectStatement<...>>`
              `posts::columns::id` implements `SelectableExpression<posts::table>`
              `posts::columns::id` implements `SelectableExpression<Join<Left, Right, Inner>>`
@@ -57,6 +58,7 @@ LL |         id -> Integer,
    = help: the following other types implement trait `SelectableExpression<QS>`:
              `posts::columns::id` implements `SelectableExpression<Only<posts::table>>`
              `posts::columns::id` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
+             `posts::columns::id` implements `SelectableExpression<ReturningQuerySource<..., ...>>`
              `posts::columns::id` implements `SelectableExpression<SelectStatement<...>>`
              `posts::columns::id` implements `SelectableExpression<posts::table>`
              `posts::columns::id` implements `SelectableExpression<Join<Left, Right, Inner>>`
@@ -101,6 +103,7 @@ LL |         id -> Integer,
    = help: the following other types implement trait `SelectableExpression<QS>`:
              `posts::columns::id` implements `SelectableExpression<Only<posts::table>>`
              `posts::columns::id` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
+             `posts::columns::id` implements `SelectableExpression<ReturningQuerySource<..., ...>>`
              `posts::columns::id` implements `SelectableExpression<SelectStatement<...>>`
              `posts::columns::id` implements `SelectableExpression<posts::table>`
              `posts::columns::id` implements `SelectableExpression<Join<Left, Right, Inner>>`
@@ -145,6 +148,7 @@ LL |         id -> Integer,
    = help: the following other types implement trait `SelectableExpression<QS>`:
              `posts::columns::id` implements `SelectableExpression<Only<posts::table>>`
              `posts::columns::id` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
+             `posts::columns::id` implements `SelectableExpression<ReturningQuerySource<..., ...>>`
              `posts::columns::id` implements `SelectableExpression<SelectStatement<...>>`
              `posts::columns::id` implements `SelectableExpression<posts::table>`
              `posts::columns::id` implements `SelectableExpression<Join<Left, Right, Inner>>`

--- a/diesel_compile_tests/tests/fail/custom_returning_requires_selectable_expression.rs
+++ b/diesel_compile_tests/tests/fail/custom_returning_requires_selectable_expression.rs
@@ -30,7 +30,7 @@ fn main() {
     let stmt = update(users.filter(id.eq(1)))
         .set(name.eq("Bill"))
         .returning(bad::age);
-    //~^ ERROR: cannot select `bad::columns::age` from `users::table`
+    //~^ ERROR: cannot select `bad::columns::age` from `ReturningQuerySource<UpdateStmt, table>`
 
     let new_user = NewUser {
         name: "Foobar".to_string(),
@@ -38,6 +38,8 @@ fn main() {
     let stmt = insert_into(users)
         .values(&new_user)
         .returning((name, bad::age));
-    //~^ ERROR: cannot select `bad::columns::age` from `users::table`
-    //~| ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
+    //~^ ERROR: cannot select `bad::columns::age` from `ReturningQuerySource<..., ...>`
+    //~| ERROR: type mismatch resolving `<ReturningQuerySource<..., ...> as AppearsInFromClause<...>>::Count == Once`
+    //~| ERROR: the trait bound `ReturningQuerySource<..., ...>: TableNotEqual<...>` is not satisfied
+    //~| ERROR: the trait bound `ReturningQuerySource<..., ...>: Table` is not satisfied
 }

--- a/diesel_compile_tests/tests/fail/custom_returning_requires_selectable_expression.stderr
+++ b/diesel_compile_tests/tests/fail/custom_returning_requires_selectable_expression.stderr
@@ -1,4 +1,4 @@
-error[E0277]: cannot select `bad::columns::age` from `users::table`
+error[E0277]: cannot select `bad::columns::age` from `ReturningQuerySource<UpdateStmt, table>`
    --> tests/fail/custom_returning_requires_selectable_expression.rs:32:20
     |
  LL |         .returning(bad::age);
@@ -6,16 +6,17 @@ error[E0277]: cannot select `bad::columns::age` from `users::table`
     |          |
     |          required by a bound introduced by this call
     |
-help: the trait `SelectableExpression<users::table>` is not implemented for `bad::columns::age`
+help: the trait `SelectableExpression<diesel::query_builder::returning::returning_query_source::ReturningQuerySource<diesel::query_builder::returning::returning_query_source::UpdateStmt, users::table>>` is not implemented for `bad::columns::age`
    --> tests/fail/custom_returning_requires_selectable_expression.rs:15:7
     |
  LL |       age -> Integer,
     |       ^^^
-    = note: `bad::columns::age` is no valid selection for `users::table`
+    = note: `bad::columns::age` is no valid selection for `ReturningQuerySource<UpdateStmt, table>`
     = help: the following other types implement trait `SelectableExpression<QS>`:
               `bad::columns::age` implements `SelectableExpression<Only<bad::table>>`
               `bad::columns::age` implements `SelectableExpression<Tablesample<bad::table, TSM>>`
               `bad::columns::age` implements `SelectableExpression<bad::table>`
+              `bad::columns::age` implements `SelectableExpression<ReturningQuerySource<..., ...>>`
               `bad::columns::age` implements `SelectableExpression<SelectStatement<...>>`
               `bad::columns::age` implements `SelectableExpression<Join<Left, Right, Inner>>`
               `bad::columns::age` implements `SelectableExpression<Join<Left, Right, LeftOuter>>`
@@ -32,7 +33,7 @@ LL |         UpdateStatement<T, U, V, ReturningClause<E>>: Query,
  
         = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: cannot select `bad::columns::age` from `users::table`
+error[E0277]: cannot select `bad::columns::age` from `ReturningQuerySource<..., ...>`
    --> tests/fail/custom_returning_requires_selectable_expression.rs:40:20
     |
  LL |         .returning((name, bad::age));
@@ -40,21 +41,22 @@ error[E0277]: cannot select `bad::columns::age` from `users::table`
     |          |
     |          required by a bound introduced by this call
     |
-help: the trait `SelectableExpression<users::table>` is not implemented for `bad::columns::age`
+help: the trait `SelectableExpression<diesel::query_builder::returning::returning_query_source::ReturningQuerySource<diesel::query_builder::returning::returning_query_source::InsertStmtWithoutOnConflictDoUpdate, users::table>>` is not implemented for `bad::columns::age`
    --> tests/fail/custom_returning_requires_selectable_expression.rs:15:7
     |
  LL |       age -> Integer,
     |       ^^^
-    = note: `bad::columns::age` is no valid selection for `users::table`
+    = note: `bad::columns::age` is no valid selection for `ReturningQuerySource<..., ...>`
     = help: the following other types implement trait `SelectableExpression<QS>`:
               `bad::columns::age` implements `SelectableExpression<Only<bad::table>>`
               `bad::columns::age` implements `SelectableExpression<Tablesample<bad::table, TSM>>`
               `bad::columns::age` implements `SelectableExpression<bad::table>`
+              `bad::columns::age` implements `SelectableExpression<ReturningQuerySource<..., ...>>`
               `bad::columns::age` implements `SelectableExpression<SelectStatement<...>>`
               `bad::columns::age` implements `SelectableExpression<Join<Left, Right, Inner>>`
               `bad::columns::age` implements `SelectableExpression<Join<Left, Right, LeftOuter>>`
               `bad::columns::age` implements `SelectableExpression<query_source::joins::JoinOn<Join, On>>`
-    = note: required for `(users::columns::name, bad::columns::age)` to implement `SelectableExpression<users::table>`
+    = note: required for `(users::columns::name, bad::columns::age)` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
     = note: required for `InsertStatement<table, ..., ..., ...>` to implement `Query`
 note: required by a bound in `InsertStatement::<T, U, Op>::returning`
    --> DIESEL/diesel/diesel/src/query_builder/insert_statement/mod.rs
@@ -67,7 +69,7 @@ LL |         InsertStatement<T, U, Op, ReturningClause<E>>: Query,
  
         = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
+error[E0271]: type mismatch resolving `<ReturningQuerySource<..., ...> as AppearsInFromClause<...>>::Count == Once`
    --> tests/fail/custom_returning_requires_selectable_expression.rs:40:20
     |
  LL |         .returning((name, bad::age));
@@ -75,15 +77,99 @@ error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Co
     |          |
     |          required by a bound introduced by this call
     |
-note: required for `bad::columns::age` to implement `AppearsOnTable<users::table>`
+note: required for `bad::columns::age` to implement `AppearsOnTable<ReturningQuerySource<..., ...>>`
    --> tests/fail/custom_returning_requires_selectable_expression.rs:15:7
     |
  LL |       age -> Integer,
     |       ^^^
     = note: associated types for the current `impl` cannot be restricted in `where` clauses
     = note: 1 redundant requirement hidden
-    = note: required for `(users::columns::name, bad::columns::age)` to implement `AppearsOnTable<users::table>`
-    = note: required for `(users::columns::name, bad::columns::age)` to implement `SelectableExpression<users::table>`
+    = note: required for `(users::columns::name, bad::columns::age)` to implement `AppearsOnTable<ReturningQuerySource<..., ...>>`
+    = note: required for `(users::columns::name, bad::columns::age)` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
+    = note: required for `InsertStatement<table, ..., ..., ...>` to implement `Query`
+note: required by a bound in `InsertStatement::<T, U, Op>::returning`
+   --> DIESEL/diesel/diesel/src/query_builder/insert_statement/mod.rs
+    |
+LL |     pub fn returning<E>(self, returns: E) -> InsertStatement<T, U, Op, ReturningClause<E>>
+    |            --------- required by a bound in this associated function
+LL |     where
+LL |         InsertStatement<T, U, Op, ReturningClause<E>>: Query,
+    |                                                        ^^^^^ required by this bound in `InsertStatement::<T, U, Op>::returning`
+ 
+        = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `ReturningQuerySource<..., ...>: TableNotEqual<...>` is not satisfied
+   --> tests/fail/custom_returning_requires_selectable_expression.rs:40:20
+    |
+ LL |         .returning((name, bad::age));
+    |          --------- ^^^^^^^^^^^^^^^^ the trait `TableNotEqual<bad::table>` is not implemented for `ReturningQuerySource<..., ...>`
+    |          |
+    |          required by a bound introduced by this call
+    |
+    = note: double check that `bad::table` and `ReturningQuerySource<..., ...>` appear in the same `allow_tables_to_appear_in_same_query!` 
+            call if both are tables
+help: the following other types implement trait `TableNotEqual<T>`
+   --> tests/fail/custom_returning_requires_selectable_expression.rs:19:1
+    |
+ LL | allow_tables_to_appear_in_same_query!(users, bad);
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    | |
+    | `bad::table` implements `TableNotEqual<users::table>`
+    | `users::table` implements `TableNotEqual<bad::table>`
+    |
+   ::: DIESEL/diesel/diesel/src/pg/metadata_lookup.rs
+    |
+LL | allow_tables_to_appear_in_same_query!(pg_type, pg_namespace);
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    | |
+    | `pg::metadata_lookup::pg_namespace::table` implements `TableNotEqual<pg::metadata_lookup::pg_type::table>`
+    | `pg::metadata_lookup::pg_type::table` implements `TableNotEqual<pg::metadata_lookup::pg_namespace::table>`
+    = note: required for `ReturningQuerySource<..., ...>` to implement `AppearsInFromClause<bad::table>`
+note: required for `bad::columns::age` to implement `AppearsOnTable<ReturningQuerySource<..., ...>>`
+   --> tests/fail/custom_returning_requires_selectable_expression.rs:15:7
+    |
+ LL |       age -> Integer,
+    |       ^^^
+    = note: 1 redundant requirement hidden
+    = note: required for `(users::columns::name, bad::columns::age)` to implement `AppearsOnTable<ReturningQuerySource<..., ...>>`
+    = note: required for `(users::columns::name, bad::columns::age)` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
+    = note: required for `InsertStatement<table, ..., ..., ...>` to implement `Query`
+note: required by a bound in `InsertStatement::<T, U, Op>::returning`
+   --> DIESEL/diesel/diesel/src/query_builder/insert_statement/mod.rs
+    |
+LL |     pub fn returning<E>(self, returns: E) -> InsertStatement<T, U, Op, ReturningClause<E>>
+    |            --------- required by a bound in this associated function
+LL |     where
+LL |         InsertStatement<T, U, Op, ReturningClause<E>>: Query,
+    |                                                        ^^^^^ required by this bound in `InsertStatement::<T, U, Op>::returning`
+ 
+        = note: this error originates in the macro `allow_tables_to_appear_in_same_query` which comes from the expansion of the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `ReturningQuerySource<..., ...>: Table` is not satisfied
+   --> tests/fail/custom_returning_requires_selectable_expression.rs:40:20
+    |
+ LL |         .returning((name, bad::age));
+    |          --------- ^^^^^^^^^^^^^^^^ the trait `Table` is not implemented for `ReturningQuerySource<..., ...>`
+    |          |
+    |          required by a bound introduced by this call
+    |
+    = help: the following other types implement trait `Table`:
+              Only<S>
+              Tablesample<S, TSM>
+              bad::table
+              pg::metadata_lookup::pg_namespace::table
+              pg::metadata_lookup::pg_type::table
+              users::table
+    = note: required for `ReturningQuerySource<..., ...>` to implement `QueryRelation`
+    = note: required for `ReturningQuerySource<..., ...>` to implement `AppearsInFromClause<bad::table>`
+note: required for `bad::columns::age` to implement `AppearsOnTable<ReturningQuerySource<..., ...>>`
+   --> tests/fail/custom_returning_requires_selectable_expression.rs:15:7
+    |
+ LL |       age -> Integer,
+    |       ^^^
+    = note: 1 redundant requirement hidden
+    = note: required for `(users::columns::name, bad::columns::age)` to implement `AppearsOnTable<ReturningQuerySource<..., ...>>`
+    = note: required for `(users::columns::name, bad::columns::age)` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
     = note: required for `InsertStatement<table, ..., ..., ...>` to implement `Query`
 note: required by a bound in `InsertStatement::<T, U, Op>::returning`
    --> DIESEL/diesel/diesel/src/query_builder/insert_statement/mod.rs

--- a/diesel_compile_tests/tests/fail/delete_statement_does_not_support_returning_methods_on_sqlite.stderr
+++ b/diesel_compile_tests/tests/fail/delete_statement_does_not_support_returning_methods_on_sqlite.stderr
@@ -10,13 +10,13 @@ error[E0277]: `ReturningClause<(id, name)>` is no valid SQL fragment for the `Sq
      = note: this usually means that the `Sqlite` database system does not support 
              this SQL syntax
 help: the following other types implement trait `QueryFragment<DB, SP>`
-    --> DIESEL/diesel/diesel/src/query_builder/returning_clause.rs
+    --> DIESEL/diesel/diesel/src/query_builder/returning/returning_clause.rs
      |
   LL | / impl<Expr, DB> QueryFragment<DB> for ReturningClause<Expr>
   LL | | where
   LL | |     DB: Backend,
   LL | |     Self: QueryFragment<DB, DB::ReturningClause>,
-     | |_________________________________________________^ `diesel::query_builder::returning_clause::ReturningClause<Expr>` implements `QueryFragment<DB>`
+     | |_________________________________________________^ `ReturningClause<Expr>` implements `QueryFragment<DB>`
 ...
   LL | / impl<Expr, DB>
   LL | |     QueryFragment<DB, crate::backend::sql_dialect::returning_clause::PgLikeReturningClause>
@@ -25,7 +25,7 @@ help: the following other types implement trait `QueryFragment<DB, SP>`
 ...    |
   LL | |     >,
   LL | |     Expr: QueryFragment<DB>,
-     | |____________________________^ `diesel::query_builder::returning_clause::ReturningClause<Expr>` implements `QueryFragment<DB, PgLikeReturningClause>`
+     | |____________________________^ `ReturningClause<Expr>` implements `QueryFragment<DB, PgLikeReturningClause>`
      |
     ::: DIESEL/diesel/diesel/src/sqlite/query_builder/returning.rs
      |
@@ -33,7 +33,7 @@ help: the following other types implement trait `QueryFragment<DB, SP>`
    LL | | where
    LL | |     DB: Backend<ReturningClause = SqliteReturningClause>,
   LL | |     Expr: QueryFragment<DB>,
-     | |____________________________^ `diesel::query_builder::returning_clause::ReturningClause<Expr>` implements `QueryFragment<DB, sqlite::backend::SqliteReturningClause>`
+     | |____________________________^ `ReturningClause<Expr>` implements `QueryFragment<DB, sqlite::backend::SqliteReturningClause>`
      = note: required for `ReturningClause<(id, name)>` to implement `QueryFragment<Sqlite>`
      = note: 1 redundant requirement hidden
      = note: required for `DeleteStatement<table, WhereClause<...>, ...>` to implement `QueryFragment<Sqlite>`
@@ -60,13 +60,13 @@ error[E0277]: `ReturningClause<name>` is no valid SQL fragment for the `Sqlite` 
      = note: this usually means that the `Sqlite` database system does not support 
              this SQL syntax
 help: the following other types implement trait `QueryFragment<DB, SP>`
-    --> DIESEL/diesel/diesel/src/query_builder/returning_clause.rs
+    --> DIESEL/diesel/diesel/src/query_builder/returning/returning_clause.rs
      |
   LL | / impl<Expr, DB> QueryFragment<DB> for ReturningClause<Expr>
   LL | | where
   LL | |     DB: Backend,
   LL | |     Self: QueryFragment<DB, DB::ReturningClause>,
-     | |_________________________________________________^ `diesel::query_builder::returning_clause::ReturningClause<Expr>` implements `QueryFragment<DB>`
+     | |_________________________________________________^ `ReturningClause<Expr>` implements `QueryFragment<DB>`
 ...
   LL | / impl<Expr, DB>
   LL | |     QueryFragment<DB, crate::backend::sql_dialect::returning_clause::PgLikeReturningClause>
@@ -75,7 +75,7 @@ help: the following other types implement trait `QueryFragment<DB, SP>`
 ...    |
   LL | |     >,
   LL | |     Expr: QueryFragment<DB>,
-     | |____________________________^ `diesel::query_builder::returning_clause::ReturningClause<Expr>` implements `QueryFragment<DB, PgLikeReturningClause>`
+     | |____________________________^ `ReturningClause<Expr>` implements `QueryFragment<DB, PgLikeReturningClause>`
      |
     ::: DIESEL/diesel/diesel/src/sqlite/query_builder/returning.rs
      |
@@ -83,7 +83,7 @@ help: the following other types implement trait `QueryFragment<DB, SP>`
    LL | | where
    LL | |     DB: Backend<ReturningClause = SqliteReturningClause>,
   LL | |     Expr: QueryFragment<DB>,
-     | |____________________________^ `diesel::query_builder::returning_clause::ReturningClause<Expr>` implements `QueryFragment<DB, sqlite::backend::SqliteReturningClause>`
+     | |____________________________^ `ReturningClause<Expr>` implements `QueryFragment<DB, sqlite::backend::SqliteReturningClause>`
      = note: required for `ReturningClause<name>` to implement `QueryFragment<Sqlite>`
      = note: 1 redundant requirement hidden
      = note: required for `DeleteStatement<table, WhereClause<...>, ...>` to implement `QueryFragment<Sqlite>`

--- a/diesel_compile_tests/tests/fail/derive/aliases.stderr
+++ b/diesel_compile_tests/tests/fail/derive/aliases.stderr
@@ -106,6 +106,7 @@ help: the trait `SelectableExpression<Alias<users2>>` is not implemented for `us
     = help: the following other types implement trait `SelectableExpression<QS>`:
               `users::columns::id` implements `SelectableExpression<Only<users::table>>`
               `users::columns::id` implements `SelectableExpression<Tablesample<users::table, TSM>>`
+              `users::columns::id` implements `SelectableExpression<ReturningQuerySource<..., ...>>`
               `users::columns::id` implements `SelectableExpression<SelectStatement<...>>`
               `users::columns::id` implements `SelectableExpression<Join<Left, Right, Inner>>`
               `users::columns::id` implements `SelectableExpression<Join<Left, Right, LeftOuter>>`
@@ -142,6 +143,7 @@ help: the trait `SelectableExpression<Alias<users2>>` is not implemented for `us
      = help: the following other types implement trait `SelectableExpression<QS>`:
                `users::columns::id` implements `SelectableExpression<Only<users::table>>`
                `users::columns::id` implements `SelectableExpression<Tablesample<users::table, TSM>>`
+               `users::columns::id` implements `SelectableExpression<ReturningQuerySource<..., ...>>`
                `users::columns::id` implements `SelectableExpression<SelectStatement<...>>`
                `users::columns::id` implements `SelectableExpression<Join<Left, Right, Inner>>`
                `users::columns::id` implements `SelectableExpression<Join<Left, Right, LeftOuter>>`

--- a/diesel_compile_tests/tests/fail/insert_statement_does_not_support_returning_methods_on_sqlite.stderr
+++ b/diesel_compile_tests/tests/fail/insert_statement_does_not_support_returning_methods_on_sqlite.stderr
@@ -10,13 +10,13 @@ error[E0277]: `ReturningClause<(id, name)>` is no valid SQL fragment for the `Sq
      = note: this usually means that the `Sqlite` database system does not support 
              this SQL syntax
 help: the following other types implement trait `QueryFragment<DB, SP>`
-    --> DIESEL/diesel/diesel/src/query_builder/returning_clause.rs
+    --> DIESEL/diesel/diesel/src/query_builder/returning/returning_clause.rs
      |
   LL | / impl<Expr, DB> QueryFragment<DB> for ReturningClause<Expr>
   LL | | where
   LL | |     DB: Backend,
   LL | |     Self: QueryFragment<DB, DB::ReturningClause>,
-     | |_________________________________________________^ `diesel::query_builder::returning_clause::ReturningClause<Expr>` implements `QueryFragment<DB>`
+     | |_________________________________________________^ `ReturningClause<Expr>` implements `QueryFragment<DB>`
 ...
   LL | / impl<Expr, DB>
   LL | |     QueryFragment<DB, crate::backend::sql_dialect::returning_clause::PgLikeReturningClause>
@@ -25,7 +25,7 @@ help: the following other types implement trait `QueryFragment<DB, SP>`
 ...    |
   LL | |     >,
   LL | |     Expr: QueryFragment<DB>,
-     | |____________________________^ `diesel::query_builder::returning_clause::ReturningClause<Expr>` implements `QueryFragment<DB, PgLikeReturningClause>`
+     | |____________________________^ `ReturningClause<Expr>` implements `QueryFragment<DB, PgLikeReturningClause>`
      |
     ::: DIESEL/diesel/diesel/src/sqlite/query_builder/returning.rs
      |
@@ -33,7 +33,7 @@ help: the following other types implement trait `QueryFragment<DB, SP>`
    LL | | where
    LL | |     DB: Backend<ReturningClause = SqliteReturningClause>,
   LL | |     Expr: QueryFragment<DB>,
-     | |____________________________^ `diesel::query_builder::returning_clause::ReturningClause<Expr>` implements `QueryFragment<DB, sqlite::backend::SqliteReturningClause>`
+     | |____________________________^ `ReturningClause<Expr>` implements `QueryFragment<DB, sqlite::backend::SqliteReturningClause>`
      = note: required for `ReturningClause<(id, name)>` to implement `QueryFragment<Sqlite>`
      = note: 1 redundant requirement hidden
      = note: required for `InsertStatement<table, ..., ..., ...>` to implement `QueryFragment<Sqlite>`
@@ -60,13 +60,13 @@ error[E0277]: `ReturningClause<name>` is no valid SQL fragment for the `Sqlite` 
      = note: this usually means that the `Sqlite` database system does not support 
              this SQL syntax
 help: the following other types implement trait `QueryFragment<DB, SP>`
-    --> DIESEL/diesel/diesel/src/query_builder/returning_clause.rs
+    --> DIESEL/diesel/diesel/src/query_builder/returning/returning_clause.rs
      |
   LL | / impl<Expr, DB> QueryFragment<DB> for ReturningClause<Expr>
   LL | | where
   LL | |     DB: Backend,
   LL | |     Self: QueryFragment<DB, DB::ReturningClause>,
-     | |_________________________________________________^ `diesel::query_builder::returning_clause::ReturningClause<Expr>` implements `QueryFragment<DB>`
+     | |_________________________________________________^ `ReturningClause<Expr>` implements `QueryFragment<DB>`
 ...
   LL | / impl<Expr, DB>
   LL | |     QueryFragment<DB, crate::backend::sql_dialect::returning_clause::PgLikeReturningClause>
@@ -75,7 +75,7 @@ help: the following other types implement trait `QueryFragment<DB, SP>`
 ...    |
   LL | |     >,
   LL | |     Expr: QueryFragment<DB>,
-     | |____________________________^ `diesel::query_builder::returning_clause::ReturningClause<Expr>` implements `QueryFragment<DB, PgLikeReturningClause>`
+     | |____________________________^ `ReturningClause<Expr>` implements `QueryFragment<DB, PgLikeReturningClause>`
      |
     ::: DIESEL/diesel/diesel/src/sqlite/query_builder/returning.rs
      |
@@ -83,7 +83,7 @@ help: the following other types implement trait `QueryFragment<DB, SP>`
    LL | | where
    LL | |     DB: Backend<ReturningClause = SqliteReturningClause>,
   LL | |     Expr: QueryFragment<DB>,
-     | |____________________________^ `diesel::query_builder::returning_clause::ReturningClause<Expr>` implements `QueryFragment<DB, sqlite::backend::SqliteReturningClause>`
+     | |____________________________^ `ReturningClause<Expr>` implements `QueryFragment<DB, sqlite::backend::SqliteReturningClause>`
      = note: required for `ReturningClause<name>` to implement `QueryFragment<Sqlite>`
      = note: 1 redundant requirement hidden
      = note: required for `InsertStatement<table, ..., ..., ...>` to implement `QueryFragment<Sqlite>`

--- a/diesel_compile_tests/tests/fail/old_in_insert_on_conflict_do_update_requires_nullable.rs
+++ b/diesel_compile_tests/tests/fail/old_in_insert_on_conflict_do_update_requires_nullable.rs
@@ -1,0 +1,63 @@
+extern crate diesel;
+
+use diesel::pg::returning::old;
+use diesel::prelude::*;
+use diesel::*;
+
+table! {
+    users {
+        id -> Integer,
+        name -> VarChar,
+    }
+}
+
+// Mirrors the supported `Selectable` shape, but without wrapping `old(name)`
+// in `.nullable()`. In an `INSERT ... ON CONFLICT ... DO UPDATE`, freshly
+// inserted rows have no `old` row, so `old.col` would be `NULL` for them;
+// loading into a non-nullable `String` would therefore be unsound. Diesel
+// rejects this at compile time.
+#[derive(Queryable, Selectable)]
+#[diesel(table_name = users)]
+struct UpsertOldNew {
+    #[diesel(select_expression = old(users::name))]
+    was: String,
+    name: String,
+}
+
+fn main() {
+    let mut connection = PgConnection::establish("…").unwrap();
+
+    insert_into(users::table)
+        .values(users::name.eq(""))
+        .on_conflict(users::id)
+        .do_update()
+        .set(users::name.eq(""))
+        .returning(UpsertOldNew::as_select())
+        //~^ ERROR: cannot select `returning::old_impl::Old<columns::name>` from `ReturningQuerySource<..., ...>`
+        .get_result::<UpsertOldNew>(&mut connection)
+        //~^ ERROR: cannot select `returning::old_impl::Old<columns::name>` from `ReturningQuerySource<..., ...>`
+        .unwrap();
+
+    // The plain tuple version mirrors the same constraint: writing
+    // `old(name)` without `.nullable()` is rejected.
+    insert_into(users::table)
+        .values(users::name.eq(""))
+        .on_conflict(users::id)
+        .do_update()
+        .set(users::name.eq(""))
+        .returning(old(users::name))
+        //~^ ERROR: cannot select `returning::old_impl::Old<columns::name>` from `ReturningQuerySource<..., ...>`
+        .get_result::<String>(&mut connection)
+        //~^ ERROR: cannot select `returning::old_impl::Old<columns::name>` from `ReturningQuerySource<..., ...>`
+        .unwrap();
+
+    // With Nullable, this compiles
+    insert_into(users::table)
+        .values(users::name.eq(""))
+        .on_conflict(users::id)
+        .do_update()
+        .set(users::name.eq(""))
+        .returning(old(users::name).nullable())
+        .get_result::<Option<String>>(&mut connection)
+        .unwrap();
+}

--- a/diesel_compile_tests/tests/fail/old_in_insert_on_conflict_do_update_requires_nullable.stderr
+++ b/diesel_compile_tests/tests/fail/old_in_insert_on_conflict_do_update_requires_nullable.stderr
@@ -1,0 +1,128 @@
+error[E0277]: cannot select `returning::old_impl::Old<columns::name>` from `ReturningQuerySource<..., ...>`
+   --> tests/fail/old_in_insert_on_conflict_do_update_requires_nullable.rs:35:20
+    |
+ LL |         .returning(UpsertOldNew::as_select())
+    |          --------- ^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+    |          |
+    |          required by a bound introduced by this call
+    |
+    = note: `returning::old_impl::Old<columns::name>` is no valid selection for `ReturningQuerySource<..., ...>`
+help: the trait `SelectableExpression<diesel::query_builder::returning::returning_query_source::ReturningQuerySource<diesel::query_builder::returning::returning_query_source::InsertStmtWithOnConflictDoUpdate, _>>` is not implemented for `returning::old_impl::Old<columns::name>`
+      but trait `SelectableExpression<diesel::query_builder::returning::returning_query_source::ReturningQuerySource<diesel::query_builder::returning::returning_query_source::UpdateStmt, _>>` is implemented for it
+   --> DIESEL/diesel/diesel/src/pg/returning/old_impl.rs
+    |
+LL | / impl<C> SelectableExpression<ReturningQuerySource<UpdateStmt, C::Table>> for Old<C>
+LL | | where
+LL | |     C: Column,
+LL | |     Self: AppearsOnTable<ReturningQuerySource<UpdateStmt, C::Table>>,
+    | |_____________________________________________________________________^
+    = help: for that trait implementation, expected `UpdateStmt`, found `InsertStmtWithOnConflictDoUpdate`
+    = note: required for `(returning::old_impl::Old<columns::name>, columns::name)` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
+    = note: 1 redundant requirement hidden
+    = note: required for `diesel::expression::select_by::SelectBy<UpsertOldNew, _>` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
+    = note: required for `InsertStatement<table, ..., ..., ...>` to implement `Query`
+note: required by a bound in `InsertStatement::<T, U, Op>::returning`
+   --> DIESEL/diesel/diesel/src/query_builder/insert_statement/mod.rs
+    |
+LL |     pub fn returning<E>(self, returns: E) -> InsertStatement<T, U, Op, ReturningClause<E>>
+    |            --------- required by a bound in this associated function
+LL |     where
+LL |         InsertStatement<T, U, Op, ReturningClause<E>>: Query,
+    |                                                        ^^^^^ required by this bound in `InsertStatement::<T, U, Op>::returning`
+ 
+    
+error[E0277]: cannot select `returning::old_impl::Old<columns::name>` from `ReturningQuerySource<..., ...>`
+    --> tests/fail/old_in_insert_on_conflict_do_update_requires_nullable.rs:37:37
+     |
+  LL |         .get_result::<UpsertOldNew>(&mut connection)
+     |          ----------                 ^^^^^^^^^^^^^^^ unsatisfied trait bound
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = note: `returning::old_impl::Old<columns::name>` is no valid selection for `ReturningQuerySource<..., ...>`
+help: the trait `SelectableExpression<diesel::query_builder::returning::returning_query_source::ReturningQuerySource<diesel::query_builder::returning::returning_query_source::InsertStmtWithOnConflictDoUpdate, _>>` is not implemented for `returning::old_impl::Old<columns::name>`
+      but trait `SelectableExpression<diesel::query_builder::returning::returning_query_source::ReturningQuerySource<diesel::query_builder::returning::returning_query_source::UpdateStmt, _>>` is implemented for it
+    --> DIESEL/diesel/diesel/src/pg/returning/old_impl.rs
+     |
+ LL | / impl<C> SelectableExpression<ReturningQuerySource<UpdateStmt, C::Table>> for Old<C>
+ LL | | where
+ LL | |     C: Column,
+ LL | |     Self: AppearsOnTable<ReturningQuerySource<UpdateStmt, C::Table>>,
+     | |_____________________________________________________________________^
+     = help: for that trait implementation, expected `UpdateStmt`, found `InsertStmtWithOnConflictDoUpdate`
+     = note: required for `(returning::old_impl::Old<columns::name>, columns::name)` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
+     = note: 1 redundant requirement hidden
+     = note: required for `diesel::expression::select_by::SelectBy<UpsertOldNew, _>` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
+     = note: required for `InsertStatement<table, ..., ..., ...>` to implement `Query`
+     = note: required for `InsertStatement<table, ..., ..., ...>` to implement `LoadQuery<'_, _, UpsertOldNew>`
+note: required by a bound in `get_result`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
+     |        ---------- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
+  
+     
+error[E0277]: cannot select `returning::old_impl::Old<columns::name>` from `ReturningQuerySource<..., ...>`
+   --> tests/fail/old_in_insert_on_conflict_do_update_requires_nullable.rs:48:20
+    |
+ LL |         .returning(old(users::name))
+    |          --------- ^^^^^^^^^^^^^^^^ unsatisfied trait bound
+    |          |
+    |          required by a bound introduced by this call
+    |
+    = note: `returning::old_impl::Old<columns::name>` is no valid selection for `ReturningQuerySource<..., ...>`
+help: the trait `SelectableExpression<diesel::query_builder::returning::returning_query_source::ReturningQuerySource<diesel::query_builder::returning::returning_query_source::InsertStmtWithOnConflictDoUpdate, _>>` is not implemented for `returning::old_impl::Old<columns::name>`
+      but trait `SelectableExpression<diesel::query_builder::returning::returning_query_source::ReturningQuerySource<diesel::query_builder::returning::returning_query_source::UpdateStmt, _>>` is implemented for it
+   --> DIESEL/diesel/diesel/src/pg/returning/old_impl.rs
+    |
+LL | / impl<C> SelectableExpression<ReturningQuerySource<UpdateStmt, C::Table>> for Old<C>
+LL | | where
+LL | |     C: Column,
+LL | |     Self: AppearsOnTable<ReturningQuerySource<UpdateStmt, C::Table>>,
+    | |_____________________________________________________________________^
+    = help: for that trait implementation, expected `UpdateStmt`, found `InsertStmtWithOnConflictDoUpdate`
+    = note: required for `InsertStatement<table, ..., ..., ...>` to implement `Query`
+note: required by a bound in `InsertStatement::<T, U, Op>::returning`
+   --> DIESEL/diesel/diesel/src/query_builder/insert_statement/mod.rs
+    |
+LL |     pub fn returning<E>(self, returns: E) -> InsertStatement<T, U, Op, ReturningClause<E>>
+    |            --------- required by a bound in this associated function
+LL |     where
+LL |         InsertStatement<T, U, Op, ReturningClause<E>>: Query,
+    |                                                        ^^^^^ required by this bound in `InsertStatement::<T, U, Op>::returning`
+ 
+    
+error[E0277]: cannot select `returning::old_impl::Old<columns::name>` from `ReturningQuerySource<..., ...>`
+    --> tests/fail/old_in_insert_on_conflict_do_update_requires_nullable.rs:50:31
+     |
+  LL |         .get_result::<String>(&mut connection)
+     |          ----------           ^^^^^^^^^^^^^^^ unsatisfied trait bound
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = note: `returning::old_impl::Old<columns::name>` is no valid selection for `ReturningQuerySource<..., ...>`
+help: the trait `SelectableExpression<diesel::query_builder::returning::returning_query_source::ReturningQuerySource<diesel::query_builder::returning::returning_query_source::InsertStmtWithOnConflictDoUpdate, _>>` is not implemented for `returning::old_impl::Old<columns::name>`
+      but trait `SelectableExpression<diesel::query_builder::returning::returning_query_source::ReturningQuerySource<diesel::query_builder::returning::returning_query_source::UpdateStmt, _>>` is implemented for it
+    --> DIESEL/diesel/diesel/src/pg/returning/old_impl.rs
+     |
+ LL | / impl<C> SelectableExpression<ReturningQuerySource<UpdateStmt, C::Table>> for Old<C>
+ LL | | where
+ LL | |     C: Column,
+ LL | |     Self: AppearsOnTable<ReturningQuerySource<UpdateStmt, C::Table>>,
+     | |_____________________________________________________________________^
+     = help: for that trait implementation, expected `UpdateStmt`, found `InsertStmtWithOnConflictDoUpdate`
+     = note: required for `InsertStatement<table, ..., ..., ...>` to implement `Query`
+     = note: required for `InsertStatement<table, ..., ..., ...>` to implement `LoadQuery<'_, _, std::string::String>`
+note: required by a bound in `get_result`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
+     |        ---------- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
+  
+     For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/old_returning_requires_pg_like_backend.rs
+++ b/diesel_compile_tests/tests/fail/old_returning_requires_pg_like_backend.rs
@@ -1,0 +1,23 @@
+extern crate diesel;
+
+use diesel::pg::returning::old;
+use diesel::*;
+
+table! {
+    users {
+        id -> Integer,
+        name -> VarChar,
+    }
+}
+
+fn main() {
+    use self::users::dsl::*;
+
+    let mut connection = SqliteConnection::establish(":memory:").unwrap();
+
+    update(users.filter(id.eq(1)))
+        .set(name.eq("Dean"))
+        .returning(old(name))
+        .get_result::<String>(&mut connection);
+    //~^ ERROR: `ReturningClause<Old<name>>` is no valid SQL fragment for the `Sqlite` backend
+}

--- a/diesel_compile_tests/tests/fail/old_returning_requires_pg_like_backend.stderr
+++ b/diesel_compile_tests/tests/fail/old_returning_requires_pg_like_backend.stderr
@@ -1,0 +1,50 @@
+error[E0277]: `ReturningClause<Old<name>>` is no valid SQL fragment for the `Sqlite` backend
+    --> tests/fail/old_returning_requires_pg_like_backend.rs:21:31
+     |
+  LL |         .get_result::<String>(&mut connection);
+     |          ----------           ^^^^^^^^^^^^^^^ unsatisfied trait bound
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = help: the trait `QueryFragment<Sqlite, backend::sql_dialect::returning_clause::DoesNotSupportReturningClause>` is not implemented for `ReturningClause<Old<name>>`
+     = note: this usually means that the `Sqlite` database system does not support 
+             this SQL syntax
+help: the following other types implement trait `QueryFragment<DB, SP>`
+    --> DIESEL/diesel/diesel/src/query_builder/returning/returning_clause.rs
+     |
+  LL | / impl<Expr, DB> QueryFragment<DB> for ReturningClause<Expr>
+  LL | | where
+  LL | |     DB: Backend,
+  LL | |     Self: QueryFragment<DB, DB::ReturningClause>,
+     | |_________________________________________________^ `ReturningClause<Expr>` implements `QueryFragment<DB>`
+...
+  LL | / impl<Expr, DB>
+  LL | |     QueryFragment<DB, crate::backend::sql_dialect::returning_clause::PgLikeReturningClause>
+  LL | |     for ReturningClause<Expr>
+  LL | | where
+...    |
+  LL | |     >,
+  LL | |     Expr: QueryFragment<DB>,
+     | |____________________________^ `ReturningClause<Expr>` implements `QueryFragment<DB, PgLikeReturningClause>`
+     |
+    ::: DIESEL/diesel/diesel/src/sqlite/query_builder/returning.rs
+     |
+   LL | / impl<Expr, DB> QueryFragment<DB, SqliteReturningClause> for ReturningClause<Expr>
+   LL | | where
+   LL | |     DB: Backend<ReturningClause = SqliteReturningClause>,
+  LL | |     Expr: QueryFragment<DB>,
+     | |____________________________^ `ReturningClause<Expr>` implements `QueryFragment<DB, sqlite::backend::SqliteReturningClause>`
+     = note: required for `ReturningClause<Old<name>>` to implement `QueryFragment<Sqlite>`
+     = note: 1 redundant requirement hidden
+     = note: required for `UpdateStatement<table, WhereClause<...>, ..., ...>` to implement `QueryFragment<Sqlite>`
+     = note: required for `UpdateStatement<table, WhereClause<...>, ..., ...>` to implement `LoadQuery<'_, diesel::SqliteConnection, std::string::String>`
+note: required by a bound in `get_result`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
+     |        ---------- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
+  
+     For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/returning_clause_requires_selectable_expression.rs
+++ b/diesel_compile_tests/tests/fail/returning_clause_requires_selectable_expression.rs
@@ -25,15 +25,15 @@ fn main() {
 
     delete(users::table.filter(users::columns::name.eq("Bill")))
         .returning(non_users::columns::noname);
-    //~^ ERROR: cannot select `non_users::columns::noname` from `users::table`
+    //~^ ERROR: cannot select `non_users::columns::noname` from `ReturningQuerySource<DeleteStmt, table>`
 
     insert_into(users::table)
         .values(&NewUser("Hello".into()))
         .returning(non_users::columns::noname);
-    //~^ ERROR: cannot select `non_users::columns::noname` from `users::table`
+    //~^ ERROR: cannot select `non_users::columns::noname` from `ReturningQuerySource<..., ...>`
 
     update(users::table)
         .set(users::columns::name.eq("Bill"))
         .returning(non_users::columns::noname);
-    //~^ ERROR: cannot select `non_users::columns::noname` from `users::table`
+    //~^ ERROR: cannot select `non_users::columns::noname` from `ReturningQuerySource<UpdateStmt, table>`
 }

--- a/diesel_compile_tests/tests/fail/returning_clause_requires_selectable_expression.stderr
+++ b/diesel_compile_tests/tests/fail/returning_clause_requires_selectable_expression.stderr
@@ -1,4 +1,4 @@
-error[E0277]: cannot select `non_users::columns::noname` from `users::table`
+error[E0277]: cannot select `non_users::columns::noname` from `ReturningQuerySource<DeleteStmt, table>`
    --> tests/fail/returning_clause_requires_selectable_expression.rs:27:20
     |
  LL |         .returning(non_users::columns::noname);
@@ -6,32 +6,34 @@ error[E0277]: cannot select `non_users::columns::noname` from `users::table`
     |          |
     |          required by a bound introduced by this call
     |
-help: the trait `SelectableExpression<users::table>` is not implemented for `non_users::columns::noname`
+help: the trait `SelectableExpression<diesel::query_builder::returning::returning_query_source::ReturningQuerySource<diesel::query_builder::returning::returning_query_source::DeleteStmt, users::table>>` is not implemented for `non_users::columns::noname`
    --> tests/fail/returning_clause_requires_selectable_expression.rs:19:9
     |
  LL |         noname -> VarChar,
     |         ^^^^^^
-    = note: `non_users::columns::noname` is no valid selection for `users::table`
+    = note: `non_users::columns::noname` is no valid selection for `ReturningQuerySource<DeleteStmt, table>`
     = help: the following other types implement trait `SelectableExpression<QS>`:
               `non_users::columns::noname` implements `SelectableExpression<Only<non_users::table>>`
               `non_users::columns::noname` implements `SelectableExpression<Tablesample<non_users::table, TSM>>`
+              `non_users::columns::noname` implements `SelectableExpression<ReturningQuerySource<..., ...>>`
               `non_users::columns::noname` implements `SelectableExpression<SelectStatement<...>>`
               `non_users::columns::noname` implements `SelectableExpression<non_users::table>`
               `non_users::columns::noname` implements `SelectableExpression<Join<Left, Right, Inner>>`
               `non_users::columns::noname` implements `SelectableExpression<Join<Left, Right, LeftOuter>>`
               `non_users::columns::noname` implements `SelectableExpression<query_source::joins::JoinOn<Join, On>>`
+    = note: required for `DeleteStatement<table, WhereClause<...>, ...>` to implement `Query`
 note: required by a bound in `DeleteStatement::<T, U>::returning`
    --> DIESEL/diesel/diesel/src/query_builder/delete_statement/mod.rs
     |
 LL |     pub fn returning<E>(self, returns: E) -> DeleteStatement<T, U, ReturningClause<E>>
     |            --------- required by a bound in this associated function
 LL |     where
-LL |         E: SelectableExpression<T>,
-    |            ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `DeleteStatement::<T, U>::returning`
+LL |         DeleteStatement<T, U, ReturningClause<E>>: Query,
+    |                                                    ^^^^^ required by this bound in `DeleteStatement::<T, U>::returning`
  
         = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: cannot select `non_users::columns::noname` from `users::table`
+error[E0277]: cannot select `non_users::columns::noname` from `ReturningQuerySource<..., ...>`
    --> tests/fail/returning_clause_requires_selectable_expression.rs:32:20
     |
  LL |         .returning(non_users::columns::noname);
@@ -39,15 +41,16 @@ error[E0277]: cannot select `non_users::columns::noname` from `users::table`
     |          |
     |          required by a bound introduced by this call
     |
-help: the trait `SelectableExpression<users::table>` is not implemented for `non_users::columns::noname`
+help: the trait `SelectableExpression<diesel::query_builder::returning::returning_query_source::ReturningQuerySource<diesel::query_builder::returning::returning_query_source::InsertStmtWithoutOnConflictDoUpdate, users::table>>` is not implemented for `non_users::columns::noname`
    --> tests/fail/returning_clause_requires_selectable_expression.rs:19:9
     |
  LL |         noname -> VarChar,
     |         ^^^^^^
-    = note: `non_users::columns::noname` is no valid selection for `users::table`
+    = note: `non_users::columns::noname` is no valid selection for `ReturningQuerySource<..., ...>`
     = help: the following other types implement trait `SelectableExpression<QS>`:
               `non_users::columns::noname` implements `SelectableExpression<Only<non_users::table>>`
               `non_users::columns::noname` implements `SelectableExpression<Tablesample<non_users::table, TSM>>`
+              `non_users::columns::noname` implements `SelectableExpression<ReturningQuerySource<..., ...>>`
               `non_users::columns::noname` implements `SelectableExpression<SelectStatement<...>>`
               `non_users::columns::noname` implements `SelectableExpression<non_users::table>`
               `non_users::columns::noname` implements `SelectableExpression<Join<Left, Right, Inner>>`
@@ -65,7 +68,7 @@ LL |         InsertStatement<T, U, Op, ReturningClause<E>>: Query,
  
         = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: cannot select `non_users::columns::noname` from `users::table`
+error[E0277]: cannot select `non_users::columns::noname` from `ReturningQuerySource<UpdateStmt, table>`
    --> tests/fail/returning_clause_requires_selectable_expression.rs:37:20
     |
  LL |         .returning(non_users::columns::noname);
@@ -73,15 +76,16 @@ error[E0277]: cannot select `non_users::columns::noname` from `users::table`
     |          |
     |          required by a bound introduced by this call
     |
-help: the trait `SelectableExpression<users::table>` is not implemented for `non_users::columns::noname`
+help: the trait `SelectableExpression<diesel::query_builder::returning::returning_query_source::ReturningQuerySource<diesel::query_builder::returning::returning_query_source::UpdateStmt, users::table>>` is not implemented for `non_users::columns::noname`
    --> tests/fail/returning_clause_requires_selectable_expression.rs:19:9
     |
  LL |         noname -> VarChar,
     |         ^^^^^^
-    = note: `non_users::columns::noname` is no valid selection for `users::table`
+    = note: `non_users::columns::noname` is no valid selection for `ReturningQuerySource<UpdateStmt, table>`
     = help: the following other types implement trait `SelectableExpression<QS>`:
               `non_users::columns::noname` implements `SelectableExpression<Only<non_users::table>>`
               `non_users::columns::noname` implements `SelectableExpression<Tablesample<non_users::table, TSM>>`
+              `non_users::columns::noname` implements `SelectableExpression<ReturningQuerySource<..., ...>>`
               `non_users::columns::noname` implements `SelectableExpression<SelectStatement<...>>`
               `non_users::columns::noname` implements `SelectableExpression<non_users::table>`
               `non_users::columns::noname` implements `SelectableExpression<Join<Left, Right, Inner>>`

--- a/diesel_compile_tests/tests/fail/returning_old_rejected_for_insert_delete_and_do_nothing.rs
+++ b/diesel_compile_tests/tests/fail/returning_old_rejected_for_insert_delete_and_do_nothing.rs
@@ -1,0 +1,52 @@
+extern crate diesel;
+
+use diesel::pg::returning::old;
+use diesel::prelude::*;
+use diesel::*;
+
+table! {
+    users {
+        id -> Integer,
+        name -> VarChar,
+    }
+}
+
+#[derive(Insertable)]
+#[diesel(table_name = users)]
+pub struct NewUser(#[diesel(column_name = name)] String);
+
+fn main() {
+    use self::users::dsl::*;
+
+    let mut connection = PgConnection::establish("").unwrap();
+
+    // Plain INSERT: `old(col)` is meaningless because no pre-existing row exists.
+    insert_into(users)
+        .values(&NewUser("Hello".into()))
+        .returning(old(name))
+        //~^ ERROR: cannot select `returning::old_impl::Old<columns::name>` from `ReturningQuerySource<..., ...>`
+        .get_result::<String>(&mut connection)
+        //~^ ERROR: cannot select `returning::old_impl::Old<columns::name>` from `ReturningQuerySource<..., ...>`
+        .unwrap();
+
+    // DELETE: `old(col)` is pointless because all columns already refer to the
+    // row being deleted — `RETURNING col` suffices.
+    delete(users.filter(id.eq(1)))
+        .returning(old(name))
+        //~^ ERROR: cannot select `returning::old_impl::Old<columns::name>` from `ReturningQuerySource<DeleteStmt, table>`
+        .get_result::<String>(&mut connection)
+        //~^ ERROR: cannot select `returning::old_impl::Old<columns::name>` from `ReturningQuerySource<DeleteStmt, table>`
+        .unwrap();
+
+    // INSERT ... ON CONFLICT DO NOTHING: conflicting rows are never returned,
+    // so `old(col)` would always be NULL and is misleading.
+    insert_into(users)
+        .values(&NewUser("Hello".into()))
+        .on_conflict(id)
+        .do_nothing()
+        .returning(old(name))
+        //~^ ERROR: cannot select `returning::old_impl::Old<columns::name>` from `ReturningQuerySource<..., ...>`
+        .get_result::<String>(&mut connection)
+        //~^ ERROR: cannot select `returning::old_impl::Old<columns::name>` from `ReturningQuerySource<..., ...>`
+        .unwrap();
+}

--- a/diesel_compile_tests/tests/fail/returning_old_rejected_for_insert_delete_and_do_nothing.stderr
+++ b/diesel_compile_tests/tests/fail/returning_old_rejected_for_insert_delete_and_do_nothing.stderr
@@ -1,0 +1,183 @@
+error[E0277]: cannot select `returning::old_impl::Old<columns::name>` from `ReturningQuerySource<..., ...>`
+   --> tests/fail/returning_old_rejected_for_insert_delete_and_do_nothing.rs:26:20
+    |
+ LL |         .returning(old(name))
+    |          --------- ^^^^^^^^^ unsatisfied trait bound
+    |          |
+    |          required by a bound introduced by this call
+    |
+    = note: `returning::old_impl::Old<columns::name>` is no valid selection for `ReturningQuerySource<..., ...>`
+help: the trait `SelectableExpression<diesel::query_builder::returning::returning_query_source::ReturningQuerySource<diesel::query_builder::returning::returning_query_source::InsertStmtWithoutOnConflictDoUpdate, _>>` is not implemented for `returning::old_impl::Old<columns::name>`
+      but trait `SelectableExpression<diesel::query_builder::returning::returning_query_source::ReturningQuerySource<diesel::query_builder::returning::returning_query_source::UpdateStmt, _>>` is implemented for it
+   --> DIESEL/diesel/diesel/src/pg/returning/old_impl.rs
+    |
+LL | / impl<C> SelectableExpression<ReturningQuerySource<UpdateStmt, C::Table>> for Old<C>
+LL | | where
+LL | |     C: Column,
+LL | |     Self: AppearsOnTable<ReturningQuerySource<UpdateStmt, C::Table>>,
+    | |_____________________________________________________________________^
+    = help: for that trait implementation, expected `UpdateStmt`, found `InsertStmtWithoutOnConflictDoUpdate`
+    = note: required for `InsertStatement<table, ..., ..., ...>` to implement `Query`
+note: required by a bound in `InsertStatement::<T, U, Op>::returning`
+   --> DIESEL/diesel/diesel/src/query_builder/insert_statement/mod.rs
+    |
+LL |     pub fn returning<E>(self, returns: E) -> InsertStatement<T, U, Op, ReturningClause<E>>
+    |            --------- required by a bound in this associated function
+LL |     where
+LL |         InsertStatement<T, U, Op, ReturningClause<E>>: Query,
+    |                                                        ^^^^^ required by this bound in `InsertStatement::<T, U, Op>::returning`
+ 
+    
+error[E0277]: cannot select `returning::old_impl::Old<columns::name>` from `ReturningQuerySource<..., ...>`
+    --> tests/fail/returning_old_rejected_for_insert_delete_and_do_nothing.rs:28:31
+     |
+  LL |         .get_result::<String>(&mut connection)
+     |          ----------           ^^^^^^^^^^^^^^^ unsatisfied trait bound
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = note: `returning::old_impl::Old<columns::name>` is no valid selection for `ReturningQuerySource<..., ...>`
+help: the trait `SelectableExpression<diesel::query_builder::returning::returning_query_source::ReturningQuerySource<diesel::query_builder::returning::returning_query_source::InsertStmtWithoutOnConflictDoUpdate, _>>` is not implemented for `returning::old_impl::Old<columns::name>`
+      but trait `SelectableExpression<diesel::query_builder::returning::returning_query_source::ReturningQuerySource<diesel::query_builder::returning::returning_query_source::UpdateStmt, _>>` is implemented for it
+    --> DIESEL/diesel/diesel/src/pg/returning/old_impl.rs
+     |
+ LL | / impl<C> SelectableExpression<ReturningQuerySource<UpdateStmt, C::Table>> for Old<C>
+ LL | | where
+ LL | |     C: Column,
+ LL | |     Self: AppearsOnTable<ReturningQuerySource<UpdateStmt, C::Table>>,
+     | |_____________________________________________________________________^
+     = help: for that trait implementation, expected `UpdateStmt`, found `InsertStmtWithoutOnConflictDoUpdate`
+     = note: required for `InsertStatement<table, ..., ..., ...>` to implement `Query`
+     = note: required for `InsertStatement<table, ..., ..., ...>` to implement `LoadQuery<'_, _, std::string::String>`
+note: required by a bound in `get_result`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
+     |        ---------- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
+  
+     
+error[E0277]: cannot select `returning::old_impl::Old<columns::name>` from `ReturningQuerySource<DeleteStmt, table>`
+   --> tests/fail/returning_old_rejected_for_insert_delete_and_do_nothing.rs:35:20
+    |
+ LL |         .returning(old(name))
+    |          --------- ^^^^^^^^^ unsatisfied trait bound
+    |          |
+    |          required by a bound introduced by this call
+    |
+    = note: `returning::old_impl::Old<columns::name>` is no valid selection for `ReturningQuerySource<DeleteStmt, table>`
+help: the trait `SelectableExpression<diesel::query_builder::returning::returning_query_source::ReturningQuerySource<diesel::query_builder::returning::returning_query_source::DeleteStmt, _>>` is not implemented for `returning::old_impl::Old<columns::name>`
+      but trait `SelectableExpression<diesel::query_builder::returning::returning_query_source::ReturningQuerySource<diesel::query_builder::returning::returning_query_source::UpdateStmt, _>>` is implemented for it
+   --> DIESEL/diesel/diesel/src/pg/returning/old_impl.rs
+    |
+LL | / impl<C> SelectableExpression<ReturningQuerySource<UpdateStmt, C::Table>> for Old<C>
+LL | | where
+LL | |     C: Column,
+LL | |     Self: AppearsOnTable<ReturningQuerySource<UpdateStmt, C::Table>>,
+    | |_____________________________________________________________________^
+    = help: for that trait implementation, expected `UpdateStmt`, found `DeleteStmt`
+    = note: required for `DeleteStatement<table, WhereClause<...>, ...>` to implement `Query`
+note: required by a bound in `DeleteStatement::<T, U>::returning`
+   --> DIESEL/diesel/diesel/src/query_builder/delete_statement/mod.rs
+    |
+LL |     pub fn returning<E>(self, returns: E) -> DeleteStatement<T, U, ReturningClause<E>>
+    |            --------- required by a bound in this associated function
+LL |     where
+LL |         DeleteStatement<T, U, ReturningClause<E>>: Query,
+    |                                                    ^^^^^ required by this bound in `DeleteStatement::<T, U>::returning`
+ 
+    
+error[E0277]: cannot select `returning::old_impl::Old<columns::name>` from `ReturningQuerySource<DeleteStmt, table>`
+    --> tests/fail/returning_old_rejected_for_insert_delete_and_do_nothing.rs:37:31
+     |
+  LL |         .get_result::<String>(&mut connection)
+     |          ----------           ^^^^^^^^^^^^^^^ unsatisfied trait bound
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = note: `returning::old_impl::Old<columns::name>` is no valid selection for `ReturningQuerySource<DeleteStmt, table>`
+help: the trait `SelectableExpression<diesel::query_builder::returning::returning_query_source::ReturningQuerySource<diesel::query_builder::returning::returning_query_source::DeleteStmt, _>>` is not implemented for `returning::old_impl::Old<columns::name>`
+      but trait `SelectableExpression<diesel::query_builder::returning::returning_query_source::ReturningQuerySource<diesel::query_builder::returning::returning_query_source::UpdateStmt, _>>` is implemented for it
+    --> DIESEL/diesel/diesel/src/pg/returning/old_impl.rs
+     |
+ LL | / impl<C> SelectableExpression<ReturningQuerySource<UpdateStmt, C::Table>> for Old<C>
+ LL | | where
+ LL | |     C: Column,
+ LL | |     Self: AppearsOnTable<ReturningQuerySource<UpdateStmt, C::Table>>,
+     | |_____________________________________________________________________^
+     = help: for that trait implementation, expected `UpdateStmt`, found `DeleteStmt`
+     = note: required for `DeleteStatement<table, WhereClause<...>, ...>` to implement `Query`
+     = note: required for `DeleteStatement<table, WhereClause<...>, ...>` to implement `LoadQuery<'_, _, std::string::String>`
+note: required by a bound in `get_result`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
+     |        ---------- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
+  
+     
+error[E0277]: cannot select `returning::old_impl::Old<columns::name>` from `ReturningQuerySource<..., ...>`
+   --> tests/fail/returning_old_rejected_for_insert_delete_and_do_nothing.rs:47:20
+    |
+ LL |         .returning(old(name))
+    |          --------- ^^^^^^^^^ unsatisfied trait bound
+    |          |
+    |          required by a bound introduced by this call
+    |
+    = note: `returning::old_impl::Old<columns::name>` is no valid selection for `ReturningQuerySource<..., ...>`
+help: the trait `SelectableExpression<diesel::query_builder::returning::returning_query_source::ReturningQuerySource<diesel::query_builder::returning::returning_query_source::InsertStmtWithoutOnConflictDoUpdate, _>>` is not implemented for `returning::old_impl::Old<columns::name>`
+      but trait `SelectableExpression<diesel::query_builder::returning::returning_query_source::ReturningQuerySource<diesel::query_builder::returning::returning_query_source::UpdateStmt, _>>` is implemented for it
+   --> DIESEL/diesel/diesel/src/pg/returning/old_impl.rs
+    |
+LL | / impl<C> SelectableExpression<ReturningQuerySource<UpdateStmt, C::Table>> for Old<C>
+LL | | where
+LL | |     C: Column,
+LL | |     Self: AppearsOnTable<ReturningQuerySource<UpdateStmt, C::Table>>,
+    | |_____________________________________________________________________^
+    = help: for that trait implementation, expected `UpdateStmt`, found `InsertStmtWithoutOnConflictDoUpdate`
+    = note: required for `InsertStatement<table, ..., ..., ...>` to implement `Query`
+note: required by a bound in `InsertStatement::<T, U, Op>::returning`
+   --> DIESEL/diesel/diesel/src/query_builder/insert_statement/mod.rs
+    |
+LL |     pub fn returning<E>(self, returns: E) -> InsertStatement<T, U, Op, ReturningClause<E>>
+    |            --------- required by a bound in this associated function
+LL |     where
+LL |         InsertStatement<T, U, Op, ReturningClause<E>>: Query,
+    |                                                        ^^^^^ required by this bound in `InsertStatement::<T, U, Op>::returning`
+ 
+    
+error[E0277]: cannot select `returning::old_impl::Old<columns::name>` from `ReturningQuerySource<..., ...>`
+    --> tests/fail/returning_old_rejected_for_insert_delete_and_do_nothing.rs:49:31
+     |
+  LL |         .get_result::<String>(&mut connection)
+     |          ----------           ^^^^^^^^^^^^^^^ unsatisfied trait bound
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = note: `returning::old_impl::Old<columns::name>` is no valid selection for `ReturningQuerySource<..., ...>`
+help: the trait `SelectableExpression<diesel::query_builder::returning::returning_query_source::ReturningQuerySource<diesel::query_builder::returning::returning_query_source::InsertStmtWithoutOnConflictDoUpdate, _>>` is not implemented for `returning::old_impl::Old<columns::name>`
+      but trait `SelectableExpression<diesel::query_builder::returning::returning_query_source::ReturningQuerySource<diesel::query_builder::returning::returning_query_source::UpdateStmt, _>>` is implemented for it
+    --> DIESEL/diesel/diesel/src/pg/returning/old_impl.rs
+     |
+ LL | / impl<C> SelectableExpression<ReturningQuerySource<UpdateStmt, C::Table>> for Old<C>
+ LL | | where
+ LL | |     C: Column,
+ LL | |     Self: AppearsOnTable<ReturningQuerySource<UpdateStmt, C::Table>>,
+     | |_____________________________________________________________________^
+     = help: for that trait implementation, expected `UpdateStmt`, found `InsertStmtWithoutOnConflictDoUpdate`
+     = note: required for `InsertStatement<table, ..., ..., ...>` to implement `Query`
+     = note: required for `InsertStatement<table, ..., ..., ...>` to implement `LoadQuery<'_, _, std::string::String>`
+note: required by a bound in `get_result`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
+     |        ---------- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
+  
+     For more information about this error, try `rustc --explain E0277`.

--- a/diesel_compile_tests/tests/fail/right_side_of_left_join_requires_nullable.stderr
+++ b/diesel_compile_tests/tests/fail/right_side_of_left_join_requires_nullable.stderr
@@ -45,6 +45,7 @@ LL |         title -> Text,
    = help: the following other types implement trait `SelectableExpression<QS>`:
              `posts::columns::title` implements `SelectableExpression<Only<posts::table>>`
              `posts::columns::title` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
+             `posts::columns::title` implements `SelectableExpression<ReturningQuerySource<..., ...>>`
              `posts::columns::title` implements `SelectableExpression<SelectStatement<...>>`
              `posts::columns::title` implements `SelectableExpression<posts::table>`
              `posts::columns::title` implements `SelectableExpression<Join<Left, Right, Inner>>`
@@ -108,6 +109,7 @@ LL |         title -> Text,
    = help: the following other types implement trait `SelectableExpression<QS>`:
              `posts::columns::title` implements `SelectableExpression<Only<posts::table>>`
              `posts::columns::title` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
+             `posts::columns::title` implements `SelectableExpression<ReturningQuerySource<..., ...>>`
              `posts::columns::title` implements `SelectableExpression<SelectStatement<...>>`
              `posts::columns::title` implements `SelectableExpression<posts::table>`
              `posts::columns::title` implements `SelectableExpression<Join<Left, Right, Inner>>`
@@ -230,6 +232,7 @@ LL |         title -> Text,
    = help: the following other types implement trait `SelectableExpression<QS>`:
              `posts::columns::title` implements `SelectableExpression<Only<posts::table>>`
              `posts::columns::title` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
+             `posts::columns::title` implements `SelectableExpression<ReturningQuerySource<..., ...>>`
              `posts::columns::title` implements `SelectableExpression<SelectStatement<...>>`
              `posts::columns::title` implements `SelectableExpression<posts::table>`
              `posts::columns::title` implements `SelectableExpression<Join<Left, Right, Inner>>`
@@ -293,6 +296,7 @@ LL |         title -> Text,
    = help: the following other types implement trait `SelectableExpression<QS>`:
              `posts::columns::title` implements `SelectableExpression<Only<posts::table>>`
              `posts::columns::title` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
+             `posts::columns::title` implements `SelectableExpression<ReturningQuerySource<..., ...>>`
              `posts::columns::title` implements `SelectableExpression<SelectStatement<...>>`
              `posts::columns::title` implements `SelectableExpression<posts::table>`
              `posts::columns::title` implements `SelectableExpression<Join<Left, Right, Inner>>`
@@ -415,6 +419,7 @@ LL |         title -> Text,
    = help: the following other types implement trait `SelectableExpression<QS>`:
              `posts::columns::title` implements `SelectableExpression<Only<posts::table>>`
              `posts::columns::title` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
+             `posts::columns::title` implements `SelectableExpression<ReturningQuerySource<..., ...>>`
              `posts::columns::title` implements `SelectableExpression<SelectStatement<...>>`
              `posts::columns::title` implements `SelectableExpression<posts::table>`
              `posts::columns::title` implements `SelectableExpression<Join<Left, Right, Inner>>`
@@ -478,6 +483,7 @@ LL |         title -> Text,
    = help: the following other types implement trait `SelectableExpression<QS>`:
              `posts::columns::title` implements `SelectableExpression<Only<posts::table>>`
              `posts::columns::title` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
+             `posts::columns::title` implements `SelectableExpression<ReturningQuerySource<..., ...>>`
              `posts::columns::title` implements `SelectableExpression<SelectStatement<...>>`
              `posts::columns::title` implements `SelectableExpression<posts::table>`
              `posts::columns::title` implements `SelectableExpression<Join<Left, Right, Inner>>`
@@ -590,6 +596,7 @@ help: the trait `SelectableExpression<pets::table>` is not implemented for `post
     = help: the following other types implement trait `SelectableExpression<QS>`:
               `posts::columns::title` implements `SelectableExpression<Only<posts::table>>`
               `posts::columns::title` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
+              `posts::columns::title` implements `SelectableExpression<ReturningQuerySource<..., ...>>`
               `posts::columns::title` implements `SelectableExpression<SelectStatement<...>>`
               `posts::columns::title` implements `SelectableExpression<posts::table>`
               `posts::columns::title` implements `SelectableExpression<Join<Left, Right, Inner>>`
@@ -643,6 +650,7 @@ help: the trait `SelectableExpression<pets::table>` is not implemented for `post
     = help: the following other types implement trait `SelectableExpression<QS>`:
               `posts::columns::title` implements `SelectableExpression<Only<posts::table>>`
               `posts::columns::title` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
+              `posts::columns::title` implements `SelectableExpression<ReturningQuerySource<..., ...>>`
               `posts::columns::title` implements `SelectableExpression<SelectStatement<...>>`
               `posts::columns::title` implements `SelectableExpression<posts::table>`
               `posts::columns::title` implements `SelectableExpression<Join<Left, Right, Inner>>`
@@ -765,6 +773,7 @@ help: the trait `SelectableExpression<users::table>` is not implemented for `pos
     = help: the following other types implement trait `SelectableExpression<QS>`:
               `posts::columns::title` implements `SelectableExpression<Only<posts::table>>`
               `posts::columns::title` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
+              `posts::columns::title` implements `SelectableExpression<ReturningQuerySource<..., ...>>`
               `posts::columns::title` implements `SelectableExpression<SelectStatement<...>>`
               `posts::columns::title` implements `SelectableExpression<posts::table>`
               `posts::columns::title` implements `SelectableExpression<Join<Left, Right, Inner>>`
@@ -828,6 +837,7 @@ help: the trait `SelectableExpression<users::table>` is not implemented for `pos
     = help: the following other types implement trait `SelectableExpression<QS>`:
               `posts::columns::title` implements `SelectableExpression<Only<posts::table>>`
               `posts::columns::title` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
+              `posts::columns::title` implements `SelectableExpression<ReturningQuerySource<..., ...>>`
               `posts::columns::title` implements `SelectableExpression<SelectStatement<...>>`
               `posts::columns::title` implements `SelectableExpression<posts::table>`
               `posts::columns::title` implements `SelectableExpression<Join<Left, Right, Inner>>`

--- a/diesel_compile_tests/tests/fail/select_requires_column_from_same_table.stderr
+++ b/diesel_compile_tests/tests/fail/select_requires_column_from_same_table.stderr
@@ -15,6 +15,7 @@ help: the trait `SelectableExpression<users::table>` is not implemented for `pos
     = help: the following other types implement trait `SelectableExpression<QS>`:
               `posts::columns::id` implements `SelectableExpression<Only<posts::table>>`
               `posts::columns::id` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
+              `posts::columns::id` implements `SelectableExpression<ReturningQuerySource<..., ...>>`
               `posts::columns::id` implements `SelectableExpression<SelectStatement<...>>`
               `posts::columns::id` implements `SelectableExpression<posts::table>`
               `posts::columns::id` implements `SelectableExpression<Join<Left, Right, Inner>>`

--- a/diesel_compile_tests/tests/fail/selectable.rs
+++ b/diesel_compile_tests/tests/fail/selectable.rs
@@ -195,13 +195,17 @@ fn main() {
     let _ = diesel::insert_into(users::table)
         .values(users::name.eq(""))
         .returning(UserWithEmbeddedPost::as_select())
-        //~^ ERROR: cannot select `posts::columns::id` from `users::table`
-        //~| ERROR: cannot select `posts::columns::title` from `users::table`
-        //~| ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
+        //~^ ERROR: cannot select `posts::columns::id` from `ReturningQuerySource<..., ...>`
+        //~| ERROR: cannot select `posts::columns::title` from `ReturningQuerySource<..., ...>`
+        //~| ERROR: type mismatch resolving `<ReturningQuerySource<..., ...> as AppearsInFromClause<...>>::Count == Once`
+        //~| ERROR: the trait bound `ReturningQuerySource<..., ...>: TableNotEqual<...>` is not satisfied
+        //~| ERROR: the trait bound `ReturningQuerySource<..., ...>: Table` is not satisfied
         .load(&mut conn)
-        //~^ ERROR: cannot select `posts::columns::id` from `users::table`
-        //~| ERROR: cannot select `posts::columns::title` from `users::table`
-        //~| ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
+        //~^ ERROR: cannot select `posts::columns::id` from `ReturningQuerySource<..., ...>`
+        //~| ERROR: cannot select `posts::columns::title` from `ReturningQuerySource<..., ...>`
+        //~| ERROR: type mismatch resolving `<ReturningQuerySource<..., ...> as AppearsInFromClause<...>>::Count == Once`
+        //~| ERROR: the trait bound `ReturningQuerySource<..., ...>: TableNotEqual<...>` is not satisfied
+        //~| ERROR: the trait bound `ReturningQuerySource<..., ...>: Table` is not satisfied
         .unwrap();
 
     // cannot load results from more than one table via
@@ -209,26 +213,34 @@ fn main() {
     let _ = diesel::update(users::table)
         .set(users::name.eq(""))
         .returning(UserWithEmbeddedPost::as_select())
-        //~^ ERROR: cannot select `posts::columns::id` from `users::table`
-        //~| ERROR: cannot select `posts::columns::title` from `users::table`
-        //~| ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
+        //~^ ERROR: cannot select `posts::columns::id` from `ReturningQuerySource<UpdateStmt, table>`
+        //~| ERROR: cannot select `posts::columns::title` from `ReturningQuerySource<UpdateStmt, table>`
+        //~| ERROR: type mismatch resolving `<ReturningQuerySource<..., ...> as AppearsInFromClause<...>>::Count == Once`
+        //~| ERROR: the trait bound `ReturningQuerySource<..., ...>: TableNotEqual<...>` is not satisfied
+        //~| ERROR: the trait bound `ReturningQuerySource<UpdateStmt, table>: Table` is not satisfied
         .load(&mut conn)
-        //~^ ERROR: cannot select `posts::columns::id` from `users::table`
-        //~| ERROR: cannot select `posts::columns::title` from `users::table`
-        //~| ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
+        //~^ ERROR: cannot select `posts::columns::id` from `ReturningQuerySource<UpdateStmt, table>`
+        //~| ERROR: cannot select `posts::columns::title` from `ReturningQuerySource<UpdateStmt, table>`
+        //~| ERROR: type mismatch resolving `<ReturningQuerySource<..., ...> as AppearsInFromClause<...>>::Count == Once`
+        //~| ERROR: the trait bound `ReturningQuerySource<..., ...>: TableNotEqual<...>` is not satisfied
+        //~| ERROR: the trait bound `ReturningQuerySource<UpdateStmt, table>: Table` is not satisfied
         .unwrap();
 
     // cannot load results from more than one table via
     // returning clauses
     let _ = diesel::delete(users::table)
         .returning(UserWithEmbeddedPost::as_select())
-        //~^ ERROR: cannot select `posts::columns::id` from `users::table`
-        //~| ERROR: cannot select `posts::columns::title` from `users::table`
-        //~| ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
+        //~^ ERROR: cannot select `posts::columns::id` from `ReturningQuerySource<DeleteStmt, table>`
+        //~| ERROR: cannot select `posts::columns::title` from `ReturningQuerySource<DeleteStmt, table>`
+        //~| ERROR: type mismatch resolving `<ReturningQuerySource<..., ...> as AppearsInFromClause<...>>::Count == Once`
+        //~| ERROR: the trait bound `ReturningQuerySource<..., ...>: TableNotEqual<...>` is not satisfied
+        //~| ERROR: the trait bound `ReturningQuerySource<DeleteStmt, table>: Table` is not satisfied
         .load(&mut conn)
-        //~^ ERROR: cannot select `posts::columns::id` from `users::table`
-        //~| ERROR: cannot select `posts::columns::title` from `users::table`
-        //~| ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
+        //~^ ERROR: cannot select `posts::columns::id` from `ReturningQuerySource<DeleteStmt, table>`
+        //~| ERROR: cannot select `posts::columns::title` from `ReturningQuerySource<DeleteStmt, table>`
+        //~| ERROR: type mismatch resolving `<ReturningQuerySource<..., ...> as AppearsInFromClause<...>>::Count == Once`
+        //~| ERROR: the trait bound `ReturningQuerySource<..., ...>: TableNotEqual<...>` is not satisfied
+        //~| ERROR: the trait bound `ReturningQuerySource<DeleteStmt, table>: Table` is not satisfied
         .unwrap();
 
     // cannot use this method without deriving selectable

--- a/diesel_compile_tests/tests/fail/selectable.stderr
+++ b/diesel_compile_tests/tests/fail/selectable.stderr
@@ -88,6 +88,7 @@ help: the trait `SelectableExpression<users::table>` is not implemented for `pos
     = help: the following other types implement trait `SelectableExpression<QS>`:
               `posts::columns::id` implements `SelectableExpression<Only<posts::table>>`
               `posts::columns::id` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
+              `posts::columns::id` implements `SelectableExpression<ReturningQuerySource<..., ...>>`
               `posts::columns::id` implements `SelectableExpression<SelectStatement<...>>`
               `posts::columns::id` implements `SelectableExpression<posts::table>`
               `posts::columns::id` implements `SelectableExpression<Join<Left, Right, Inner>>`
@@ -119,6 +120,7 @@ help: the trait `SelectableExpression<users::table>` is not implemented for `pos
     = help: the following other types implement trait `SelectableExpression<QS>`:
               `posts::columns::title` implements `SelectableExpression<Only<posts::table>>`
               `posts::columns::title` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
+              `posts::columns::title` implements `SelectableExpression<ReturningQuerySource<..., ...>>`
               `posts::columns::title` implements `SelectableExpression<SelectStatement<...>>`
               `posts::columns::title` implements `SelectableExpression<posts::table>`
               `posts::columns::title` implements `SelectableExpression<Join<Left, Right, Inner>>`
@@ -196,6 +198,7 @@ help: the trait `SelectableExpression<users::table>` is not implemented for `pos
      = help: the following other types implement trait `SelectableExpression<QS>`:
                `posts::columns::id` implements `SelectableExpression<Only<posts::table>>`
                `posts::columns::id` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
+               `posts::columns::id` implements `SelectableExpression<ReturningQuerySource<..., ...>>`
                `posts::columns::id` implements `SelectableExpression<SelectStatement<...>>`
                `posts::columns::id` implements `SelectableExpression<posts::table>`
                `posts::columns::id` implements `SelectableExpression<Join<Left, Right, Inner>>`
@@ -239,6 +242,7 @@ help: the trait `SelectableExpression<users::table>` is not implemented for `pos
      = help: the following other types implement trait `SelectableExpression<QS>`:
                `posts::columns::title` implements `SelectableExpression<Only<posts::table>>`
                `posts::columns::title` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
+               `posts::columns::title` implements `SelectableExpression<ReturningQuerySource<..., ...>>`
                `posts::columns::title` implements `SelectableExpression<SelectStatement<...>>`
                `posts::columns::title` implements `SelectableExpression<posts::table>`
                `posts::columns::title` implements `SelectableExpression<Join<Left, Right, Inner>>`
@@ -357,7 +361,7 @@ LL |     impl MixedAggregates<Never> for No {
     = note: required for `SelectStatement<FromClause<JoinOn<..., ...>>>` to implement `SelectDsl<SelectBy<UserWithPostCount, Pg>>`
  
     
-error[E0277]: cannot select `posts::columns::id` from `users::table`
+error[E0277]: cannot select `posts::columns::id` from `ReturningQuerySource<..., ...>`
    --> tests/fail/selectable.rs:197:20
     |
 LL |         .returning(UserWithEmbeddedPost::as_select())
@@ -365,23 +369,24 @@ LL |         .returning(UserWithEmbeddedPost::as_select())
     |          |
     |          required by a bound introduced by this call
     |
-help: the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::id`
+help: the trait `SelectableExpression<diesel::query_builder::returning::returning_query_source::ReturningQuerySource<diesel::query_builder::returning::returning_query_source::InsertStmtWithoutOnConflictDoUpdate, users::table>>` is not implemented for `posts::columns::id`
    --> tests/fail/selectable.rs:14:9
     |
  LL |         id -> Integer,
     |         ^^
-    = note: `posts::columns::id` is no valid selection for `users::table`
+    = note: `posts::columns::id` is no valid selection for `ReturningQuerySource<..., ...>`
     = help: the following other types implement trait `SelectableExpression<QS>`:
               `posts::columns::id` implements `SelectableExpression<Only<posts::table>>`
               `posts::columns::id` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
+              `posts::columns::id` implements `SelectableExpression<ReturningQuerySource<..., ...>>`
               `posts::columns::id` implements `SelectableExpression<SelectStatement<...>>`
               `posts::columns::id` implements `SelectableExpression<posts::table>`
               `posts::columns::id` implements `SelectableExpression<Join<Left, Right, Inner>>`
               `posts::columns::id` implements `SelectableExpression<Join<Left, Right, LeftOuter>>`
               `posts::columns::id` implements `SelectableExpression<query_source::joins::JoinOn<Join, On>>`
-    = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<users::table>`
+    = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
     = note: 2 redundant requirements hidden
-    = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<users::table>`
+    = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
     = note: required for `InsertStatement<table, ..., ..., ...>` to implement `Query`
 note: required by a bound in `InsertStatement::<T, U, Op>::returning`
    --> DIESEL/diesel/diesel/src/query_builder/insert_statement/mod.rs
@@ -394,7 +399,7 @@ LL |         InsertStatement<T, U, Op, ReturningClause<E>>: Query,
  
         = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: cannot select `posts::columns::title` from `users::table`
+error[E0277]: cannot select `posts::columns::title` from `ReturningQuerySource<..., ...>`
    --> tests/fail/selectable.rs:197:20
     |
 LL |         .returning(UserWithEmbeddedPost::as_select())
@@ -402,23 +407,24 @@ LL |         .returning(UserWithEmbeddedPost::as_select())
     |          |
     |          required by a bound introduced by this call
     |
-help: the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::title`
+help: the trait `SelectableExpression<diesel::query_builder::returning::returning_query_source::ReturningQuerySource<diesel::query_builder::returning::returning_query_source::InsertStmtWithoutOnConflictDoUpdate, users::table>>` is not implemented for `posts::columns::title`
    --> tests/fail/selectable.rs:15:9
     |
  LL |         title -> Text,
     |         ^^^^^
-    = note: `posts::columns::title` is no valid selection for `users::table`
+    = note: `posts::columns::title` is no valid selection for `ReturningQuerySource<..., ...>`
     = help: the following other types implement trait `SelectableExpression<QS>`:
               `posts::columns::title` implements `SelectableExpression<Only<posts::table>>`
               `posts::columns::title` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
+              `posts::columns::title` implements `SelectableExpression<ReturningQuerySource<..., ...>>`
               `posts::columns::title` implements `SelectableExpression<SelectStatement<...>>`
               `posts::columns::title` implements `SelectableExpression<posts::table>`
               `posts::columns::title` implements `SelectableExpression<Join<Left, Right, Inner>>`
               `posts::columns::title` implements `SelectableExpression<Join<Left, Right, LeftOuter>>`
               `posts::columns::title` implements `SelectableExpression<query_source::joins::JoinOn<Join, On>>`
-    = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<users::table>`
+    = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
     = note: 2 redundant requirements hidden
-    = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<users::table>`
+    = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
     = note: required for `InsertStatement<table, ..., ..., ...>` to implement `Query`
 note: required by a bound in `InsertStatement::<T, U, Op>::returning`
    --> DIESEL/diesel/diesel/src/query_builder/insert_statement/mod.rs
@@ -431,7 +437,7 @@ LL |         InsertStatement<T, U, Op, ReturningClause<E>>: Query,
  
         = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
+error[E0271]: type mismatch resolving `<ReturningQuerySource<..., ...> as AppearsInFromClause<...>>::Count == Once`
    --> tests/fail/selectable.rs:197:20
     |
 LL |         .returning(UserWithEmbeddedPost::as_select())
@@ -439,17 +445,17 @@ LL |         .returning(UserWithEmbeddedPost::as_select())
     |          |
     |          required by a bound introduced by this call
     |
-note: required for `posts::columns::id` to implement `AppearsOnTable<users::table>`
+note: required for `posts::columns::id` to implement `AppearsOnTable<ReturningQuerySource<..., ...>>`
    --> tests/fail/selectable.rs:14:9
     |
  LL |         id -> Integer,
     |         ^^
     = note: associated types for the current `impl` cannot be restricted in `where` clauses
     = note: 1 redundant requirement hidden
-    = note: required for `(posts::columns::id, posts::columns::title)` to implement `AppearsOnTable<users::table>`
-    = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<users::table>`
+    = note: required for `(posts::columns::id, posts::columns::title)` to implement `AppearsOnTable<ReturningQuerySource<..., ...>>`
+    = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
     = note: 2 redundant requirements hidden
-    = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<users::table>`
+    = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
     = note: required for `InsertStatement<table, ..., ..., ...>` to implement `Query`
 note: required by a bound in `InsertStatement::<T, U, Op>::returning`
    --> DIESEL/diesel/diesel/src/query_builder/insert_statement/mod.rs
@@ -462,31 +468,120 @@ LL |         InsertStatement<T, U, Op, ReturningClause<E>>: Query,
  
         = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: cannot select `posts::columns::id` from `users::table`
-    --> tests/fail/selectable.rs:201:15
+error[E0277]: the trait bound `ReturningQuerySource<..., ...>: TableNotEqual<...>` is not satisfied
+   --> tests/fail/selectable.rs:197:20
+    |
+LL |         .returning(UserWithEmbeddedPost::as_select())
+    |          --------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `TableNotEqual<posts::table>` is not implemented for `ReturningQuerySource<..., ...>`
+    |          |
+    |          required by a bound introduced by this call
+    |
+    = note: double check that `posts::table` and `ReturningQuerySource<..., ...>` appear in the same `allow_tables_to_appear_in_same_query!` 
+            call if both are tables
+help: the following other types implement trait `TableNotEqual<T>`
+   --> tests/fail/selectable.rs:23:1
+    |
+ LL | allow_tables_to_appear_in_same_query!(users, posts);
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    | |
+    | `posts::table` implements `TableNotEqual<users::table>`
+    | `users::table` implements `TableNotEqual<posts::table>`
+    |
+   ::: DIESEL/diesel/diesel/src/pg/metadata_lookup.rs
+    |
+LL | allow_tables_to_appear_in_same_query!(pg_type, pg_namespace);
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    | |
+    | `pg::metadata_lookup::pg_namespace::table` implements `TableNotEqual<pg::metadata_lookup::pg_type::table>`
+    | `pg::metadata_lookup::pg_type::table` implements `TableNotEqual<pg::metadata_lookup::pg_namespace::table>`
+    = note: required for `ReturningQuerySource<..., ...>` to implement `AppearsInFromClause<posts::table>`
+note: required for `posts::columns::id` to implement `AppearsOnTable<ReturningQuerySource<..., ...>>`
+   --> tests/fail/selectable.rs:14:9
+    |
+ LL |         id -> Integer,
+    |         ^^
+    = note: 1 redundant requirement hidden
+    = note: required for `(posts::columns::id, posts::columns::title)` to implement `AppearsOnTable<ReturningQuerySource<..., ...>>`
+    = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
+    = note: 2 redundant requirements hidden
+    = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
+    = note: required for `InsertStatement<table, ..., ..., ...>` to implement `Query`
+note: required by a bound in `InsertStatement::<T, U, Op>::returning`
+   --> DIESEL/diesel/diesel/src/query_builder/insert_statement/mod.rs
+    |
+LL |     pub fn returning<E>(self, returns: E) -> InsertStatement<T, U, Op, ReturningClause<E>>
+    |            --------- required by a bound in this associated function
+LL |     where
+LL |         InsertStatement<T, U, Op, ReturningClause<E>>: Query,
+    |                                                        ^^^^^ required by this bound in `InsertStatement::<T, U, Op>::returning`
+ 
+        = note: this error originates in the macro `allow_tables_to_appear_in_same_query` which comes from the expansion of the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `ReturningQuerySource<..., ...>: Table` is not satisfied
+   --> tests/fail/selectable.rs:197:20
+    |
+LL |         .returning(UserWithEmbeddedPost::as_select())
+    |          --------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Table` is not implemented for `ReturningQuerySource<..., ...>`
+    |          |
+    |          required by a bound introduced by this call
+    |
+    = help: the following other types implement trait `Table`:
+              Only<S>
+              Tablesample<S, TSM>
+              pg::metadata_lookup::pg_namespace::table
+              pg::metadata_lookup::pg_type::table
+              posts::table
+              users::table
+    = note: required for `ReturningQuerySource<..., ...>` to implement `QueryRelation`
+    = note: required for `ReturningQuerySource<..., ...>` to implement `AppearsInFromClause<posts::table>`
+note: required for `posts::columns::id` to implement `AppearsOnTable<ReturningQuerySource<..., ...>>`
+   --> tests/fail/selectable.rs:14:9
+    |
+ LL |         id -> Integer,
+    |         ^^
+    = note: 1 redundant requirement hidden
+    = note: required for `(posts::columns::id, posts::columns::title)` to implement `AppearsOnTable<ReturningQuerySource<..., ...>>`
+    = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
+    = note: 2 redundant requirements hidden
+    = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
+    = note: required for `InsertStatement<table, ..., ..., ...>` to implement `Query`
+note: required by a bound in `InsertStatement::<T, U, Op>::returning`
+   --> DIESEL/diesel/diesel/src/query_builder/insert_statement/mod.rs
+    |
+LL |     pub fn returning<E>(self, returns: E) -> InsertStatement<T, U, Op, ReturningClause<E>>
+    |            --------- required by a bound in this associated function
+LL |     where
+LL |         InsertStatement<T, U, Op, ReturningClause<E>>: Query,
+    |                                                        ^^^^^ required by this bound in `InsertStatement::<T, U, Op>::returning`
+ 
+        = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: cannot select `posts::columns::id` from `ReturningQuerySource<..., ...>`
+    --> tests/fail/selectable.rs:203:15
      |
  LL |         .load(&mut conn)
      |          ---- ^^^^^^^^^ unsatisfied trait bound
      |          |
      |          required by a bound introduced by this call
      |
-help: the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::id`
+help: the trait `SelectableExpression<diesel::query_builder::returning::returning_query_source::ReturningQuerySource<diesel::query_builder::returning::returning_query_source::InsertStmtWithoutOnConflictDoUpdate, users::table>>` is not implemented for `posts::columns::id`
     --> tests/fail/selectable.rs:14:9
      |
   LL |         id -> Integer,
      |         ^^
-     = note: `posts::columns::id` is no valid selection for `users::table`
+     = note: `posts::columns::id` is no valid selection for `ReturningQuerySource<..., ...>`
      = help: the following other types implement trait `SelectableExpression<QS>`:
                `posts::columns::id` implements `SelectableExpression<Only<posts::table>>`
                `posts::columns::id` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
+               `posts::columns::id` implements `SelectableExpression<ReturningQuerySource<..., ...>>`
                `posts::columns::id` implements `SelectableExpression<SelectStatement<...>>`
                `posts::columns::id` implements `SelectableExpression<posts::table>`
                `posts::columns::id` implements `SelectableExpression<Join<Left, Right, Inner>>`
                `posts::columns::id` implements `SelectableExpression<Join<Left, Right, LeftOuter>>`
                `posts::columns::id` implements `SelectableExpression<query_source::joins::JoinOn<Join, On>>`
-     = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<users::table>`
+     = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
      = note: 2 redundant requirements hidden
-     = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<users::table>`
+     = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
      = note: required for `InsertStatement<table, ..., ..., ...>` to implement `Query`
      = note: required for `InsertStatement<table, ..., ..., ...>` to implement `LoadQuery<'_, _, UserWithEmbeddedPost>`
 note: required by a bound in `load`
@@ -500,31 +595,32 @@ LL |         Self: LoadQuery<'query, Conn, U>,
   
           = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: cannot select `posts::columns::title` from `users::table`
-    --> tests/fail/selectable.rs:201:15
+error[E0277]: cannot select `posts::columns::title` from `ReturningQuerySource<..., ...>`
+    --> tests/fail/selectable.rs:203:15
      |
  LL |         .load(&mut conn)
      |          ---- ^^^^^^^^^ unsatisfied trait bound
      |          |
      |          required by a bound introduced by this call
      |
-help: the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::title`
+help: the trait `SelectableExpression<diesel::query_builder::returning::returning_query_source::ReturningQuerySource<diesel::query_builder::returning::returning_query_source::InsertStmtWithoutOnConflictDoUpdate, users::table>>` is not implemented for `posts::columns::title`
     --> tests/fail/selectable.rs:15:9
      |
   LL |         title -> Text,
      |         ^^^^^
-     = note: `posts::columns::title` is no valid selection for `users::table`
+     = note: `posts::columns::title` is no valid selection for `ReturningQuerySource<..., ...>`
      = help: the following other types implement trait `SelectableExpression<QS>`:
                `posts::columns::title` implements `SelectableExpression<Only<posts::table>>`
                `posts::columns::title` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
+               `posts::columns::title` implements `SelectableExpression<ReturningQuerySource<..., ...>>`
                `posts::columns::title` implements `SelectableExpression<SelectStatement<...>>`
                `posts::columns::title` implements `SelectableExpression<posts::table>`
                `posts::columns::title` implements `SelectableExpression<Join<Left, Right, Inner>>`
                `posts::columns::title` implements `SelectableExpression<Join<Left, Right, LeftOuter>>`
                `posts::columns::title` implements `SelectableExpression<query_source::joins::JoinOn<Join, On>>`
-     = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<users::table>`
+     = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
      = note: 2 redundant requirements hidden
-     = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<users::table>`
+     = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
      = note: required for `InsertStatement<table, ..., ..., ...>` to implement `Query`
      = note: required for `InsertStatement<table, ..., ..., ...>` to implement `LoadQuery<'_, _, UserWithEmbeddedPost>`
 note: required by a bound in `load`
@@ -538,25 +634,25 @@ LL |         Self: LoadQuery<'query, Conn, U>,
   
           = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
-    --> tests/fail/selectable.rs:201:15
+error[E0271]: type mismatch resolving `<ReturningQuerySource<..., ...> as AppearsInFromClause<...>>::Count == Once`
+    --> tests/fail/selectable.rs:203:15
      |
  LL |         .load(&mut conn)
      |          ---- ^^^^^^^^^ expected `Once`, found `Never`
      |          |
      |          required by a bound introduced by this call
      |
-note: required for `posts::columns::id` to implement `AppearsOnTable<users::table>`
+note: required for `posts::columns::id` to implement `AppearsOnTable<ReturningQuerySource<..., ...>>`
     --> tests/fail/selectable.rs:14:9
      |
   LL |         id -> Integer,
      |         ^^
      = note: associated types for the current `impl` cannot be restricted in `where` clauses
      = note: 1 redundant requirement hidden
-     = note: required for `(posts::columns::id, posts::columns::title)` to implement `AppearsOnTable<users::table>`
-     = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<users::table>`
+     = note: required for `(posts::columns::id, posts::columns::title)` to implement `AppearsOnTable<ReturningQuerySource<..., ...>>`
+     = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
      = note: 2 redundant requirements hidden
-     = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<users::table>`
+     = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
      = note: required for `InsertStatement<table, ..., ..., ...>` to implement `Query`
      = note: required for `InsertStatement<table, ..., ..., ...>` to implement `LoadQuery<'_, _, UserWithEmbeddedPost>`
 note: required by a bound in `load`
@@ -570,31 +666,122 @@ LL |         Self: LoadQuery<'query, Conn, U>,
   
           = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: cannot select `posts::columns::id` from `users::table`
-   --> tests/fail/selectable.rs:211:20
+error[E0277]: the trait bound `ReturningQuerySource<..., ...>: TableNotEqual<...>` is not satisfied
+    --> tests/fail/selectable.rs:203:15
+     |
+ LL |         .load(&mut conn)
+     |          ---- ^^^^^^^^^ the trait `TableNotEqual<posts::table>` is not implemented for `ReturningQuerySource<..., ...>`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = note: double check that `posts::table` and `ReturningQuerySource<..., ...>` appear in the same `allow_tables_to_appear_in_same_query!` 
+             call if both are tables
+help: the following other types implement trait `TableNotEqual<T>`
+    --> tests/fail/selectable.rs:23:1
+     |
+  LL | allow_tables_to_appear_in_same_query!(users, posts);
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     | |
+     | `posts::table` implements `TableNotEqual<users::table>`
+     | `users::table` implements `TableNotEqual<posts::table>`
+     |
+    ::: DIESEL/diesel/diesel/src/pg/metadata_lookup.rs
+     |
+ LL | allow_tables_to_appear_in_same_query!(pg_type, pg_namespace);
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     | |
+     | `pg::metadata_lookup::pg_namespace::table` implements `TableNotEqual<pg::metadata_lookup::pg_type::table>`
+     | `pg::metadata_lookup::pg_type::table` implements `TableNotEqual<pg::metadata_lookup::pg_namespace::table>`
+     = note: required for `ReturningQuerySource<..., ...>` to implement `AppearsInFromClause<posts::table>`
+note: required for `posts::columns::id` to implement `AppearsOnTable<ReturningQuerySource<..., ...>>`
+    --> tests/fail/selectable.rs:14:9
+     |
+  LL |         id -> Integer,
+     |         ^^
+     = note: 1 redundant requirement hidden
+     = note: required for `(posts::columns::id, posts::columns::title)` to implement `AppearsOnTable<ReturningQuerySource<..., ...>>`
+     = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
+     = note: 2 redundant requirements hidden
+     = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
+     = note: required for `InsertStatement<table, ..., ..., ...>` to implement `Query`
+     = note: required for `InsertStatement<table, ..., ..., ...>` to implement `LoadQuery<'_, _, UserWithEmbeddedPost>`
+note: required by a bound in `load`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+          = note: this error originates in the macro `allow_tables_to_appear_in_same_query` which comes from the expansion of the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `ReturningQuerySource<..., ...>: Table` is not satisfied
+    --> tests/fail/selectable.rs:203:15
+     |
+ LL |         .load(&mut conn)
+     |          ---- ^^^^^^^^^ the trait `Table` is not implemented for `ReturningQuerySource<..., ...>`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = help: the following other types implement trait `Table`:
+               Only<S>
+               Tablesample<S, TSM>
+               pg::metadata_lookup::pg_namespace::table
+               pg::metadata_lookup::pg_type::table
+               posts::table
+               users::table
+     = note: required for `ReturningQuerySource<..., ...>` to implement `QueryRelation`
+     = note: required for `ReturningQuerySource<..., ...>` to implement `AppearsInFromClause<posts::table>`
+note: required for `posts::columns::id` to implement `AppearsOnTable<ReturningQuerySource<..., ...>>`
+    --> tests/fail/selectable.rs:14:9
+     |
+  LL |         id -> Integer,
+     |         ^^
+     = note: 1 redundant requirement hidden
+     = note: required for `(posts::columns::id, posts::columns::title)` to implement `AppearsOnTable<ReturningQuerySource<..., ...>>`
+     = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
+     = note: 2 redundant requirements hidden
+     = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
+     = note: required for `InsertStatement<table, ..., ..., ...>` to implement `Query`
+     = note: required for `InsertStatement<table, ..., ..., ...>` to implement `LoadQuery<'_, _, UserWithEmbeddedPost>`
+note: required by a bound in `load`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+          = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: cannot select `posts::columns::id` from `ReturningQuerySource<UpdateStmt, table>`
+   --> tests/fail/selectable.rs:215:20
     |
 LL |         .returning(UserWithEmbeddedPost::as_select())
     |          --------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
     |          |
     |          required by a bound introduced by this call
     |
-help: the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::id`
+help: the trait `SelectableExpression<diesel::query_builder::returning::returning_query_source::ReturningQuerySource<diesel::query_builder::returning::returning_query_source::UpdateStmt, users::table>>` is not implemented for `posts::columns::id`
    --> tests/fail/selectable.rs:14:9
     |
  LL |         id -> Integer,
     |         ^^
-    = note: `posts::columns::id` is no valid selection for `users::table`
+    = note: `posts::columns::id` is no valid selection for `ReturningQuerySource<UpdateStmt, table>`
     = help: the following other types implement trait `SelectableExpression<QS>`:
               `posts::columns::id` implements `SelectableExpression<Only<posts::table>>`
               `posts::columns::id` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
+              `posts::columns::id` implements `SelectableExpression<ReturningQuerySource<..., ...>>`
               `posts::columns::id` implements `SelectableExpression<SelectStatement<...>>`
               `posts::columns::id` implements `SelectableExpression<posts::table>`
               `posts::columns::id` implements `SelectableExpression<Join<Left, Right, Inner>>`
               `posts::columns::id` implements `SelectableExpression<Join<Left, Right, LeftOuter>>`
               `posts::columns::id` implements `SelectableExpression<query_source::joins::JoinOn<Join, On>>`
-    = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<users::table>`
+    = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
     = note: 2 redundant requirements hidden
-    = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<users::table>`
+    = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
     = note: required for `UpdateStatement<table, NoWhereClause, ..., ...>` to implement `Query`
 note: required by a bound in `UpdateStatement::<T, U, V>::returning`
    --> DIESEL/diesel/diesel/src/query_builder/update_statement/mod.rs
@@ -607,31 +794,32 @@ LL |         UpdateStatement<T, U, V, ReturningClause<E>>: Query,
  
         = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: cannot select `posts::columns::title` from `users::table`
-   --> tests/fail/selectable.rs:211:20
+error[E0277]: cannot select `posts::columns::title` from `ReturningQuerySource<UpdateStmt, table>`
+   --> tests/fail/selectable.rs:215:20
     |
 LL |         .returning(UserWithEmbeddedPost::as_select())
     |          --------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
     |          |
     |          required by a bound introduced by this call
     |
-help: the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::title`
+help: the trait `SelectableExpression<diesel::query_builder::returning::returning_query_source::ReturningQuerySource<diesel::query_builder::returning::returning_query_source::UpdateStmt, users::table>>` is not implemented for `posts::columns::title`
    --> tests/fail/selectable.rs:15:9
     |
  LL |         title -> Text,
     |         ^^^^^
-    = note: `posts::columns::title` is no valid selection for `users::table`
+    = note: `posts::columns::title` is no valid selection for `ReturningQuerySource<UpdateStmt, table>`
     = help: the following other types implement trait `SelectableExpression<QS>`:
               `posts::columns::title` implements `SelectableExpression<Only<posts::table>>`
               `posts::columns::title` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
+              `posts::columns::title` implements `SelectableExpression<ReturningQuerySource<..., ...>>`
               `posts::columns::title` implements `SelectableExpression<SelectStatement<...>>`
               `posts::columns::title` implements `SelectableExpression<posts::table>`
               `posts::columns::title` implements `SelectableExpression<Join<Left, Right, Inner>>`
               `posts::columns::title` implements `SelectableExpression<Join<Left, Right, LeftOuter>>`
               `posts::columns::title` implements `SelectableExpression<query_source::joins::JoinOn<Join, On>>`
-    = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<users::table>`
+    = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
     = note: 2 redundant requirements hidden
-    = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<users::table>`
+    = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
     = note: required for `UpdateStatement<table, NoWhereClause, ..., ...>` to implement `Query`
 note: required by a bound in `UpdateStatement::<T, U, V>::returning`
    --> DIESEL/diesel/diesel/src/query_builder/update_statement/mod.rs
@@ -644,25 +832,25 @@ LL |         UpdateStatement<T, U, V, ReturningClause<E>>: Query,
  
         = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
-   --> tests/fail/selectable.rs:211:20
+error[E0271]: type mismatch resolving `<ReturningQuerySource<..., ...> as AppearsInFromClause<...>>::Count == Once`
+   --> tests/fail/selectable.rs:215:20
     |
 LL |         .returning(UserWithEmbeddedPost::as_select())
     |          --------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Once`, found `Never`
     |          |
     |          required by a bound introduced by this call
     |
-note: required for `posts::columns::id` to implement `AppearsOnTable<users::table>`
+note: required for `posts::columns::id` to implement `AppearsOnTable<ReturningQuerySource<..., ...>>`
    --> tests/fail/selectable.rs:14:9
     |
  LL |         id -> Integer,
     |         ^^
     = note: associated types for the current `impl` cannot be restricted in `where` clauses
     = note: 1 redundant requirement hidden
-    = note: required for `(posts::columns::id, posts::columns::title)` to implement `AppearsOnTable<users::table>`
-    = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<users::table>`
+    = note: required for `(posts::columns::id, posts::columns::title)` to implement `AppearsOnTable<ReturningQuerySource<..., ...>>`
+    = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
     = note: 2 redundant requirements hidden
-    = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<users::table>`
+    = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
     = note: required for `UpdateStatement<table, NoWhereClause, ..., ...>` to implement `Query`
 note: required by a bound in `UpdateStatement::<T, U, V>::returning`
    --> DIESEL/diesel/diesel/src/query_builder/update_statement/mod.rs
@@ -675,31 +863,121 @@ LL |         UpdateStatement<T, U, V, ReturningClause<E>>: Query,
  
         = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: cannot select `posts::columns::id` from `users::table`
-    --> tests/fail/selectable.rs:215:15
+error[E0277]: the trait bound `ReturningQuerySource<..., ...>: TableNotEqual<...>` is not satisfied
+   --> tests/fail/selectable.rs:215:20
+    |
+LL |         .returning(UserWithEmbeddedPost::as_select())
+    |          --------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+    |          |
+    |          required by a bound introduced by this call
+    |
+    = help: the trait `TableNotEqual<posts::table>` is not implemented for `ReturningQuerySource<UpdateStmt, table>`
+    = note: double check that `posts::table` and `ReturningQuerySource<UpdateStmt, table>` appear in the same `allow_tables_to_appear_in_same_query!` 
+            call if both are tables
+help: the following other types implement trait `TableNotEqual<T>`
+   --> tests/fail/selectable.rs:23:1
+    |
+ LL | allow_tables_to_appear_in_same_query!(users, posts);
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    | |
+    | `posts::table` implements `TableNotEqual<users::table>`
+    | `users::table` implements `TableNotEqual<posts::table>`
+    |
+   ::: DIESEL/diesel/diesel/src/pg/metadata_lookup.rs
+    |
+LL | allow_tables_to_appear_in_same_query!(pg_type, pg_namespace);
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    | |
+    | `pg::metadata_lookup::pg_namespace::table` implements `TableNotEqual<pg::metadata_lookup::pg_type::table>`
+    | `pg::metadata_lookup::pg_type::table` implements `TableNotEqual<pg::metadata_lookup::pg_namespace::table>`
+    = note: required for `ReturningQuerySource<UpdateStmt, table>` to implement `AppearsInFromClause<posts::table>`
+note: required for `posts::columns::id` to implement `AppearsOnTable<ReturningQuerySource<..., ...>>`
+   --> tests/fail/selectable.rs:14:9
+    |
+ LL |         id -> Integer,
+    |         ^^
+    = note: 1 redundant requirement hidden
+    = note: required for `(posts::columns::id, posts::columns::title)` to implement `AppearsOnTable<ReturningQuerySource<..., ...>>`
+    = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
+    = note: 2 redundant requirements hidden
+    = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
+    = note: required for `UpdateStatement<table, NoWhereClause, ..., ...>` to implement `Query`
+note: required by a bound in `UpdateStatement::<T, U, V>::returning`
+   --> DIESEL/diesel/diesel/src/query_builder/update_statement/mod.rs
+    |
+LL |     pub fn returning<E>(self, returns: E) -> UpdateStatement<T, U, V, ReturningClause<E>>
+    |            --------- required by a bound in this associated function
+...
+LL |         UpdateStatement<T, U, V, ReturningClause<E>>: Query,
+    |                                                       ^^^^^ required by this bound in `UpdateStatement::<T, U, V>::returning`
+ 
+        = note: this error originates in the macro `allow_tables_to_appear_in_same_query` which comes from the expansion of the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `ReturningQuerySource<UpdateStmt, table>: Table` is not satisfied
+   --> tests/fail/selectable.rs:215:20
+    |
+LL |         .returning(UserWithEmbeddedPost::as_select())
+    |          --------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Table` is not implemented for `ReturningQuerySource<UpdateStmt, table>`
+    |          |
+    |          required by a bound introduced by this call
+    |
+    = help: the following other types implement trait `Table`:
+              Only<S>
+              Tablesample<S, TSM>
+              pg::metadata_lookup::pg_namespace::table
+              pg::metadata_lookup::pg_type::table
+              posts::table
+              users::table
+    = note: required for `ReturningQuerySource<UpdateStmt, table>` to implement `QueryRelation`
+    = note: required for `ReturningQuerySource<UpdateStmt, table>` to implement `AppearsInFromClause<posts::table>`
+note: required for `posts::columns::id` to implement `AppearsOnTable<ReturningQuerySource<..., ...>>`
+   --> tests/fail/selectable.rs:14:9
+    |
+ LL |         id -> Integer,
+    |         ^^
+    = note: 1 redundant requirement hidden
+    = note: required for `(posts::columns::id, posts::columns::title)` to implement `AppearsOnTable<ReturningQuerySource<..., ...>>`
+    = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
+    = note: 2 redundant requirements hidden
+    = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
+    = note: required for `UpdateStatement<table, NoWhereClause, ..., ...>` to implement `Query`
+note: required by a bound in `UpdateStatement::<T, U, V>::returning`
+   --> DIESEL/diesel/diesel/src/query_builder/update_statement/mod.rs
+    |
+LL |     pub fn returning<E>(self, returns: E) -> UpdateStatement<T, U, V, ReturningClause<E>>
+    |            --------- required by a bound in this associated function
+...
+LL |         UpdateStatement<T, U, V, ReturningClause<E>>: Query,
+    |                                                       ^^^^^ required by this bound in `UpdateStatement::<T, U, V>::returning`
+ 
+        = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: cannot select `posts::columns::id` from `ReturningQuerySource<UpdateStmt, table>`
+    --> tests/fail/selectable.rs:221:15
      |
  LL |         .load(&mut conn)
      |          ---- ^^^^^^^^^ unsatisfied trait bound
      |          |
      |          required by a bound introduced by this call
      |
-help: the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::id`
+help: the trait `SelectableExpression<diesel::query_builder::returning::returning_query_source::ReturningQuerySource<diesel::query_builder::returning::returning_query_source::UpdateStmt, users::table>>` is not implemented for `posts::columns::id`
     --> tests/fail/selectable.rs:14:9
      |
   LL |         id -> Integer,
      |         ^^
-     = note: `posts::columns::id` is no valid selection for `users::table`
+     = note: `posts::columns::id` is no valid selection for `ReturningQuerySource<UpdateStmt, table>`
      = help: the following other types implement trait `SelectableExpression<QS>`:
                `posts::columns::id` implements `SelectableExpression<Only<posts::table>>`
                `posts::columns::id` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
+               `posts::columns::id` implements `SelectableExpression<ReturningQuerySource<..., ...>>`
                `posts::columns::id` implements `SelectableExpression<SelectStatement<...>>`
                `posts::columns::id` implements `SelectableExpression<posts::table>`
                `posts::columns::id` implements `SelectableExpression<Join<Left, Right, Inner>>`
                `posts::columns::id` implements `SelectableExpression<Join<Left, Right, LeftOuter>>`
                `posts::columns::id` implements `SelectableExpression<query_source::joins::JoinOn<Join, On>>`
-     = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<users::table>`
+     = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
      = note: 2 redundant requirements hidden
-     = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<users::table>`
+     = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
      = note: required for `UpdateStatement<table, NoWhereClause, ..., ...>` to implement `Query`
      = note: required for `UpdateStatement<table, NoWhereClause, ..., ...>` to implement `LoadQuery<'_, _, UserWithEmbeddedPost>`
 note: required by a bound in `load`
@@ -713,31 +991,32 @@ LL |         Self: LoadQuery<'query, Conn, U>,
   
           = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: cannot select `posts::columns::title` from `users::table`
-    --> tests/fail/selectable.rs:215:15
+error[E0277]: cannot select `posts::columns::title` from `ReturningQuerySource<UpdateStmt, table>`
+    --> tests/fail/selectable.rs:221:15
      |
  LL |         .load(&mut conn)
      |          ---- ^^^^^^^^^ unsatisfied trait bound
      |          |
      |          required by a bound introduced by this call
      |
-help: the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::title`
+help: the trait `SelectableExpression<diesel::query_builder::returning::returning_query_source::ReturningQuerySource<diesel::query_builder::returning::returning_query_source::UpdateStmt, users::table>>` is not implemented for `posts::columns::title`
     --> tests/fail/selectable.rs:15:9
      |
   LL |         title -> Text,
      |         ^^^^^
-     = note: `posts::columns::title` is no valid selection for `users::table`
+     = note: `posts::columns::title` is no valid selection for `ReturningQuerySource<UpdateStmt, table>`
      = help: the following other types implement trait `SelectableExpression<QS>`:
                `posts::columns::title` implements `SelectableExpression<Only<posts::table>>`
                `posts::columns::title` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
+               `posts::columns::title` implements `SelectableExpression<ReturningQuerySource<..., ...>>`
                `posts::columns::title` implements `SelectableExpression<SelectStatement<...>>`
                `posts::columns::title` implements `SelectableExpression<posts::table>`
                `posts::columns::title` implements `SelectableExpression<Join<Left, Right, Inner>>`
                `posts::columns::title` implements `SelectableExpression<Join<Left, Right, LeftOuter>>`
                `posts::columns::title` implements `SelectableExpression<query_source::joins::JoinOn<Join, On>>`
-     = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<users::table>`
+     = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
      = note: 2 redundant requirements hidden
-     = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<users::table>`
+     = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
      = note: required for `UpdateStatement<table, NoWhereClause, ..., ...>` to implement `Query`
      = note: required for `UpdateStatement<table, NoWhereClause, ..., ...>` to implement `LoadQuery<'_, _, UserWithEmbeddedPost>`
 note: required by a bound in `load`
@@ -751,25 +1030,25 @@ LL |         Self: LoadQuery<'query, Conn, U>,
   
           = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
-    --> tests/fail/selectable.rs:215:15
+error[E0271]: type mismatch resolving `<ReturningQuerySource<..., ...> as AppearsInFromClause<...>>::Count == Once`
+    --> tests/fail/selectable.rs:221:15
      |
  LL |         .load(&mut conn)
      |          ---- ^^^^^^^^^ expected `Once`, found `Never`
      |          |
      |          required by a bound introduced by this call
      |
-note: required for `posts::columns::id` to implement `AppearsOnTable<users::table>`
+note: required for `posts::columns::id` to implement `AppearsOnTable<ReturningQuerySource<..., ...>>`
     --> tests/fail/selectable.rs:14:9
      |
   LL |         id -> Integer,
      |         ^^
      = note: associated types for the current `impl` cannot be restricted in `where` clauses
      = note: 1 redundant requirement hidden
-     = note: required for `(posts::columns::id, posts::columns::title)` to implement `AppearsOnTable<users::table>`
-     = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<users::table>`
+     = note: required for `(posts::columns::id, posts::columns::title)` to implement `AppearsOnTable<ReturningQuerySource<..., ...>>`
+     = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
      = note: 2 redundant requirements hidden
-     = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<users::table>`
+     = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
      = note: required for `UpdateStatement<table, NoWhereClause, ..., ...>` to implement `Query`
      = note: required for `UpdateStatement<table, NoWhereClause, ..., ...>` to implement `LoadQuery<'_, _, UserWithEmbeddedPost>`
 note: required by a bound in `load`
@@ -783,132 +1062,319 @@ LL |         Self: LoadQuery<'query, Conn, U>,
   
           = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: cannot select `posts::columns::id` from `users::table`
-   --> tests/fail/selectable.rs:224:20
-    |
-LL |         .returning(UserWithEmbeddedPost::as_select())
-    |          --------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
-    |          |
-    |          required by a bound introduced by this call
-    |
-help: the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::id`
-   --> tests/fail/selectable.rs:14:9
-    |
- LL |         id -> Integer,
-    |         ^^
-    = note: `posts::columns::id` is no valid selection for `users::table`
-    = help: the following other types implement trait `SelectableExpression<QS>`:
-              `posts::columns::id` implements `SelectableExpression<Only<posts::table>>`
-              `posts::columns::id` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
-              `posts::columns::id` implements `SelectableExpression<SelectStatement<...>>`
-              `posts::columns::id` implements `SelectableExpression<posts::table>`
-              `posts::columns::id` implements `SelectableExpression<Join<Left, Right, Inner>>`
-              `posts::columns::id` implements `SelectableExpression<Join<Left, Right, LeftOuter>>`
-              `posts::columns::id` implements `SelectableExpression<query_source::joins::JoinOn<Join, On>>`
-    = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<users::table>`
-    = note: 2 redundant requirements hidden
-    = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<users::table>`
-note: required by a bound in `DeleteStatement::<T, U>::returning`
-   --> DIESEL/diesel/diesel/src/query_builder/delete_statement/mod.rs
-    |
-LL |     pub fn returning<E>(self, returns: E) -> DeleteStatement<T, U, ReturningClause<E>>
-    |            --------- required by a bound in this associated function
-LL |     where
-LL |         E: SelectableExpression<T>,
-    |            ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `DeleteStatement::<T, U>::returning`
- 
-        = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: cannot select `posts::columns::title` from `users::table`
-   --> tests/fail/selectable.rs:224:20
-    |
-LL |         .returning(UserWithEmbeddedPost::as_select())
-    |          --------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
-    |          |
-    |          required by a bound introduced by this call
-    |
-help: the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::title`
-   --> tests/fail/selectable.rs:15:9
-    |
- LL |         title -> Text,
-    |         ^^^^^
-    = note: `posts::columns::title` is no valid selection for `users::table`
-    = help: the following other types implement trait `SelectableExpression<QS>`:
-              `posts::columns::title` implements `SelectableExpression<Only<posts::table>>`
-              `posts::columns::title` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
-              `posts::columns::title` implements `SelectableExpression<SelectStatement<...>>`
-              `posts::columns::title` implements `SelectableExpression<posts::table>`
-              `posts::columns::title` implements `SelectableExpression<Join<Left, Right, Inner>>`
-              `posts::columns::title` implements `SelectableExpression<Join<Left, Right, LeftOuter>>`
-              `posts::columns::title` implements `SelectableExpression<query_source::joins::JoinOn<Join, On>>`
-    = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<users::table>`
-    = note: 2 redundant requirements hidden
-    = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<users::table>`
-note: required by a bound in `DeleteStatement::<T, U>::returning`
-   --> DIESEL/diesel/diesel/src/query_builder/delete_statement/mod.rs
-    |
-LL |     pub fn returning<E>(self, returns: E) -> DeleteStatement<T, U, ReturningClause<E>>
-    |            --------- required by a bound in this associated function
-LL |     where
-LL |         E: SelectableExpression<T>,
-    |            ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `DeleteStatement::<T, U>::returning`
- 
-        = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
-   --> tests/fail/selectable.rs:224:20
-    |
-LL |         .returning(UserWithEmbeddedPost::as_select())
-    |          --------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Once`, found `Never`
-    |          |
-    |          required by a bound introduced by this call
-    |
-note: required for `posts::columns::id` to implement `AppearsOnTable<users::table>`
-   --> tests/fail/selectable.rs:14:9
-    |
- LL |         id -> Integer,
-    |         ^^
-    = note: associated types for the current `impl` cannot be restricted in `where` clauses
-    = note: 1 redundant requirement hidden
-    = note: required for `(posts::columns::id, posts::columns::title)` to implement `AppearsOnTable<users::table>`
-    = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<users::table>`
-    = note: 2 redundant requirements hidden
-    = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<users::table>`
-note: required by a bound in `DeleteStatement::<T, U>::returning`
-   --> DIESEL/diesel/diesel/src/query_builder/delete_statement/mod.rs
-    |
-LL |     pub fn returning<E>(self, returns: E) -> DeleteStatement<T, U, ReturningClause<E>>
-    |            --------- required by a bound in this associated function
-LL |     where
-LL |         E: SelectableExpression<T>,
-    |            ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `DeleteStatement::<T, U>::returning`
-    = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: cannot select `posts::columns::id` from `users::table`
-    --> tests/fail/selectable.rs:228:15
+error[E0277]: the trait bound `ReturningQuerySource<..., ...>: TableNotEqual<...>` is not satisfied
+    --> tests/fail/selectable.rs:221:15
      |
  LL |         .load(&mut conn)
      |          ---- ^^^^^^^^^ unsatisfied trait bound
      |          |
      |          required by a bound introduced by this call
      |
-help: the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::id`
+     = help: the trait `TableNotEqual<posts::table>` is not implemented for `ReturningQuerySource<UpdateStmt, table>`
+     = note: double check that `posts::table` and `ReturningQuerySource<UpdateStmt, table>` appear in the same `allow_tables_to_appear_in_same_query!` 
+             call if both are tables
+help: the following other types implement trait `TableNotEqual<T>`
+    --> tests/fail/selectable.rs:23:1
+     |
+  LL | allow_tables_to_appear_in_same_query!(users, posts);
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     | |
+     | `posts::table` implements `TableNotEqual<users::table>`
+     | `users::table` implements `TableNotEqual<posts::table>`
+     |
+    ::: DIESEL/diesel/diesel/src/pg/metadata_lookup.rs
+     |
+ LL | allow_tables_to_appear_in_same_query!(pg_type, pg_namespace);
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     | |
+     | `pg::metadata_lookup::pg_namespace::table` implements `TableNotEqual<pg::metadata_lookup::pg_type::table>`
+     | `pg::metadata_lookup::pg_type::table` implements `TableNotEqual<pg::metadata_lookup::pg_namespace::table>`
+     = note: required for `ReturningQuerySource<UpdateStmt, table>` to implement `AppearsInFromClause<posts::table>`
+note: required for `posts::columns::id` to implement `AppearsOnTable<ReturningQuerySource<..., ...>>`
     --> tests/fail/selectable.rs:14:9
      |
   LL |         id -> Integer,
      |         ^^
-     = note: `posts::columns::id` is no valid selection for `users::table`
+     = note: 1 redundant requirement hidden
+     = note: required for `(posts::columns::id, posts::columns::title)` to implement `AppearsOnTable<ReturningQuerySource<..., ...>>`
+     = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
+     = note: 2 redundant requirements hidden
+     = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
+     = note: required for `UpdateStatement<table, NoWhereClause, ..., ...>` to implement `Query`
+     = note: required for `UpdateStatement<table, NoWhereClause, ..., ...>` to implement `LoadQuery<'_, _, UserWithEmbeddedPost>`
+note: required by a bound in `load`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+          = note: this error originates in the macro `allow_tables_to_appear_in_same_query` which comes from the expansion of the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `ReturningQuerySource<UpdateStmt, table>: Table` is not satisfied
+    --> tests/fail/selectable.rs:221:15
+     |
+ LL |         .load(&mut conn)
+     |          ---- ^^^^^^^^^ the trait `Table` is not implemented for `ReturningQuerySource<UpdateStmt, table>`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = help: the following other types implement trait `Table`:
+               Only<S>
+               Tablesample<S, TSM>
+               pg::metadata_lookup::pg_namespace::table
+               pg::metadata_lookup::pg_type::table
+               posts::table
+               users::table
+     = note: required for `ReturningQuerySource<UpdateStmt, table>` to implement `QueryRelation`
+     = note: required for `ReturningQuerySource<UpdateStmt, table>` to implement `AppearsInFromClause<posts::table>`
+note: required for `posts::columns::id` to implement `AppearsOnTable<ReturningQuerySource<..., ...>>`
+    --> tests/fail/selectable.rs:14:9
+     |
+  LL |         id -> Integer,
+     |         ^^
+     = note: 1 redundant requirement hidden
+     = note: required for `(posts::columns::id, posts::columns::title)` to implement `AppearsOnTable<ReturningQuerySource<..., ...>>`
+     = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
+     = note: 2 redundant requirements hidden
+     = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
+     = note: required for `UpdateStatement<table, NoWhereClause, ..., ...>` to implement `Query`
+     = note: required for `UpdateStatement<table, NoWhereClause, ..., ...>` to implement `LoadQuery<'_, _, UserWithEmbeddedPost>`
+note: required by a bound in `load`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+          = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: cannot select `posts::columns::id` from `ReturningQuerySource<DeleteStmt, table>`
+   --> tests/fail/selectable.rs:232:20
+    |
+LL |         .returning(UserWithEmbeddedPost::as_select())
+    |          --------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+    |          |
+    |          required by a bound introduced by this call
+    |
+help: the trait `SelectableExpression<diesel::query_builder::returning::returning_query_source::ReturningQuerySource<diesel::query_builder::returning::returning_query_source::DeleteStmt, users::table>>` is not implemented for `posts::columns::id`
+   --> tests/fail/selectable.rs:14:9
+    |
+ LL |         id -> Integer,
+    |         ^^
+    = note: `posts::columns::id` is no valid selection for `ReturningQuerySource<DeleteStmt, table>`
+    = help: the following other types implement trait `SelectableExpression<QS>`:
+              `posts::columns::id` implements `SelectableExpression<Only<posts::table>>`
+              `posts::columns::id` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
+              `posts::columns::id` implements `SelectableExpression<ReturningQuerySource<..., ...>>`
+              `posts::columns::id` implements `SelectableExpression<SelectStatement<...>>`
+              `posts::columns::id` implements `SelectableExpression<posts::table>`
+              `posts::columns::id` implements `SelectableExpression<Join<Left, Right, Inner>>`
+              `posts::columns::id` implements `SelectableExpression<Join<Left, Right, LeftOuter>>`
+              `posts::columns::id` implements `SelectableExpression<query_source::joins::JoinOn<Join, On>>`
+    = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
+    = note: 2 redundant requirements hidden
+    = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
+    = note: required for `DeleteStatement<table, NoWhereClause, ...>` to implement `Query`
+note: required by a bound in `DeleteStatement::<T, U>::returning`
+   --> DIESEL/diesel/diesel/src/query_builder/delete_statement/mod.rs
+    |
+LL |     pub fn returning<E>(self, returns: E) -> DeleteStatement<T, U, ReturningClause<E>>
+    |            --------- required by a bound in this associated function
+LL |     where
+LL |         DeleteStatement<T, U, ReturningClause<E>>: Query,
+    |                                                    ^^^^^ required by this bound in `DeleteStatement::<T, U>::returning`
+ 
+        = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: cannot select `posts::columns::title` from `ReturningQuerySource<DeleteStmt, table>`
+   --> tests/fail/selectable.rs:232:20
+    |
+LL |         .returning(UserWithEmbeddedPost::as_select())
+    |          --------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+    |          |
+    |          required by a bound introduced by this call
+    |
+help: the trait `SelectableExpression<diesel::query_builder::returning::returning_query_source::ReturningQuerySource<diesel::query_builder::returning::returning_query_source::DeleteStmt, users::table>>` is not implemented for `posts::columns::title`
+   --> tests/fail/selectable.rs:15:9
+    |
+ LL |         title -> Text,
+    |         ^^^^^
+    = note: `posts::columns::title` is no valid selection for `ReturningQuerySource<DeleteStmt, table>`
+    = help: the following other types implement trait `SelectableExpression<QS>`:
+              `posts::columns::title` implements `SelectableExpression<Only<posts::table>>`
+              `posts::columns::title` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
+              `posts::columns::title` implements `SelectableExpression<ReturningQuerySource<..., ...>>`
+              `posts::columns::title` implements `SelectableExpression<SelectStatement<...>>`
+              `posts::columns::title` implements `SelectableExpression<posts::table>`
+              `posts::columns::title` implements `SelectableExpression<Join<Left, Right, Inner>>`
+              `posts::columns::title` implements `SelectableExpression<Join<Left, Right, LeftOuter>>`
+              `posts::columns::title` implements `SelectableExpression<query_source::joins::JoinOn<Join, On>>`
+    = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
+    = note: 2 redundant requirements hidden
+    = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
+    = note: required for `DeleteStatement<table, NoWhereClause, ...>` to implement `Query`
+note: required by a bound in `DeleteStatement::<T, U>::returning`
+   --> DIESEL/diesel/diesel/src/query_builder/delete_statement/mod.rs
+    |
+LL |     pub fn returning<E>(self, returns: E) -> DeleteStatement<T, U, ReturningClause<E>>
+    |            --------- required by a bound in this associated function
+LL |     where
+LL |         DeleteStatement<T, U, ReturningClause<E>>: Query,
+    |                                                    ^^^^^ required by this bound in `DeleteStatement::<T, U>::returning`
+ 
+        = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0271]: type mismatch resolving `<ReturningQuerySource<..., ...> as AppearsInFromClause<...>>::Count == Once`
+   --> tests/fail/selectable.rs:232:20
+    |
+LL |         .returning(UserWithEmbeddedPost::as_select())
+    |          --------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Once`, found `Never`
+    |          |
+    |          required by a bound introduced by this call
+    |
+note: required for `posts::columns::id` to implement `AppearsOnTable<ReturningQuerySource<..., ...>>`
+   --> tests/fail/selectable.rs:14:9
+    |
+ LL |         id -> Integer,
+    |         ^^
+    = note: associated types for the current `impl` cannot be restricted in `where` clauses
+    = note: 1 redundant requirement hidden
+    = note: required for `(posts::columns::id, posts::columns::title)` to implement `AppearsOnTable<ReturningQuerySource<..., ...>>`
+    = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
+    = note: 2 redundant requirements hidden
+    = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
+    = note: required for `DeleteStatement<table, NoWhereClause, ...>` to implement `Query`
+note: required by a bound in `DeleteStatement::<T, U>::returning`
+   --> DIESEL/diesel/diesel/src/query_builder/delete_statement/mod.rs
+    |
+LL |     pub fn returning<E>(self, returns: E) -> DeleteStatement<T, U, ReturningClause<E>>
+    |            --------- required by a bound in this associated function
+LL |     where
+LL |         DeleteStatement<T, U, ReturningClause<E>>: Query,
+    |                                                    ^^^^^ required by this bound in `DeleteStatement::<T, U>::returning`
+ 
+        = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `ReturningQuerySource<..., ...>: TableNotEqual<...>` is not satisfied
+   --> tests/fail/selectable.rs:232:20
+    |
+LL |         .returning(UserWithEmbeddedPost::as_select())
+    |          --------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+    |          |
+    |          required by a bound introduced by this call
+    |
+    = help: the trait `TableNotEqual<posts::table>` is not implemented for `ReturningQuerySource<DeleteStmt, table>`
+    = note: double check that `posts::table` and `ReturningQuerySource<DeleteStmt, table>` appear in the same `allow_tables_to_appear_in_same_query!` 
+            call if both are tables
+help: the following other types implement trait `TableNotEqual<T>`
+   --> tests/fail/selectable.rs:23:1
+    |
+ LL | allow_tables_to_appear_in_same_query!(users, posts);
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    | |
+    | `posts::table` implements `TableNotEqual<users::table>`
+    | `users::table` implements `TableNotEqual<posts::table>`
+    |
+   ::: DIESEL/diesel/diesel/src/pg/metadata_lookup.rs
+    |
+LL | allow_tables_to_appear_in_same_query!(pg_type, pg_namespace);
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    | |
+    | `pg::metadata_lookup::pg_namespace::table` implements `TableNotEqual<pg::metadata_lookup::pg_type::table>`
+    | `pg::metadata_lookup::pg_type::table` implements `TableNotEqual<pg::metadata_lookup::pg_namespace::table>`
+    = note: required for `ReturningQuerySource<DeleteStmt, table>` to implement `AppearsInFromClause<posts::table>`
+note: required for `posts::columns::id` to implement `AppearsOnTable<ReturningQuerySource<..., ...>>`
+   --> tests/fail/selectable.rs:14:9
+    |
+ LL |         id -> Integer,
+    |         ^^
+    = note: 1 redundant requirement hidden
+    = note: required for `(posts::columns::id, posts::columns::title)` to implement `AppearsOnTable<ReturningQuerySource<..., ...>>`
+    = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
+    = note: 2 redundant requirements hidden
+    = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
+    = note: required for `DeleteStatement<table, NoWhereClause, ...>` to implement `Query`
+note: required by a bound in `DeleteStatement::<T, U>::returning`
+   --> DIESEL/diesel/diesel/src/query_builder/delete_statement/mod.rs
+    |
+LL |     pub fn returning<E>(self, returns: E) -> DeleteStatement<T, U, ReturningClause<E>>
+    |            --------- required by a bound in this associated function
+LL |     where
+LL |         DeleteStatement<T, U, ReturningClause<E>>: Query,
+    |                                                    ^^^^^ required by this bound in `DeleteStatement::<T, U>::returning`
+ 
+        = note: this error originates in the macro `allow_tables_to_appear_in_same_query` which comes from the expansion of the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `ReturningQuerySource<DeleteStmt, table>: Table` is not satisfied
+   --> tests/fail/selectable.rs:232:20
+    |
+LL |         .returning(UserWithEmbeddedPost::as_select())
+    |          --------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Table` is not implemented for `ReturningQuerySource<DeleteStmt, table>`
+    |          |
+    |          required by a bound introduced by this call
+    |
+    = help: the following other types implement trait `Table`:
+              Only<S>
+              Tablesample<S, TSM>
+              pg::metadata_lookup::pg_namespace::table
+              pg::metadata_lookup::pg_type::table
+              posts::table
+              users::table
+    = note: required for `ReturningQuerySource<DeleteStmt, table>` to implement `QueryRelation`
+    = note: required for `ReturningQuerySource<DeleteStmt, table>` to implement `AppearsInFromClause<posts::table>`
+note: required for `posts::columns::id` to implement `AppearsOnTable<ReturningQuerySource<..., ...>>`
+   --> tests/fail/selectable.rs:14:9
+    |
+ LL |         id -> Integer,
+    |         ^^
+    = note: 1 redundant requirement hidden
+    = note: required for `(posts::columns::id, posts::columns::title)` to implement `AppearsOnTable<ReturningQuerySource<..., ...>>`
+    = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
+    = note: 2 redundant requirements hidden
+    = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
+    = note: required for `DeleteStatement<table, NoWhereClause, ...>` to implement `Query`
+note: required by a bound in `DeleteStatement::<T, U>::returning`
+   --> DIESEL/diesel/diesel/src/query_builder/delete_statement/mod.rs
+    |
+LL |     pub fn returning<E>(self, returns: E) -> DeleteStatement<T, U, ReturningClause<E>>
+    |            --------- required by a bound in this associated function
+LL |     where
+LL |         DeleteStatement<T, U, ReturningClause<E>>: Query,
+    |                                                    ^^^^^ required by this bound in `DeleteStatement::<T, U>::returning`
+ 
+        = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: cannot select `posts::columns::id` from `ReturningQuerySource<DeleteStmt, table>`
+    --> tests/fail/selectable.rs:238:15
+     |
+ LL |         .load(&mut conn)
+     |          ---- ^^^^^^^^^ unsatisfied trait bound
+     |          |
+     |          required by a bound introduced by this call
+     |
+help: the trait `SelectableExpression<diesel::query_builder::returning::returning_query_source::ReturningQuerySource<diesel::query_builder::returning::returning_query_source::DeleteStmt, users::table>>` is not implemented for `posts::columns::id`
+    --> tests/fail/selectable.rs:14:9
+     |
+  LL |         id -> Integer,
+     |         ^^
+     = note: `posts::columns::id` is no valid selection for `ReturningQuerySource<DeleteStmt, table>`
      = help: the following other types implement trait `SelectableExpression<QS>`:
                `posts::columns::id` implements `SelectableExpression<Only<posts::table>>`
                `posts::columns::id` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
+               `posts::columns::id` implements `SelectableExpression<ReturningQuerySource<..., ...>>`
                `posts::columns::id` implements `SelectableExpression<SelectStatement<...>>`
                `posts::columns::id` implements `SelectableExpression<posts::table>`
                `posts::columns::id` implements `SelectableExpression<Join<Left, Right, Inner>>`
                `posts::columns::id` implements `SelectableExpression<Join<Left, Right, LeftOuter>>`
                `posts::columns::id` implements `SelectableExpression<query_source::joins::JoinOn<Join, On>>`
-     = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<users::table>`
+     = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
      = note: 2 redundant requirements hidden
-     = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<users::table>`
+     = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
      = note: required for `DeleteStatement<table, NoWhereClause, ...>` to implement `Query`
      = note: required for `DeleteStatement<table, NoWhereClause, ...>` to implement `LoadQuery<'_, _, UserWithEmbeddedPost>`
 note: required by a bound in `load`
@@ -922,31 +1388,32 @@ LL |         Self: LoadQuery<'query, Conn, U>,
   
           = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: cannot select `posts::columns::title` from `users::table`
-    --> tests/fail/selectable.rs:228:15
+error[E0277]: cannot select `posts::columns::title` from `ReturningQuerySource<DeleteStmt, table>`
+    --> tests/fail/selectable.rs:238:15
      |
  LL |         .load(&mut conn)
      |          ---- ^^^^^^^^^ unsatisfied trait bound
      |          |
      |          required by a bound introduced by this call
      |
-help: the trait `SelectableExpression<users::table>` is not implemented for `posts::columns::title`
+help: the trait `SelectableExpression<diesel::query_builder::returning::returning_query_source::ReturningQuerySource<diesel::query_builder::returning::returning_query_source::DeleteStmt, users::table>>` is not implemented for `posts::columns::title`
     --> tests/fail/selectable.rs:15:9
      |
   LL |         title -> Text,
      |         ^^^^^
-     = note: `posts::columns::title` is no valid selection for `users::table`
+     = note: `posts::columns::title` is no valid selection for `ReturningQuerySource<DeleteStmt, table>`
      = help: the following other types implement trait `SelectableExpression<QS>`:
                `posts::columns::title` implements `SelectableExpression<Only<posts::table>>`
                `posts::columns::title` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
+               `posts::columns::title` implements `SelectableExpression<ReturningQuerySource<..., ...>>`
                `posts::columns::title` implements `SelectableExpression<SelectStatement<...>>`
                `posts::columns::title` implements `SelectableExpression<posts::table>`
                `posts::columns::title` implements `SelectableExpression<Join<Left, Right, Inner>>`
                `posts::columns::title` implements `SelectableExpression<Join<Left, Right, LeftOuter>>`
                `posts::columns::title` implements `SelectableExpression<query_source::joins::JoinOn<Join, On>>`
-     = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<users::table>`
+     = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
      = note: 2 redundant requirements hidden
-     = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<users::table>`
+     = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
      = note: required for `DeleteStatement<table, NoWhereClause, ...>` to implement `Query`
      = note: required for `DeleteStatement<table, NoWhereClause, ...>` to implement `LoadQuery<'_, _, UserWithEmbeddedPost>`
 note: required by a bound in `load`
@@ -960,25 +1427,116 @@ LL |         Self: LoadQuery<'query, Conn, U>,
   
           = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
-    --> tests/fail/selectable.rs:228:15
+error[E0271]: type mismatch resolving `<ReturningQuerySource<..., ...> as AppearsInFromClause<...>>::Count == Once`
+    --> tests/fail/selectable.rs:238:15
      |
  LL |         .load(&mut conn)
      |          ---- ^^^^^^^^^ expected `Once`, found `Never`
      |          |
      |          required by a bound introduced by this call
      |
-note: required for `posts::columns::id` to implement `AppearsOnTable<users::table>`
+note: required for `posts::columns::id` to implement `AppearsOnTable<ReturningQuerySource<..., ...>>`
     --> tests/fail/selectable.rs:14:9
      |
   LL |         id -> Integer,
      |         ^^
      = note: associated types for the current `impl` cannot be restricted in `where` clauses
      = note: 1 redundant requirement hidden
-     = note: required for `(posts::columns::id, posts::columns::title)` to implement `AppearsOnTable<users::table>`
-     = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<users::table>`
+     = note: required for `(posts::columns::id, posts::columns::title)` to implement `AppearsOnTable<ReturningQuerySource<..., ...>>`
+     = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
      = note: 2 redundant requirements hidden
-     = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<users::table>`
+     = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
+     = note: required for `DeleteStatement<table, NoWhereClause, ...>` to implement `Query`
+     = note: required for `DeleteStatement<table, NoWhereClause, ...>` to implement `LoadQuery<'_, _, UserWithEmbeddedPost>`
+note: required by a bound in `load`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+          = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `ReturningQuerySource<..., ...>: TableNotEqual<...>` is not satisfied
+    --> tests/fail/selectable.rs:238:15
+     |
+ LL |         .load(&mut conn)
+     |          ---- ^^^^^^^^^ unsatisfied trait bound
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = help: the trait `TableNotEqual<posts::table>` is not implemented for `ReturningQuerySource<DeleteStmt, table>`
+     = note: double check that `posts::table` and `ReturningQuerySource<DeleteStmt, table>` appear in the same `allow_tables_to_appear_in_same_query!` 
+             call if both are tables
+help: the following other types implement trait `TableNotEqual<T>`
+    --> tests/fail/selectable.rs:23:1
+     |
+  LL | allow_tables_to_appear_in_same_query!(users, posts);
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     | |
+     | `posts::table` implements `TableNotEqual<users::table>`
+     | `users::table` implements `TableNotEqual<posts::table>`
+     |
+    ::: DIESEL/diesel/diesel/src/pg/metadata_lookup.rs
+     |
+ LL | allow_tables_to_appear_in_same_query!(pg_type, pg_namespace);
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     | |
+     | `pg::metadata_lookup::pg_namespace::table` implements `TableNotEqual<pg::metadata_lookup::pg_type::table>`
+     | `pg::metadata_lookup::pg_type::table` implements `TableNotEqual<pg::metadata_lookup::pg_namespace::table>`
+     = note: required for `ReturningQuerySource<DeleteStmt, table>` to implement `AppearsInFromClause<posts::table>`
+note: required for `posts::columns::id` to implement `AppearsOnTable<ReturningQuerySource<..., ...>>`
+    --> tests/fail/selectable.rs:14:9
+     |
+  LL |         id -> Integer,
+     |         ^^
+     = note: 1 redundant requirement hidden
+     = note: required for `(posts::columns::id, posts::columns::title)` to implement `AppearsOnTable<ReturningQuerySource<..., ...>>`
+     = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
+     = note: 2 redundant requirements hidden
+     = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
+     = note: required for `DeleteStatement<table, NoWhereClause, ...>` to implement `Query`
+     = note: required for `DeleteStatement<table, NoWhereClause, ...>` to implement `LoadQuery<'_, _, UserWithEmbeddedPost>`
+note: required by a bound in `load`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+          = note: this error originates in the macro `allow_tables_to_appear_in_same_query` which comes from the expansion of the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `ReturningQuerySource<DeleteStmt, table>: Table` is not satisfied
+    --> tests/fail/selectable.rs:238:15
+     |
+ LL |         .load(&mut conn)
+     |          ---- ^^^^^^^^^ the trait `Table` is not implemented for `ReturningQuerySource<DeleteStmt, table>`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = help: the following other types implement trait `Table`:
+               Only<S>
+               Tablesample<S, TSM>
+               pg::metadata_lookup::pg_namespace::table
+               pg::metadata_lookup::pg_type::table
+               posts::table
+               users::table
+     = note: required for `ReturningQuerySource<DeleteStmt, table>` to implement `QueryRelation`
+     = note: required for `ReturningQuerySource<DeleteStmt, table>` to implement `AppearsInFromClause<posts::table>`
+note: required for `posts::columns::id` to implement `AppearsOnTable<ReturningQuerySource<..., ...>>`
+    --> tests/fail/selectable.rs:14:9
+     |
+  LL |         id -> Integer,
+     |         ^^
+     = note: 1 redundant requirement hidden
+     = note: required for `(posts::columns::id, posts::columns::title)` to implement `AppearsOnTable<ReturningQuerySource<..., ...>>`
+     = note: required for `(posts::columns::id, posts::columns::title)` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
+     = note: 2 redundant requirements hidden
+     = note: required for `diesel::expression::select_by::SelectBy<UserWithEmbeddedPost, _>` to implement `SelectableExpression<ReturningQuerySource<..., ...>>`
      = note: required for `DeleteStatement<table, NoWhereClause, ...>` to implement `Query`
      = note: required for `DeleteStatement<table, NoWhereClause, ...>` to implement `LoadQuery<'_, _, UserWithEmbeddedPost>`
 note: required by a bound in `load`
@@ -993,7 +1551,7 @@ LL |         Self: LoadQuery<'query, Conn, U>,
           = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0599]: the function or associated item `as_select` exists for struct `UserWithoutSelectable`, but its trait bounds were not satisfied
-   --> tests/fail/selectable.rs:236:40
+   --> tests/fail/selectable.rs:248:40
     |
  LL | struct UserWithoutSelectable {
     | ---------------------------- function or associated item `as_select` not found for this struct because it doesn't satisfy `UserWithoutSelectable: diesel::Selectable<_>` or `UserWithoutSelectable: diesel::SelectableHelper<_>`
@@ -1018,7 +1576,7 @@ LL | pub trait Selectable<DB: Backend> {
             candidate #1: `diesel::SelectableHelper`
 
 error[E0277]: the trait bound `diesel::expression::select_by::SelectBy<Post, _>: SingleValue` is not satisfied
-    --> tests/fail/selectable.rs:244:32
+    --> tests/fail/selectable.rs:256:32
      |
  LL |         .load::<(i32, String)>(&mut conn)
      |          ----                  ^^^^^^^^^ the trait `SingleValue` is not implemented for `diesel::expression::select_by::SelectBy<Post, _>`
@@ -1048,7 +1606,7 @@ LL |         Self: LoadQuery<'query, Conn, U>,
   
      
 error[E0277]: the trait bound `(i32, String): Queryable<SelectBy<Post, _>, _>` is not satisfied
-    --> tests/fail/selectable.rs:244:32
+    --> tests/fail/selectable.rs:256:32
      |
  LL |         .load::<(i32, String)>(&mut conn)
      |          ----                  ^^^^^^^^^ unsatisfied trait bound
@@ -1080,7 +1638,7 @@ LL |         Self: LoadQuery<'query, Conn, U>,
   
      
 error[E0277]: the trait bound `diesel::expression::select_by::SelectBy<Post, _>: SingleValue` is not satisfied
-    --> tests/fail/selectable.rs:251:32
+    --> tests/fail/selectable.rs:263:32
      |
  LL |         .load::<(i32, String)>(&mut conn)
      |          ----                  ^^^^^^^^^ the trait `SingleValue` is not implemented for `diesel::expression::select_by::SelectBy<Post, _>`
@@ -1110,7 +1668,7 @@ LL |         Self: LoadQuery<'query, Conn, U>,
   
      
 error[E0277]: the trait bound `(i32, String): Queryable<SelectBy<Post, _>, _>` is not satisfied
-    --> tests/fail/selectable.rs:251:32
+    --> tests/fail/selectable.rs:263:32
      |
  LL |         .load::<(i32, String)>(&mut conn)
      |          ----                  ^^^^^^^^^ unsatisfied trait bound
@@ -1142,7 +1700,7 @@ LL |         Self: LoadQuery<'query, Conn, U>,
   
      
 error[E0277]: the trait bound `(SelectBy<Post, _>, Text): CompatibleType<..., _>` is not satisfied
-    --> tests/fail/selectable.rs:257:42
+    --> tests/fail/selectable.rs:269:42
      |
  LL |         .load::<((i32, String), String)>(&mut conn)
      |          ----                            ^^^^^^^^^ unsatisfied trait bound
@@ -1176,7 +1734,7 @@ LL |         Self: LoadQuery<'query, Conn, U>,
   
      
 error[E0277]: the trait bound `diesel::expression::select_by::SelectBy<Post, _>: SingleValue` is not satisfied
-    --> tests/fail/selectable.rs:263:37
+    --> tests/fail/selectable.rs:275:37
      |
  LL |         .load::<(i32, String, i32)>(&mut conn)
      |          ----                       ^^^^^^^^^ the trait `SingleValue` is not implemented for `diesel::expression::select_by::SelectBy<Post, _>`
@@ -1206,7 +1764,7 @@ LL |         Self: LoadQuery<'query, Conn, U>,
   
      
 error[E0277]: the trait bound `(i32, String, i32): Queryable<SelectBy<..., _>, _>` is not satisfied
-    --> tests/fail/selectable.rs:263:37
+    --> tests/fail/selectable.rs:275:37
      |
  LL |         .load::<(i32, String, i32)>(&mut conn)
      |          ----                       ^^^^^^^^^ unsatisfied trait bound
@@ -1238,7 +1796,7 @@ LL |         Self: LoadQuery<'query, Conn, U>,
   
      
 error[E0271]: type mismatch resolving `<SqliteConnection as Connection>::Backend == Pg`
-    --> tests/fail/selectable.rs:274:15
+    --> tests/fail/selectable.rs:286:15
      |
  LL |         .load(&mut conn)
      |          ---- ^^^^^^^^^ expected `Pg`, found `Sqlite`

--- a/diesel_compile_tests/tests/fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.stderr
+++ b/diesel_compile_tests/tests/fail/selecting_multiple_columns_requires_all_must_be_from_selectable_table.stderr
@@ -13,6 +13,7 @@ LL |         id -> Integer,
    = help: the following other types implement trait `SelectableExpression<QS>`:
              `posts::columns::id` implements `SelectableExpression<Only<posts::table>>`
              `posts::columns::id` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
+             `posts::columns::id` implements `SelectableExpression<ReturningQuerySource<..., ...>>`
              `posts::columns::id` implements `SelectableExpression<SelectStatement<...>>`
              `posts::columns::id` implements `SelectableExpression<posts::table>`
              `posts::columns::id` implements `SelectableExpression<Join<Left, Right, Inner>>`
@@ -38,6 +39,7 @@ LL |         user_id -> Integer,
    = help: the following other types implement trait `SelectableExpression<QS>`:
              `posts::columns::user_id` implements `SelectableExpression<Only<posts::table>>`
              `posts::columns::user_id` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
+             `posts::columns::user_id` implements `SelectableExpression<ReturningQuerySource<..., ...>>`
              `posts::columns::user_id` implements `SelectableExpression<SelectStatement<...>>`
              `posts::columns::user_id` implements `SelectableExpression<posts::table>`
              `posts::columns::user_id` implements `SelectableExpression<Join<Left, Right, Inner>>`
@@ -82,6 +84,7 @@ LL |         id -> Integer,
    = help: the following other types implement trait `SelectableExpression<QS>`:
              `posts::columns::id` implements `SelectableExpression<Only<posts::table>>`
              `posts::columns::id` implements `SelectableExpression<Tablesample<posts::table, TSM>>`
+             `posts::columns::id` implements `SelectableExpression<ReturningQuerySource<..., ...>>`
              `posts::columns::id` implements `SelectableExpression<SelectStatement<...>>`
              `posts::columns::id` implements `SelectableExpression<posts::table>`
              `posts::columns::id` implements `SelectableExpression<Join<Left, Right, Inner>>`

--- a/diesel_compile_tests/tests/fail/update_statement_does_not_support_returning_methods_on_sqlite.stderr
+++ b/diesel_compile_tests/tests/fail/update_statement_does_not_support_returning_methods_on_sqlite.stderr
@@ -10,13 +10,13 @@ error[E0277]: `ReturningClause<(id, name)>` is no valid SQL fragment for the `Sq
      = note: this usually means that the `Sqlite` database system does not support 
              this SQL syntax
 help: the following other types implement trait `QueryFragment<DB, SP>`
-    --> DIESEL/diesel/diesel/src/query_builder/returning_clause.rs
+    --> DIESEL/diesel/diesel/src/query_builder/returning/returning_clause.rs
      |
   LL | / impl<Expr, DB> QueryFragment<DB> for ReturningClause<Expr>
   LL | | where
   LL | |     DB: Backend,
   LL | |     Self: QueryFragment<DB, DB::ReturningClause>,
-     | |_________________________________________________^ `diesel::query_builder::returning_clause::ReturningClause<Expr>` implements `QueryFragment<DB>`
+     | |_________________________________________________^ `ReturningClause<Expr>` implements `QueryFragment<DB>`
 ...
   LL | / impl<Expr, DB>
   LL | |     QueryFragment<DB, crate::backend::sql_dialect::returning_clause::PgLikeReturningClause>
@@ -25,7 +25,7 @@ help: the following other types implement trait `QueryFragment<DB, SP>`
 ...    |
   LL | |     >,
   LL | |     Expr: QueryFragment<DB>,
-     | |____________________________^ `diesel::query_builder::returning_clause::ReturningClause<Expr>` implements `QueryFragment<DB, PgLikeReturningClause>`
+     | |____________________________^ `ReturningClause<Expr>` implements `QueryFragment<DB, PgLikeReturningClause>`
      |
     ::: DIESEL/diesel/diesel/src/sqlite/query_builder/returning.rs
      |
@@ -33,7 +33,7 @@ help: the following other types implement trait `QueryFragment<DB, SP>`
    LL | | where
    LL | |     DB: Backend<ReturningClause = SqliteReturningClause>,
   LL | |     Expr: QueryFragment<DB>,
-     | |____________________________^ `diesel::query_builder::returning_clause::ReturningClause<Expr>` implements `QueryFragment<DB, sqlite::backend::SqliteReturningClause>`
+     | |____________________________^ `ReturningClause<Expr>` implements `QueryFragment<DB, sqlite::backend::SqliteReturningClause>`
      = note: required for `ReturningClause<(id, name)>` to implement `QueryFragment<Sqlite>`
      = note: 1 redundant requirement hidden
      = note: required for `UpdateStatement<table, WhereClause<...>, ..., ...>` to implement `QueryFragment<Sqlite>`
@@ -60,13 +60,13 @@ error[E0277]: `ReturningClause<name>` is no valid SQL fragment for the `Sqlite` 
      = note: this usually means that the `Sqlite` database system does not support 
              this SQL syntax
 help: the following other types implement trait `QueryFragment<DB, SP>`
-    --> DIESEL/diesel/diesel/src/query_builder/returning_clause.rs
+    --> DIESEL/diesel/diesel/src/query_builder/returning/returning_clause.rs
      |
   LL | / impl<Expr, DB> QueryFragment<DB> for ReturningClause<Expr>
   LL | | where
   LL | |     DB: Backend,
   LL | |     Self: QueryFragment<DB, DB::ReturningClause>,
-     | |_________________________________________________^ `diesel::query_builder::returning_clause::ReturningClause<Expr>` implements `QueryFragment<DB>`
+     | |_________________________________________________^ `ReturningClause<Expr>` implements `QueryFragment<DB>`
 ...
   LL | / impl<Expr, DB>
   LL | |     QueryFragment<DB, crate::backend::sql_dialect::returning_clause::PgLikeReturningClause>
@@ -75,7 +75,7 @@ help: the following other types implement trait `QueryFragment<DB, SP>`
 ...    |
   LL | |     >,
   LL | |     Expr: QueryFragment<DB>,
-     | |____________________________^ `diesel::query_builder::returning_clause::ReturningClause<Expr>` implements `QueryFragment<DB, PgLikeReturningClause>`
+     | |____________________________^ `ReturningClause<Expr>` implements `QueryFragment<DB, PgLikeReturningClause>`
      |
     ::: DIESEL/diesel/diesel/src/sqlite/query_builder/returning.rs
      |
@@ -83,7 +83,7 @@ help: the following other types implement trait `QueryFragment<DB, SP>`
    LL | | where
    LL | |     DB: Backend<ReturningClause = SqliteReturningClause>,
   LL | |     Expr: QueryFragment<DB>,
-     | |____________________________^ `diesel::query_builder::returning_clause::ReturningClause<Expr>` implements `QueryFragment<DB, sqlite::backend::SqliteReturningClause>`
+     | |____________________________^ `ReturningClause<Expr>` implements `QueryFragment<DB, sqlite::backend::SqliteReturningClause>`
      = note: required for `ReturningClause<name>` to implement `QueryFragment<Sqlite>`
      = note: 1 redundant requirement hidden
      = note: required for `UpdateStatement<table, WhereClause<...>, ..., ...>` to implement `QueryFragment<Sqlite>`

--- a/diesel_derives/src/table.rs
+++ b/diesel_derives/src/table.rs
@@ -1,7 +1,6 @@
 use diesel_table_macro_syntax::{ColumnDef, TableDecl};
 use proc_macro2::{Span, TokenStream};
-use syn::Ident;
-use syn::parse_quote;
+use syn::{Ident, parse_quote};
 
 const DEFAULT_PRIMARY_KEY_NAME: &str = "id";
 
@@ -888,6 +887,16 @@ fn expand_column_def(
         }
 
         impl diesel::SelectableExpression<super::#query_source_ident> for #column_name {
+        }
+
+        impl<__StmtKind>
+            diesel::SelectableExpression<
+                diesel::internal::table_macro::returning::ReturningQuerySource<
+                    __StmtKind,
+                    super::#query_source_ident,
+                >,
+            > for #column_name
+        {
         }
 
         impl<QS> diesel::AppearsOnTable<QS> for #column_name where

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__table_1 (postgres).snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__table_1 (postgres).snap
@@ -559,6 +559,14 @@ pub mod users {
             }
         }
         impl diesel::SelectableExpression<super::table> for id {}
+        impl<
+            __StmtKind,
+        > diesel::SelectableExpression<
+            diesel::internal::table_macro::returning::ReturningQuerySource<
+                __StmtKind,
+                super::table,
+            >,
+        > for id {}
         impl<QS> diesel::AppearsOnTable<QS> for id
         where
             QS: diesel::query_source::AppearsInFromClause<
@@ -805,6 +813,14 @@ pub mod users {
             }
         }
         impl diesel::SelectableExpression<super::table> for name {}
+        impl<
+            __StmtKind,
+        > diesel::SelectableExpression<
+            diesel::internal::table_macro::returning::ReturningQuerySource<
+                __StmtKind,
+                super::table,
+            >,
+        > for name {}
         impl<QS> diesel::AppearsOnTable<QS> for name
         where
             QS: diesel::query_source::AppearsInFromClause<

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__table_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__table_1.snap
@@ -497,6 +497,14 @@ pub mod users {
             }
         }
         impl diesel::SelectableExpression<super::table> for id {}
+        impl<
+            __StmtKind,
+        > diesel::SelectableExpression<
+            diesel::internal::table_macro::returning::ReturningQuerySource<
+                __StmtKind,
+                super::table,
+            >,
+        > for id {}
         impl<QS> diesel::AppearsOnTable<QS> for id
         where
             QS: diesel::query_source::AppearsInFromClause<
@@ -718,6 +726,14 @@ pub mod users {
             }
         }
         impl diesel::SelectableExpression<super::table> for name {}
+        impl<
+            __StmtKind,
+        > diesel::SelectableExpression<
+            diesel::internal::table_macro::returning::ReturningQuerySource<
+                __StmtKind,
+                super::table,
+            >,
+        > for name {}
         impl<QS> diesel::AppearsOnTable<QS> for name
         where
             QS: diesel::query_source::AppearsInFromClause<

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__view_1 (postgres).snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__view_1 (postgres).snap
@@ -455,6 +455,14 @@ pub mod view {
             }
         }
         impl diesel::SelectableExpression<super::view> for id {}
+        impl<
+            __StmtKind,
+        > diesel::SelectableExpression<
+            diesel::internal::table_macro::returning::ReturningQuerySource<
+                __StmtKind,
+                super::view,
+            >,
+        > for id {}
         impl<QS> diesel::AppearsOnTable<QS> for id
         where
             QS: diesel::query_source::AppearsInFromClause<
@@ -676,6 +684,14 @@ pub mod view {
             }
         }
         impl diesel::SelectableExpression<super::view> for name {}
+        impl<
+            __StmtKind,
+        > diesel::SelectableExpression<
+            diesel::internal::table_macro::returning::ReturningQuerySource<
+                __StmtKind,
+                super::view,
+            >,
+        > for name {}
         impl<QS> diesel::AppearsOnTable<QS> for name
         where
             QS: diesel::query_source::AppearsInFromClause<

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__view_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__view_1.snap
@@ -455,6 +455,14 @@ pub mod view {
             }
         }
         impl diesel::SelectableExpression<super::view> for id {}
+        impl<
+            __StmtKind,
+        > diesel::SelectableExpression<
+            diesel::internal::table_macro::returning::ReturningQuerySource<
+                __StmtKind,
+                super::view,
+            >,
+        > for id {}
         impl<QS> diesel::AppearsOnTable<QS> for id
         where
             QS: diesel::query_source::AppearsInFromClause<
@@ -676,6 +684,14 @@ pub mod view {
             }
         }
         impl diesel::SelectableExpression<super::view> for name {}
+        impl<
+            __StmtKind,
+        > diesel::SelectableExpression<
+            diesel::internal::table_macro::returning::ReturningQuerySource<
+                __StmtKind,
+                super::view,
+            >,
+        > for name {}
         impl<QS> diesel::AppearsOnTable<QS> for name
         where
             QS: diesel::query_source::AppearsInFromClause<

--- a/diesel_derives/tests/auto_type.rs
+++ b/diesel_derives/tests/auto_type.rs
@@ -394,6 +394,12 @@ fn test_pg_timestamp_expression_methods() -> _ {
     pg_extras::timestamp.at_time_zone(s)
 }
 
+#[cfg(feature = "postgres")]
+#[auto_type]
+fn test_pg_returning_old() -> _ {
+    diesel::pg::returning::old(users::id)
+}
+
 #[cfg(feature = "sqlite")]
 #[auto_type]
 fn test_sqlite_expression_methods() -> _ {

--- a/diesel_tests/tests/insert.rs
+++ b/diesel_tests/tests/insert.rs
@@ -1260,3 +1260,106 @@ fn batch_upsert_with_returning() {
 
     assert_eq!(inserted_users, expected_users);
 }
+
+#[diesel_test_helper::test]
+#[cfg(feature = "postgres")]
+fn returning_old_column_in_insert_on_conflict_do_update() {
+    use crate::schema::users::dsl::*;
+    use diesel::pg::returning::old;
+
+    let connection = &mut connection_with_sean_and_tess_in_users_table();
+
+    if !pg_server_supports_returning_old(connection) {
+        return;
+    }
+
+    use diesel::ExpressionMethods;
+
+    let sean = find_user_by_name("Sean", connection);
+
+    // Conflict path: row already exists, so `old.name` is `Some(...)`.
+    // `old(col)` must be wrapped in `.nullable()` in `ON CONFLICT ... DO UPDATE`
+    // because rows that were freshly inserted (rather than updated) come back
+    // with `old.col = NULL`. Forgetting `.nullable()` is a compile-time error.
+    let (was, now): (Option<String>, String) = insert_into(users)
+        .values((id.eq(sean.id), name.eq("temp")))
+        .on_conflict(id)
+        .do_update()
+        .set(name.eq("Renamed"))
+        .returning((old(name).nullable(), name))
+        .get_result(connection)
+        .unwrap();
+    assert_eq!(Some("Sean".to_string()), was);
+    assert_eq!("Renamed", now);
+
+    // Non-conflict path: row is being inserted, so `old.name` is `None`.
+    let (was, now): (Option<String>, String) = insert_into(users)
+        .values(name.eq("Brand New"))
+        .on_conflict(id)
+        .do_update()
+        .set(name.eq("Should not happen"))
+        .returning((old(name).nullable(), name))
+        .get_result(connection)
+        .unwrap();
+    assert_eq!(None, was);
+    assert_eq!("Brand New", now);
+}
+
+#[diesel_test_helper::test]
+#[cfg(feature = "postgres")]
+fn returning_old_column_in_insert_on_conflict_do_update_via_selectable() {
+    use crate::schema::users;
+
+    let connection = &mut connection_with_sean_and_tess_in_users_table();
+
+    if !pg_server_supports_returning_old(connection) {
+        return;
+    }
+
+    // In `INSERT ... ON CONFLICT ... DO UPDATE`, freshly inserted rows have no
+    // pre-existing values, so `old(col)` must be wrapped in `.nullable()` —
+    // and the `Selectable` field must therefore be an `Option<...>`.
+    #[derive(Queryable, Selectable, PartialEq, Debug)]
+    #[diesel(table_name = users)]
+    struct UpsertOldNew {
+        #[diesel(select_expression = diesel::pg::returning::old(users::name).nullable())]
+        was: Option<String>,
+        name: String,
+    }
+
+    let sean = find_user_by_name("Sean", connection);
+
+    // Conflict path: row already exists, so `old.name` is `Some(...)`.
+    let row: UpsertOldNew = insert_into(users::table)
+        .values((users::id.eq(sean.id), users::name.eq("temp")))
+        .on_conflict(users::id)
+        .do_update()
+        .set(users::name.eq("Renamed"))
+        .returning(UpsertOldNew::as_select())
+        .get_result(connection)
+        .unwrap();
+    assert_eq!(
+        UpsertOldNew {
+            was: Some("Sean".to_string()),
+            name: "Renamed".to_string(),
+        },
+        row,
+    );
+
+    // Non-conflict path: row is being inserted, so `old.name` is `None`.
+    let row: UpsertOldNew = insert_into(users::table)
+        .values(users::name.eq("Brand New"))
+        .on_conflict(users::id)
+        .do_update()
+        .set(users::name.eq("Should not happen"))
+        .returning(UpsertOldNew::as_select())
+        .get_result(connection)
+        .unwrap();
+    assert_eq!(
+        UpsertOldNew {
+            was: None,
+            name: "Brand New".to_string(),
+        },
+        row,
+    );
+}

--- a/diesel_tests/tests/schema/mod.rs
+++ b/diesel_tests/tests/schema/mod.rs
@@ -1,4 +1,5 @@
-use diesel::{associations::HasTable, *};
+use diesel::associations::HasTable;
+use diesel::*;
 
 #[cfg(feature = "postgres")]
 mod custom_schemas;
@@ -514,4 +515,19 @@ pub fn find_user_by_name(name: &str, connection: &mut TestConnection) -> User {
         .filter(users::name.eq(name))
         .first(connection)
         .unwrap()
+}
+
+/// `RETURNING old.col` was introduced in PostgreSQL 18; on older servers
+/// the query will be rejected at execution time, so we just skip.
+///
+/// Returns `true` if the connected PostgreSQL server is version 18 or newer.
+/// On non-postgres backends this always returns `false`.
+#[cfg(feature = "postgres")]
+pub fn pg_server_supports_returning_old(connection: &mut TestConnection) -> bool {
+    diesel::dsl::sql::<diesel::sql_types::Integer>(
+        "SELECT current_setting('server_version_num')::int",
+    )
+    .get_result::<i32>(connection)
+    .expect("Failed to get PostgreSQL server version")
+        >= 180000
 }

--- a/diesel_tests/tests/update.rs
+++ b/diesel_tests/tests/update.rs
@@ -669,3 +669,66 @@ fn update_array_slice_to_expression() {
 
     assert_eq!(Ok(expected_data), data);
 }
+
+#[diesel_test_helper::test]
+#[cfg(feature = "postgres")]
+fn returning_old_column_in_update() {
+    use crate::schema::users::dsl::*;
+    use diesel::pg::returning::old;
+
+    let connection = &mut connection_with_sean_and_tess_in_users_table();
+
+    if !pg_server_supports_returning_old(connection) {
+        return;
+    }
+
+    let sean = find_user_by_name("Sean", connection);
+
+    let (was, now): (String, String) = update(users.filter(id.eq(sean.id)))
+        .set(name.eq("Renamed"))
+        .returning((old(name), name))
+        .get_result(connection)
+        .unwrap();
+
+    assert_eq!("Sean", was);
+    assert_eq!("Renamed", now);
+}
+
+#[diesel_test_helper::test]
+#[cfg(feature = "postgres")]
+fn returning_old_column_in_update_via_selectable() {
+    use crate::schema::users;
+
+    let connection = &mut connection_with_sean_and_tess_in_users_table();
+
+    if !pg_server_supports_returning_old(connection) {
+        return;
+    }
+
+    // Mix `old(col)` and a raw column on the same table inside a `Selectable`
+    // struct: in `UPDATE`, the row necessarily existed pre-update, so `old(col)`
+    // has the same Rust SQL type as the column itself.
+    #[derive(Queryable, Selectable, PartialEq, Debug)]
+    #[diesel(table_name = users)]
+    struct UpdateOldNew {
+        #[diesel(select_expression = diesel::pg::returning::old(users::name))]
+        was: String,
+        name: String,
+    }
+
+    let sean = find_user_by_name("Sean", connection);
+
+    let row: UpdateOldNew = update(users::table.filter(users::id.eq(sean.id)))
+        .set(users::name.eq("Renamed"))
+        .returning(UpdateOldNew::as_select())
+        .get_result(connection)
+        .unwrap();
+
+    assert_eq!(
+        UpdateOldNew {
+            was: "Sean".to_string(),
+            name: "Renamed".to_string(),
+        },
+        row,
+    );
+}


### PR DESCRIPTION
PostgreSQL 18 introduces the `RETURNING old.col_name` syntax to fetch the previous value of a column in `UPDATE` or `INSERT ... ON CONFLICT DO UPDATE` statements.
This is a useful feature to avoid DB round trips on update.
This PR implements this feature via `diesel::pg::returning::old`, similarly to `diesel::upsert::excluded`.

Line diff count may look scary but most of it is really test and snapshot updates.

This is implemented by making `QS` a `ReturningQuerySource<Table>` when considering whether `F: SelectableExpression<QS>` for returning, instead of just checking whether `F: SelectableExpression<Table>`.
(Same for `AppearsInFromClause`.)
This allows leveraging existing generic recursive `SelectableExpression` implementations to keep allowing everything else that was already allowed (functions, tuples...) along with the new syntax.

**Warnings:**
- This implies this minor breaking change:
https://github.com/Ten0/diesel/blob/62fcb8a2f0283dabea9b0ca9b96e4a679dc46537/diesel/src/query_builder/update_statement/mod.rs#L245
(where this used to be only `SelectableExpression<T>`) which may imply breakage only when users were writing very generic code.
In the past we have often considered similar "technically a breaking change" to be very unlikely to cause issues for many people, such that they would be worth it.
- As highlighted by the compile tests, error messages for selecting a column of the wrong table from a returning expression are slightly worsened. I have experimented with adding an extra `ValidInReturningOf` trait to improve error messages [`71d599e`](https://github.com/diesel-rs/diesel/pull/5049/changes/71d599e031ecf39eb5d3388ffbe2beb6a49a39cb) , but couldn't find a way to do it fully generically without running into conflicting impls, so users would have had to implement it manually on custom types, and overall it drastically worsened the complexity of the implementation, so I ended up reverting it.
- I have opted to not squash commits to keep these experimentations for reference, but that probably means that if we merge this we want to "squash-and-merge" it, not just merge it, to avoid bloating the tree with non descriptive commits.

Most of the code is effectively *written* by Opus 4.6/7 but design is mine and I told it what to write (and hopefully I reviewed accurately enough that I didn't miss mistakes 😅).