### PR TITLE
Document MariaDB alongside the existing MySQL backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Rust."
 
 Supported databases:
 1. [PostgreSQL](https://docs.diesel.rs/main/diesel/pg/index.html)
-2. [MySQL](https://docs.diesel.rs/main/diesel/mysql/index.html)
+2. [MySQL (MariaDB)](https://docs.diesel.rs/main/diesel/mysql/index.html)
 3. [SQLite](https://docs.diesel.rs/main/diesel/sqlite/index.html)
 
 You can configure the database backend in `Cargo.toml`:

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -2,7 +2,7 @@
 name = "diesel"
 version = "2.3.9"
 license = "MIT OR Apache-2.0"
-description = "A safe, extensible ORM and Query Builder for PostgreSQL, SQLite, and MySQL"
+description = "A safe, extensible ORM and Query Builder for PostgreSQL, SQLite, MySQL, and MariaDB"
 readme = "README.md"
 documentation = "https://docs.rs/diesel/"
 homepage = "https://diesel.rs"

--- a/diesel/src/mysql/mod.rs
+++ b/diesel/src/mysql/mod.rs
@@ -1,4 +1,4 @@
-//! Provides types and functions related to working with MySQL
+//! Provides types and functions related to working with MySQL and MariaDB
 //!
 //! Much of this module is re-exported from database agnostic locations.
 //! However, if you are writing code specifically to extend Diesel on


### PR DESCRIPTION
## Summary

MariaDB is already supported through the existing `mysql` feature and MySQL-compatible connections (`mysql://` URLs, `mysqlclient-sys` / libmysqlclient or libmariadb). User-facing docs only mentioned MySQL.

This PR updates the README supported-databases list, the crates.io `description` in `diesel/Cargo.toml`, and the `mysql` module rustdoc to mention MariaDB alongside MySQL. No code or feature changes.

## Already supported today

- Recent CHANGELOG entries fix **libmariadb** compatibility ([2.3.5](https://github.com/diesel-rs/diesel/blob/main/CHANGELOG.md#L70), [2.3.4](https://github.com/diesel-rs/diesel/blob/main/CHANGELOG.md#L79), [2.3.2](https://github.com/diesel-rs/diesel/blob/main/CHANGELOG.md#L97)).
- [`diesel_bench/Readme.md`](https://github.com/diesel-rs/diesel/blob/main/diesel_bench/Readme.md#L12) already lists **MySQL/MariaDB**.
- The [`mysql` connection code](https://github.com/diesel-rs/diesel/blob/main/diesel/src/mysql/connection/bind.rs#L1284-L1287) handles MariaDB-specific behavior (more comments in [`bind.rs`](https://github.com/diesel-rs/diesel/blob/main/diesel/src/mysql/connection/bind.rs#L1232-L1287)).

CI exercises the `mysql` backend; there is no separate `mariadb` feature.

## Follow-up (out of scope)

The [diesel.rs](https://diesel.rs) site is maintained in [sgrif/diesel.rs-website](https://github.com/sgrif/diesel.rs-website). The getting started guide is still PostgreSQL-centric; mentioning MySQL/MariaDB there would be a separate PR to that repo.