### PR TITLE
QueryableByName is now nostd.

### DIFF
--- a/diesel_compile_tests/tests/fail/derive/queryable_by_name_no_std.rs
+++ b/diesel_compile_tests/tests/fail/derive/queryable_by_name_no_std.rs
@@ -1,0 +1,20 @@
+//@check-pass
+//@compile-flags: --crate-type lib
+#![no_std]
+#![allow(dead_code)]
+
+mod core {}
+
+#[derive(diesel::QueryableByName)]
+struct Row {
+    #[diesel(sql_type = diesel::sql_types::Integer, deserialize_as = i32)]
+    value: Newtype,
+}
+
+struct Newtype(i32);
+
+impl From<i32> for Newtype {
+    fn from(value: i32) -> Self {
+        Self(value)
+    }
+}

--- a/diesel_derives/src/queryable_by_name.rs
+++ b/diesel_derives/src/queryable_by_name.rs
@@ -31,7 +31,7 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
                 Ok(quote!(
                    {
                        let field = diesel::row::NamedRow::get::<#st, #deserialize_ty>(row, #name)?;
-                       <#deserialize_ty as std::convert::Into<#field_ty>>::into(field)
+                       <#deserialize_ty as ::core::convert::Into<#field_ty>>::into(field)
                    }
                 ))
             }

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__queryable_by_name_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__queryable_by_name_1.snap
@@ -23,14 +23,14 @@ const _: () = {
                     diesel::dsl::SqlTypeOf<users::r#id>,
                     i32,
                 >(row, "id")?;
-                <i32 as std::convert::Into<i32>>::into(field)
+                <i32 as ::core::convert::Into<i32>>::into(field)
             };
             let mut name = {
                 let field = diesel::row::NamedRow::get::<
                     diesel::dsl::SqlTypeOf<users::r#name>,
                     String,
                 >(row, "name")?;
-                <String as std::convert::Into<String>>::into(field)
+                <String as ::core::convert::Into<String>>::into(field)
             };
             diesel::deserialize::Result::Ok(Self { id: id, name: name })
         }


### PR DESCRIPTION
Make `#[derive(QueryableByName)]` no-std compatible.

Codex was used to draft and test this small change.