### PR TITLE
Fix flaky test in insert_get_result

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -14,6 +14,13 @@ filter = 'package(diesel_cli)'
 test-group = 'cli_tests'
 
 [[profile.default.overrides]]
-# fails sometimes due to a deadlock
-filter = 'test(insert_get_results_batch)'
-retries = 2 
+# Retry flaky tests:
+# - on MySQL/SQLite, `now`/`CURRENT_TIMESTAMP` is statement-bound, so
+#   `select(diesel::dsl::now)` and the implicit `CURRENT_TIMESTAMP`
+#   default applied by the INSERT can disagree when run as separate
+#   statements straddling a second boundary;
+# - `insert_get_results_batch` fails sometimes due to a deadlock.
+# This is substring matching so `test(insert_get_result)` covers
+# `insert_get_results_batch`, and `insert_get_results_batch`.
+filter = 'test(insert_get_result) | test(insert_insertable_struct_get_results_batch)'
+retries = 2


### PR DESCRIPTION
On MySQL this could happen:
```
    thread 'insert_get_result' (23651) panicked at examples/mysql/all_about_inserts/src/lib.rs:354:9:
    assertion `left == right` failed
      left: User { id: 3, name: "Ruby", hair_color: None, created_at: 2026-05-13T17:03:18, updated_at: 2026-05-13T17:03:18 }
     right: User { id: 3, name: "Ruby", hair_color: None, created_at: 2026-05-13T17:03:19, updated_at: 2026-05-13T17:03:19 }
```

https://github.com/diesel-rs/diesel/actions/runs/25813067679/job/75835973321?pr=5049

