### PR TITLE
Fix order_by/then_order_by with GROUP BY rejecting valid aggregate expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 * `Bpchar` is now a distinct PostgreSQL SQL type (previously a hidden alias for `Varchar`). Binds on `CHAR(N)` / `BPCHAR` columns are now sent with OID 1042, allowing PostgreSQL to use the column's index instead of casting it to text.
 * Fix non-deterministic test failures on PostgreSQL caused by loading rows without `ORDER BY` and assuming insertion order
 * `diesel_derives` does now correctly handle feature flag unification in mixed build/target dependency situations
+* Fix a regression introduced in 2.3.8 where `order_by()` and `then_order_by()` with an aggregate expression incorrectly failed to compile when a `group_by()` clause was present
 
 ### Changed
 

--- a/diesel/src/query_builder/select_statement/dsl_impls.rs
+++ b/diesel/src/query_builder/select_statement/dsl_impls.rs
@@ -378,7 +378,7 @@ where
     }
 }
 
-// With GROUP BY: only validate that the new ORDER BY term is valid for the group.
+// With GROUP BY: Validate the whole order expression against the given group by expression
 impl<ST, F, S, D, W, O, LOf, GB, H, LC, Expr> ThenOrderDsl<Expr>
     for SelectStatement<FromClause<F>, S, D, W, OrderClause<O>, LOf, GroupByClause<GB>, H, LC>
 where
@@ -387,7 +387,7 @@ where
     Self: SelectQuery<SqlType = ST>,
     SelectStatement<FromClause<F>, S, D, W, OrderClause<(O, Expr)>, LOf, GroupByClause<GB>, H, LC>:
         SelectQuery<SqlType = ST>,
-    Expr: ValidGrouping<GB>,
+    (O, Expr): ValidGrouping<GB>,
 {
     type Output = SelectStatement<
         FromClause<F>,

--- a/diesel/src/query_builder/select_statement/dsl_impls.rs
+++ b/diesel/src/query_builder/select_statement/dsl_impls.rs
@@ -268,23 +268,25 @@ where
 }
 
 // no impls for `NoFromClause` here because order is not really supported there yet
-impl<ST, F, S, D, W, O, LOf, G, H, LC, Expr> OrderDsl<Expr>
-    for SelectStatement<FromClause<F>, S, D, W, O, LOf, G, H, LC>
+
+// Without GROUP BY: validate that SELECT and ORDER BY have matching aggregate nature.
+impl<ST, F, S, D, W, O, LOf, H, LC, Expr> OrderDsl<Expr>
+    for SelectStatement<FromClause<F>, S, D, W, O, LOf, NoGroupByClause, H, LC>
 where
     F: QuerySource,
     Expr: AppearsOnTable<F>,
     Self: SelectQuery<SqlType = ST>,
-    SelectStatement<FromClause<F>, S, D, W, OrderClause<Expr>, LOf, G, H, LC>:
+    SelectStatement<FromClause<F>, S, D, W, OrderClause<Expr>, LOf, NoGroupByClause, H, LC>:
         SelectQuery<SqlType = ST>,
     OrderClause<Expr>: ValidOrderingForDistinct<D>,
-    G: ValidGroupByClause,
     S: SelectClauseExpression<FromClause<F>>,
-    Expr: ValidGrouping<G::Expressions>,
-    S::Selection: ValidGrouping<G::Expressions>,
-    <S::Selection as ValidGrouping<G::Expressions>>::IsAggregate:
-        MixedAggregates<<Expr as ValidGrouping<G::Expressions>>::IsAggregate>,
+    Expr: ValidGrouping<()>,
+    S::Selection: ValidGrouping<()>,
+    <S::Selection as ValidGrouping<()>>::IsAggregate:
+        MixedAggregates<<Expr as ValidGrouping<()>>::IsAggregate>,
 {
-    type Output = SelectStatement<FromClause<F>, S, D, W, OrderClause<Expr>, LOf, G, H, LC>;
+    type Output =
+        SelectStatement<FromClause<F>, S, D, W, OrderClause<Expr>, LOf, NoGroupByClause, H, LC>;
 
     fn order(self, expr: Expr) -> Self::Output {
         let order = OrderClause(expr);
@@ -302,19 +304,102 @@ where
     }
 }
 
-impl<F, S, D, W, O, LOf, G, H, LC, Expr> ThenOrderDsl<Expr>
-    for SelectStatement<FromClause<F>, S, D, W, OrderClause<O>, LOf, G, H, LC>
+// With GROUP BY: only validate that the ORDER BY expression is valid for the group
+// (grouped column or aggregate). SELECT validity is enforced by the Query impl at
+// execution time, so checking it here would reject valid queries where order_by()
+// is called before select() with a non-trivial GROUP BY.
+impl<ST, F, S, D, W, O, LOf, GB, H, LC, Expr> OrderDsl<Expr>
+    for SelectStatement<FromClause<F>, S, D, W, O, LOf, GroupByClause<GB>, H, LC>
 where
     F: QuerySource,
     Expr: AppearsOnTable<F>,
-    G: ValidGroupByClause,
-    S: SelectClauseExpression<FromClause<F>>,
-    Expr: ValidGrouping<G::Expressions>,
-    S::Selection: ValidGrouping<G::Expressions>,
-    <S::Selection as ValidGrouping<G::Expressions>>::IsAggregate:
-        MixedAggregates<<Expr as ValidGrouping<G::Expressions>>::IsAggregate>,
+    Self: SelectQuery<SqlType = ST>,
+    SelectStatement<FromClause<F>, S, D, W, OrderClause<Expr>, LOf, GroupByClause<GB>, H, LC>:
+        SelectQuery<SqlType = ST>,
+    OrderClause<Expr>: ValidOrderingForDistinct<D>,
+    Expr: ValidGrouping<GB>,
 {
-    type Output = SelectStatement<FromClause<F>, S, D, W, OrderClause<(O, Expr)>, LOf, G, H, LC>;
+    type Output =
+        SelectStatement<FromClause<F>, S, D, W, OrderClause<Expr>, LOf, GroupByClause<GB>, H, LC>;
+
+    fn order(self, expr: Expr) -> Self::Output {
+        let order = OrderClause(expr);
+        SelectStatement::new(
+            self.select,
+            self.from,
+            self.distinct,
+            self.where_clause,
+            order,
+            self.limit_offset,
+            self.group_by,
+            self.having,
+            self.locking,
+        )
+    }
+}
+
+// Without GROUP BY: validate that SELECT and the new ORDER BY term have matching
+// aggregate nature.
+impl<F, S, D, W, O, LOf, H, LC, Expr> ThenOrderDsl<Expr>
+    for SelectStatement<FromClause<F>, S, D, W, OrderClause<O>, LOf, NoGroupByClause, H, LC>
+where
+    F: QuerySource,
+    Expr: AppearsOnTable<F>,
+    S: SelectClauseExpression<FromClause<F>>,
+    Expr: ValidGrouping<()>,
+    S::Selection: ValidGrouping<()>,
+    <S::Selection as ValidGrouping<()>>::IsAggregate:
+        MixedAggregates<<Expr as ValidGrouping<()>>::IsAggregate>,
+{
+    type Output = SelectStatement<
+        FromClause<F>,
+        S,
+        D,
+        W,
+        OrderClause<(O, Expr)>,
+        LOf,
+        NoGroupByClause,
+        H,
+        LC,
+    >;
+
+    fn then_order_by(self, expr: Expr) -> Self::Output {
+        SelectStatement::new(
+            self.select,
+            self.from,
+            self.distinct,
+            self.where_clause,
+            OrderClause((self.order.0, expr)),
+            self.limit_offset,
+            self.group_by,
+            self.having,
+            self.locking,
+        )
+    }
+}
+
+// With GROUP BY: only validate that the new ORDER BY term is valid for the group.
+impl<ST, F, S, D, W, O, LOf, GB, H, LC, Expr> ThenOrderDsl<Expr>
+    for SelectStatement<FromClause<F>, S, D, W, OrderClause<O>, LOf, GroupByClause<GB>, H, LC>
+where
+    F: QuerySource,
+    Expr: AppearsOnTable<F>,
+    Self: SelectQuery<SqlType = ST>,
+    SelectStatement<FromClause<F>, S, D, W, OrderClause<(O, Expr)>, LOf, GroupByClause<GB>, H, LC>:
+        SelectQuery<SqlType = ST>,
+    Expr: ValidGrouping<GB>,
+{
+    type Output = SelectStatement<
+        FromClause<F>,
+        S,
+        D,
+        W,
+        OrderClause<(O, Expr)>,
+        LOf,
+        GroupByClause<GB>,
+        H,
+        LC,
+    >;
 
     fn then_order_by(self, expr: Expr) -> Self::Output {
         SelectStatement::new(

--- a/diesel_compile_tests/tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs
+++ b/diesel_compile_tests/tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs
@@ -6,22 +6,45 @@ table! {
     users {
         id -> Integer,
         name -> Text,
+        hair_color -> Nullable<Text>,
     }
 }
+
+table! {
+    parent {
+        id -> Integer,
+        name -> Text,
+    }
+}
+
+table! {
+    child {
+        id -> Integer,
+        parent_id -> Integer,
+        value -> Text,
+    }
+}
+
+joinable!(child -> parent (parent_id));
+allow_tables_to_appear_in_same_query!(parent, child);
 
 fn main() {
     use self::users::dsl::*;
     use diesel::dsl::max;
 
-    // aggregate SELECT + non-aggregate ORDER BY (the issue's example)
+    // -------------------------------------------------------------------------
+    // Without GROUP BY — mixing aggregate and non-aggregate is always invalid
+    // -------------------------------------------------------------------------
+
+    // aggregate SELECT + non-aggregate ORDER BY
     let _ = users.select(max(id)).order_by(name);
     //~^ ERROR: mixing aggregate and not aggregate expressions is not allowed in SQL
 
-    // non-aggregate SELECT + aggregate ORDER BY (also invalid SQL)
+    // non-aggregate SELECT + aggregate ORDER BY
     let _ = users.select(id).order_by(max(id));
     //~^ ERROR: mixing aggregate and not aggregate expressions is not allowed in SQL
 
-    // aggregate SELECT + non-aggregate then_order_by
+    // aggregate SELECT + aggregate ORDER BY + non-aggregate then_order_by
     let _ = users
         .select(max(id))
         .order_by(max(id))
@@ -35,4 +58,85 @@ fn main() {
     // non-aggregate ORDER BY first, then .count() (issue #3815)
     let _ = users.order_by(name).count();
     //~^ ERROR: SelectDsl
+
+    // aggregate ORDER BY without explicit SELECT (default non-aggregate select, no GROUP BY)
+    let _ = users.order_by(max(id));
+    //~^ ERROR: mixing aggregate and not aggregate expressions is not allowed in SQL
+
+    // non-aggregate SELECT + aggregate then_order_by (ThenOrderDsl→NoOrderClause path)
+    let _ = users.select(id).then_order_by(max(id));
+    //~^ ERROR: mixing aggregate and not aggregate expressions is not allowed in SQL
+
+    // non-aggregate ORDER BY + aggregate then_order_by (ThenOrderDsl→existing OrderClause path)
+    let _ = users.order_by(name).then_order_by(max(id));
+    //~^ ERROR: mixing aggregate and not aggregate expressions is not allowed in SQL
+
+    // -------------------------------------------------------------------------
+    // With GROUP BY — non-grouped non-aggregate column in ORDER BY is invalid
+    // -------------------------------------------------------------------------
+
+    // non-grouped column in order_by, default select, order before select
+    let _ = users.group_by(name).order_by(id);
+    //~^ ERROR: IsContainedInGroupBy
+
+    // non-grouped column in order_by, order before explicit select
+    let _ = users.group_by(name).order_by(id).select(name);
+    //~^ ERROR: IsContainedInGroupBy
+    //~| ERROR: SelectDsl
+
+    // non-grouped column in order_by, select called first
+    // When select is first, S::Selection satisfies ValidGrouping, so the error
+    // narrows to the specific column's IsContainedInGroupBy constraint
+    let _ = users
+        .group_by(name)
+        .select((name, max(id)))
+        .order_by(id);
+    //~^ ERROR: IsContainedInGroupBy
+
+    // valid order_by (aggregate), then non-grouped column in then_order_by; select first
+    let _ = users
+        .group_by(name)
+        .select((name, max(id)))
+        .order_by(max(id))
+        .then_order_by(id);
+    //~^ ERROR: IsContainedInGroupBy
+
+    // valid order_by (grouped column), then non-grouped column in then_order_by; select first
+    let _ = users
+        .group_by(name)
+        .select((name, max(id)))
+        .order_by(name)
+        .then_order_by(id);
+    //~^ ERROR: IsContainedInGroupBy
+
+    // non-grouped then_order_by after grouped col order_by, order-before-select
+    let _ = users.group_by(name).order_by(name).then_order_by(id);
+    //~^ ERROR: IsContainedInGroupBy
+
+    // non-grouped then_order_by after aggregate order_by, order-before-select
+    let _ = users.group_by(name).order_by(max(id)).then_order_by(id);
+    //~^ ERROR: IsContainedInGroupBy
+
+    // multi-column GROUP BY, non-grouped column in order_by, default select
+    let _ = users.group_by((name, hair_color)).order_by(id);
+    //~^ ERROR: IsContainedInGroupBy
+
+    // -------------------------------------------------------------------------
+    // With GROUP BY + LEFT JOIN — non-grouped right-side column in ORDER BY
+    // -------------------------------------------------------------------------
+
+    // non-grouped right-side column in order_by, default select
+    let _ = parent::table
+        .left_join(child::table)
+        .group_by(parent::id)
+        .order_by(child::value);
+    //~^ ERROR: IsContainedInGroupBy
+
+    // non-grouped right-side column in then_order_by after valid grouped order_by, default select
+    let _ = parent::table
+        .left_join(child::table)
+        .group_by(parent::id)
+        .order_by(parent::id)
+        .then_order_by(child::value);
+    //~^ ERROR: IsContainedInGroupBy
 }

--- a/diesel_compile_tests/tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs
+++ b/diesel_compile_tests/tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs
@@ -32,6 +32,8 @@ fn main() {
     use self::users::dsl::*;
     use diesel::dsl::max;
 
+    let conn = &mut SqliteConnection::establish("…").unwrap();
+
     // -------------------------------------------------------------------------
     // Without GROUP BY — mixing aggregate and non-aggregate is always invalid
     // -------------------------------------------------------------------------
@@ -45,10 +47,7 @@ fn main() {
     //~^ ERROR: mixing aggregate and not aggregate expressions is not allowed in SQL
 
     // aggregate SELECT + aggregate ORDER BY + non-aggregate then_order_by
-    let _ = users
-        .select(max(id))
-        .order_by(max(id))
-        .then_order_by(name);
+    let _ = users.select(max(id)).order_by(max(id)).then_order_by(name);
     //~^ ERROR: mixing aggregate and not aggregate expressions is not allowed in SQL
 
     // non-aggregate ORDER BY first, then aggregate SELECT (issue #3815)
@@ -87,10 +86,7 @@ fn main() {
     // non-grouped column in order_by, select called first
     // When select is first, S::Selection satisfies ValidGrouping, so the error
     // narrows to the specific column's IsContainedInGroupBy constraint
-    let _ = users
-        .group_by(name)
-        .select((name, max(id)))
-        .order_by(id);
+    let _ = users.group_by(name).select((name, max(id))).order_by(id);
     //~^ ERROR: IsContainedInGroupBy
 
     // valid order_by (aggregate), then non-grouped column in then_order_by; select first
@@ -139,4 +135,20 @@ fn main() {
         .order_by(parent::id)
         .then_order_by(child::value);
     //~^ ERROR: IsContainedInGroupBy
+
+    // also check existing order clause
+    let _ = parent::table
+        .left_join(child::table)
+        .order_by(child::value)
+        .group_by(parent::id)
+        .get_result(conn);
+    //~^ ERROR: the trait bound `SkipSelectableExpressionBoundCheckWrapper<...>: ValidGrouping<...>` is not satisfied
+
+    // also check existing order clause
+    let _ = parent::table
+        .left_join(child::table)
+        .order_by(child::value)
+        .group_by(parent::id)
+        .then_order_by(parent::id);
+    //~^ ERROR: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ...>: ThenOrderDsl<_>` is not satisfied
 }

--- a/diesel_compile_tests/tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.stderr
+++ b/diesel_compile_tests/tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.stderr
@@ -1,5 +1,5 @@
 error[E0277]: mixing aggregate and not aggregate expressions is not allowed in SQL
-   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:40:44
+   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:42:44
     |
  LL |     let _ = users.select(max(id)).order_by(name);
     |                                   -------- ^^^^ unsatisfied trait bound
@@ -30,7 +30,7 @@ LL |         Self: methods::OrderDsl<Expr>,
  
     
 error[E0277]: mixing aggregate and not aggregate expressions is not allowed in SQL
-   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:44:39
+   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:46:39
     |
  LL |     let _ = users.select(id).order_by(max(id));
     |                              -------- ^^^^^^^ unsatisfied trait bound
@@ -61,12 +61,12 @@ LL |         Self: methods::OrderDsl<Expr>,
  
     
 error[E0277]: mixing aggregate and not aggregate expressions is not allowed in SQL
-   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:51:24
+   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:50:67
     |
- LL |         .then_order_by(name);
-    |          ------------- ^^^^ unsatisfied trait bound
-    |          |
-    |          required by a bound introduced by this call
+ LL |     let _ = users.select(max(id)).order_by(max(id)).then_order_by(name);
+    |                                                     ------------- ^^^^ unsatisfied trait bound
+    |                                                     |
+    |                                                     required by a bound introduced by this call
     |
     = help: the trait `MixedAggregates<diesel::expression::is_aggregate::No>` is not implemented for `diesel::expression::is_aggregate::Yes`
     = note: you tried to combine expressions that aggregate over a certain column with expressions that don't aggregate over that column
@@ -92,7 +92,7 @@ LL |         Self: methods::ThenOrderDsl<Order>,
  
     
 error[E0277]: mixing aggregate and not aggregate expressions is not allowed in SQL
-   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:55:41
+   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:54:41
     |
  LL |     let _ = users.order_by(name).select(max(id));
     |                                  ------ ^^^^^^^ unsatisfied trait bound
@@ -123,7 +123,7 @@ LL |         Self: methods::SelectDsl<Selection>,
  
     
 error[E0277]: the trait bound `SelectStatement<..., ..., ..., ..., ...>: SelectDsl<...>` is not satisfied
-   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:59:34
+   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:58:34
     |
  LL |     let _ = users.order_by(name).count();
     |                                  ^^^^^ unsatisfied trait bound
@@ -152,7 +152,7 @@ LL | |     D: ValidDistinctForGroupBy<Selection, G::Expressions>,
  
     
 error[E0277]: mixing aggregate and not aggregate expressions is not allowed in SQL
-   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:63:28
+   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:62:28
     |
  LL |     let _ = users.order_by(max(id));
     |                   -------- ^^^^^^^ unsatisfied trait bound
@@ -185,7 +185,7 @@ LL |         Self: methods::OrderDsl<Expr>,
  
     
 error[E0277]: mixing aggregate and not aggregate expressions is not allowed in SQL
-   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:67:44
+   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:66:44
     |
  LL |     let _ = users.select(id).then_order_by(max(id));
     |                              ------------- ^^^^^^^ unsatisfied trait bound
@@ -217,7 +217,7 @@ LL |         Self: methods::ThenOrderDsl<Order>,
  
     
 error[E0277]: mixing aggregate and not aggregate expressions is not allowed in SQL
-   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:71:48
+   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:70:48
     |
  LL |     let _ = users.order_by(name).then_order_by(max(id));
     |                                  ------------- ^^^^^^^ unsatisfied trait bound
@@ -248,7 +248,7 @@ LL |         Self: methods::ThenOrderDsl<Order>,
  
     
 error[E0271]: type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
-  --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:79:34
+  --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:78:34
    |
 LL |     let _ = users.group_by(name).order_by(id);
    |                                  ^^^^^^^^ type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
@@ -274,7 +274,7 @@ note: required for `users::columns::id` to implement `ValidGrouping<users::colum
       = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0271]: type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
-  --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:83:34
+  --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:82:34
    |
 LL |     let _ = users.group_by(name).order_by(id).select(name);
    |                                  ^^^^^^^^ type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
@@ -300,7 +300,7 @@ note: required for `users::columns::id` to implement `ValidGrouping<users::colum
       = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ...>: SelectDsl<_>` is not satisfied
-   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:83:47
+   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:82:47
     |
  LL |     let _ = users.group_by(name).order_by(id).select(name);
     |                                               ^^^^^^ the trait `SelectDsl<_>` is not implemented for `SelectStatement<..., ..., ..., ..., ..., ..., ...>`
@@ -328,10 +328,10 @@ LL | |     D: ValidDistinctForGroupBy<Selection, G::Expressions>,
  
     
 error[E0271]: type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
-  --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:93:10
+  --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:89:58
    |
-LL |         .order_by(id);
-   |          ^^^^^^^^ type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
+LL |     let _ = users.group_by(name).select((name, max(id))).order_by(id);
+   |                                                          ^^^^^^^^ type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
    |
 note: expected this to be `diesel::expression::is_contained_in_group_by::Yes`
   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:5:1
@@ -354,7 +354,35 @@ note: required for `users::columns::id` to implement `ValidGrouping<users::colum
       = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0271]: type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
-   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:101:10
+  --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:97:10
+   |
+LL |         .then_order_by(id);
+   |          ^^^^^^^^^^^^^ type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
+   |
+note: expected this to be `diesel::expression::is_contained_in_group_by::Yes`
+  --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:5:1
+   |
+ LL | / table! {
+ LL | |     users {
+ LL | |         id -> Integer,
+ LL | |         name -> Text,
+...  |
+LL | | }
+   | |_^
+note: required for `users::columns::id` to implement `ValidGrouping<users::columns::name>`
+  --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:7:9
+   |
+ LL |         id -> Integer,
+   |         ^^
+   = note: associated types for the current `impl` cannot be restricted in `where` clauses
+   = note: 2 redundant requirements hidden
+   = note: required for `(max<Integer, id>, id)` to implement `ValidGrouping<users::columns::name>`
+   = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ...>` to implement `ThenOrderDsl<users::columns::id>`
+
+      = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0271]: type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
+   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:105:10
     |
 LL |         .then_order_by(id);
     |          ^^^^^^^^^^^^^ type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
@@ -375,38 +403,14 @@ note: required for `users::columns::id` to implement `ValidGrouping<users::colum
   LL |         id -> Integer,
     |         ^^
     = note: associated types for the current `impl` cannot be restricted in `where` clauses
+    = note: 2 redundant requirements hidden
+    = note: required for `(users::columns::name, users::columns::id)` to implement `ValidGrouping<users::columns::name>`
     = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ...>` to implement `ThenOrderDsl<users::columns::id>`
  
         = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0271]: type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
-   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:109:10
-    |
-LL |         .then_order_by(id);
-    |          ^^^^^^^^^^^^^ type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
-    |
-note: expected this to be `diesel::expression::is_contained_in_group_by::Yes`
-   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:5:1
-    |
-  LL | / table! {
-  LL | |     users {
-  LL | |         id -> Integer,
-  LL | |         name -> Text,
-...   |
- LL | | }
-    | |_^
-note: required for `users::columns::id` to implement `ValidGrouping<users::columns::name>`
-   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:7:9
-    |
-  LL |         id -> Integer,
-    |         ^^
-    = note: associated types for the current `impl` cannot be restricted in `where` clauses
-    = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ...>` to implement `ThenOrderDsl<users::columns::id>`
- 
-        = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0271]: type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
-   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:113:49
+   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:109:49
     |
 LL |     let _ = users.group_by(name).order_by(name).then_order_by(id);
     |                                                 ^^^^^^^^^^^^^ type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
@@ -427,12 +431,14 @@ note: required for `users::columns::id` to implement `ValidGrouping<users::colum
   LL |         id -> Integer,
     |         ^^
     = note: associated types for the current `impl` cannot be restricted in `where` clauses
+    = note: 2 redundant requirements hidden
+    = note: required for `(users::columns::name, users::columns::id)` to implement `ValidGrouping<users::columns::name>`
     = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ...>` to implement `ThenOrderDsl<users::columns::id>`
  
         = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0271]: type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
-   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:117:52
+   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:113:52
     |
 LL |     let _ = users.group_by(name).order_by(max(id)).then_order_by(id);
     |                                                    ^^^^^^^^^^^^^ type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
@@ -453,12 +459,14 @@ note: required for `users::columns::id` to implement `ValidGrouping<users::colum
   LL |         id -> Integer,
     |         ^^
     = note: associated types for the current `impl` cannot be restricted in `where` clauses
+    = note: 2 redundant requirements hidden
+    = note: required for `(max<Integer, id>, id)` to implement `ValidGrouping<users::columns::name>`
     = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ...>` to implement `ThenOrderDsl<users::columns::id>`
  
         = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0271]: type mismatch resolving `<(name, hair_color) as IsContainedInGroupBy<id>>::Output == Yes`
-   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:121:48
+   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:117:48
     |
 LL |     let _ = users.group_by((name, hair_color)).order_by(id);
     |                                                ^^^^^^^^ expected `Yes`, found `No`
@@ -474,7 +482,7 @@ note: required for `users::columns::id` to implement `ValidGrouping<(users::colu
         = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `id: IsContainedInGroupBy<value>` is not satisfied
-   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:132:10
+   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:128:10
     |
 LL |         .order_by(child::value);
     |          ^^^^^^^^ unsatisfied trait bound
@@ -505,7 +513,7 @@ note: required for `child::columns::value` to implement `ValidGrouping<parent::c
         = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `id: IsContainedInGroupBy<value>` is not satisfied
-   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:140:10
+   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:136:10
     |
 LL |         .then_order_by(child::value);
     |          ^^^^^^^^^^^^^ unsatisfied trait bound
@@ -531,6 +539,70 @@ note: required for `child::columns::value` to implement `ValidGrouping<parent::c
     |
  LL |         value -> Text,
     |         ^^^^^
+    = note: 2 redundant requirements hidden
+    = note: required for `(parent::columns::id, child::columns::value)` to implement `ValidGrouping<parent::columns::id>`
     = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ...>` to implement `ThenOrderDsl<child::columns::value>`
  
         = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `SkipSelectableExpressionBoundCheckWrapper<...>: ValidGrouping<...>` is not satisfied
+    --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:144:21
+     |
+ LL |         .get_result(conn);
+     |          ---------- ^^^^ unsatisfied trait bound
+     |          |
+     |          required by a bound introduced by this call
+     |
+help: the trait `ValidGrouping<parent::columns::id>` is not implemented for `SkipSelectableExpressionBoundCheckWrapper<...>`
+      but trait `ValidGrouping<()>` is implemented for it
+    --> DIESEL/diesel/diesel/src/query_source/joins.rs
+     |
+ LL |     impl<T> ValidGrouping<()> for SkipSelectableExpressionBoundCheckWrapper<T> {
+     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     = help: for that trait implementation, expected `()`, found `parent::columns::id`
+     = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ...>` to implement `Query`
+     = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ...>` to implement `LoadQuery<'_, _, _>`
+note: required by a bound in `get_result`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn get_result<'query, U>(self, conn: &mut Conn) -> QueryResult<U>
+     |        ---------- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::get_result`
+  
+     
+error[E0277]: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ...>: ThenOrderDsl<_>` is not satisfied
+   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:152:10
+    |
+LL |         .then_order_by(parent::id);
+    |          ^^^^^^^^^^^^^ unsatisfied trait bound
+    |
+    = help: the trait `ThenOrderDsl<_>` is not implemented for `SelectStatement<..., ..., ..., ..., ..., ..., ...>`
+help: the following other types implement trait `ThenOrderDsl<Expr>`
+   --> DIESEL/diesel/diesel/src/query_builder/select_statement/dsl_impls.rs
+    |
+LL | / impl<F, S, D, W, O, LOf, H, LC, Expr> ThenOrderDsl<Expr>
+LL | |     for SelectStatement<FromClause<F>, S, D, W, OrderClause<O>, LOf, NoGroupByClause, H, LC>
+LL | | where
+LL | |     F: QuerySource,
+...   |
+LL | |     <S::Selection as ValidGrouping<()>>::IsAggregate:
+LL | |         MixedAggregates<<Expr as ValidGrouping<()>>::IsAggregate>,
+    | |__________________________________________________________________^ `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
+...
+LL | / impl<ST, F, S, D, W, O, LOf, GB, H, LC, Expr> ThenOrderDsl<Expr>
+LL | |     for SelectStatement<FromClause<F>, S, D, W, OrderClause<O>, LOf, GroupByClause<GB>, H...
+LL | | where
+LL | |     F: QuerySource,
+...   |
+LL | |         SelectQuery<SqlType = ST>,
+LL | |     (O, Expr): ValidGrouping<GB>,
+    | |_________________________________^ `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
+...
+LL | / impl<F, S, D, W, LOf, G, LC, Expr> ThenOrderDsl<Expr>
+LL | |     for SelectStatement<F, S, D, W, NoOrderClause, LOf, G, LC>
+LL | | where
+LL | |     Expr: Expression,
+LL | |     Self: OrderDsl<Expr>,
+    | |_________________________^ `SelectStatement<F, S, D, W, ..., ..., ..., ...>`

--- a/diesel_compile_tests/tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.stderr
+++ b/diesel_compile_tests/tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.stderr
@@ -1,5 +1,5 @@
 error[E0277]: mixing aggregate and not aggregate expressions is not allowed in SQL
-   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:17:44
+   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:40:44
     |
  LL |     let _ = users.select(max(id)).order_by(name);
     |                                   -------- ^^^^ unsatisfied trait bound
@@ -18,7 +18,7 @@ LL |     impl MixedAggregates<Yes> for Yes {
 ...
 LL |     impl MixedAggregates<Never> for Yes {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `MixedAggregates<diesel::expression::is_aggregate::Never>`
-    = note: required for `SelectStatement<FromClause<table>, ...>` to implement `OrderDsl<columns::name>`
+    = note: required for `SelectStatement<FromClause<table>, ...>` to implement `OrderDsl<users::columns::name>`
 note: required by a bound in `order_by`
    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
     |
@@ -30,7 +30,7 @@ LL |         Self: methods::OrderDsl<Expr>,
  
     
 error[E0277]: mixing aggregate and not aggregate expressions is not allowed in SQL
-   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:21:39
+   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:44:39
     |
  LL |     let _ = users.select(id).order_by(max(id));
     |                              -------- ^^^^^^^ unsatisfied trait bound
@@ -61,7 +61,7 @@ LL |         Self: methods::OrderDsl<Expr>,
  
     
 error[E0277]: mixing aggregate and not aggregate expressions is not allowed in SQL
-   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:28:24
+   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:51:24
     |
  LL |         .then_order_by(name);
     |          ------------- ^^^^ unsatisfied trait bound
@@ -80,7 +80,7 @@ LL |     impl MixedAggregates<Yes> for Yes {
 ...
 LL |     impl MixedAggregates<Never> for Yes {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `MixedAggregates<diesel::expression::is_aggregate::Never>`
-    = note: required for `SelectStatement<..., ..., ..., ..., ...>` to implement `ThenOrderDsl<columns::name>`
+    = note: required for `SelectStatement<..., ..., ..., ..., ...>` to implement `ThenOrderDsl<users::columns::name>`
 note: required by a bound in `diesel::QueryDsl::then_order_by`
    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
     |
@@ -92,7 +92,7 @@ LL |         Self: methods::ThenOrderDsl<Order>,
  
     
 error[E0277]: mixing aggregate and not aggregate expressions is not allowed in SQL
-   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:32:41
+   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:55:41
     |
  LL |     let _ = users.order_by(name).select(max(id));
     |                                  ------ ^^^^^^^ unsatisfied trait bound
@@ -123,7 +123,7 @@ LL |         Self: methods::SelectDsl<Selection>,
  
     
 error[E0277]: the trait bound `SelectStatement<..., ..., ..., ..., ...>: SelectDsl<...>` is not satisfied
-   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:36:34
+   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:59:34
     |
  LL |     let _ = users.order_by(name).count();
     |                                  ^^^^^ unsatisfied trait bound
@@ -150,4 +150,387 @@ LL | |     SelectStatement<NoFromClause, SelectClause<Selection>, D, W, O, LOf, 
 LL | |     D: ValidDistinctForGroupBy<Selection, G::Expressions>,
     | |__________________________________________________________^ `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
  
-    For more information about this error, try `rustc --explain E0277`.
+    
+error[E0277]: mixing aggregate and not aggregate expressions is not allowed in SQL
+   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:63:28
+    |
+ LL |     let _ = users.order_by(max(id));
+    |                   -------- ^^^^^^^ unsatisfied trait bound
+    |                   |
+    |                   required by a bound introduced by this call
+    |
+    = help: the trait `MixedAggregates<diesel::expression::is_aggregate::Yes>` is not implemented for `diesel::expression::is_aggregate::No`
+    = note: you tried to combine expressions that aggregate over a certain column with expressions that don't aggregate over that column
+    = note: try to either use aggregate functions like `min`/`max`/… for this column or add the column to your `GROUP BY` clause
+    = note: also there are clauses like `WHERE` or `RETURNING` that does not accept aggregate expressions at all
+help: `diesel::expression::is_aggregate::No` implements trait `MixedAggregates<Other>`
+   --> DIESEL/diesel/diesel/src/expression/mod.rs
+    |
+LL |     impl MixedAggregates<No> for No {
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `MixedAggregates<diesel::expression::is_aggregate::No>`
+...
+LL |     impl MixedAggregates<Never> for No {
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `MixedAggregates<diesel::expression::is_aggregate::Never>`
+    = note: required for `SelectStatement<FromClause<table>>` to implement `OrderDsl<max<Integer, id>>`
+    = note: 1 redundant requirement hidden
+    = note: required for `users::table` to implement `OrderDsl<max<Integer, id>>`
+note: required by a bound in `order_by`
+   --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+    |
+LL |     fn order_by<Expr>(self, expr: Expr) -> OrderBy<Self, Expr>
+    |        -------- required by a bound in this associated function
+...
+LL |         Self: methods::OrderDsl<Expr>,
+    |               ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::order_by`
+ 
+    
+error[E0277]: mixing aggregate and not aggregate expressions is not allowed in SQL
+   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:67:44
+    |
+ LL |     let _ = users.select(id).then_order_by(max(id));
+    |                              ------------- ^^^^^^^ unsatisfied trait bound
+    |                              |
+    |                              required by a bound introduced by this call
+    |
+    = help: the trait `MixedAggregates<diesel::expression::is_aggregate::Yes>` is not implemented for `diesel::expression::is_aggregate::No`
+    = note: you tried to combine expressions that aggregate over a certain column with expressions that don't aggregate over that column
+    = note: try to either use aggregate functions like `min`/`max`/… for this column or add the column to your `GROUP BY` clause
+    = note: also there are clauses like `WHERE` or `RETURNING` that does not accept aggregate expressions at all
+help: `diesel::expression::is_aggregate::No` implements trait `MixedAggregates<Other>`
+   --> DIESEL/diesel/diesel/src/expression/mod.rs
+    |
+LL |     impl MixedAggregates<No> for No {
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `MixedAggregates<diesel::expression::is_aggregate::No>`
+...
+LL |     impl MixedAggregates<Never> for No {
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `MixedAggregates<diesel::expression::is_aggregate::Never>`
+    = note: required for `SelectStatement<FromClause<table>, ...>` to implement `OrderDsl<max<Integer, id>>`
+    = note: required for `SelectStatement<FromClause<table>, ...>` to implement `ThenOrderDsl<max<Integer, id>>`
+note: required by a bound in `diesel::QueryDsl::then_order_by`
+   --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+    |
+LL |     fn then_order_by<Order>(self, order: Order) -> ThenOrderBy<Self, Order>
+    |        ------------- required by a bound in this associated function
+LL |     where
+LL |         Self: methods::ThenOrderDsl<Order>,
+    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::then_order_by`
+ 
+    
+error[E0277]: mixing aggregate and not aggregate expressions is not allowed in SQL
+   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:71:48
+    |
+ LL |     let _ = users.order_by(name).then_order_by(max(id));
+    |                                  ------------- ^^^^^^^ unsatisfied trait bound
+    |                                  |
+    |                                  required by a bound introduced by this call
+    |
+    = help: the trait `MixedAggregates<diesel::expression::is_aggregate::Yes>` is not implemented for `diesel::expression::is_aggregate::No`
+    = note: you tried to combine expressions that aggregate over a certain column with expressions that don't aggregate over that column
+    = note: try to either use aggregate functions like `min`/`max`/… for this column or add the column to your `GROUP BY` clause
+    = note: also there are clauses like `WHERE` or `RETURNING` that does not accept aggregate expressions at all
+help: `diesel::expression::is_aggregate::No` implements trait `MixedAggregates<Other>`
+   --> DIESEL/diesel/diesel/src/expression/mod.rs
+    |
+LL |     impl MixedAggregates<No> for No {
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `MixedAggregates<diesel::expression::is_aggregate::No>`
+...
+LL |     impl MixedAggregates<Never> for No {
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `MixedAggregates<diesel::expression::is_aggregate::Never>`
+    = note: required for `SelectStatement<..., ..., ..., ..., ...>` to implement `ThenOrderDsl<max<Integer, id>>`
+note: required by a bound in `diesel::QueryDsl::then_order_by`
+   --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+    |
+LL |     fn then_order_by<Order>(self, order: Order) -> ThenOrderBy<Self, Order>
+    |        ------------- required by a bound in this associated function
+LL |     where
+LL |         Self: methods::ThenOrderDsl<Order>,
+    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::then_order_by`
+ 
+    
+error[E0271]: type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
+  --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:79:34
+   |
+LL |     let _ = users.group_by(name).order_by(id);
+   |                                  ^^^^^^^^ type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
+   |
+note: expected this to be `diesel::expression::is_contained_in_group_by::Yes`
+  --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:5:1
+   |
+ LL | / table! {
+ LL | |     users {
+ LL | |         id -> Integer,
+ LL | |         name -> Text,
+...  |
+LL | | }
+   | |_^
+note: required for `users::columns::id` to implement `ValidGrouping<users::columns::name>`
+  --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:7:9
+   |
+ LL |         id -> Integer,
+   |         ^^
+   = note: associated types for the current `impl` cannot be restricted in `where` clauses
+   = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ...>` to implement `OrderDsl<users::columns::id>`
+
+      = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0271]: type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
+  --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:83:34
+   |
+LL |     let _ = users.group_by(name).order_by(id).select(name);
+   |                                  ^^^^^^^^ type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
+   |
+note: expected this to be `diesel::expression::is_contained_in_group_by::Yes`
+  --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:5:1
+   |
+ LL | / table! {
+ LL | |     users {
+ LL | |         id -> Integer,
+ LL | |         name -> Text,
+...  |
+LL | | }
+   | |_^
+note: required for `users::columns::id` to implement `ValidGrouping<users::columns::name>`
+  --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:7:9
+   |
+ LL |         id -> Integer,
+   |         ^^
+   = note: associated types for the current `impl` cannot be restricted in `where` clauses
+   = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ...>` to implement `OrderDsl<users::columns::id>`
+
+      = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `SelectStatement<..., ..., ..., ..., ..., ..., ...>: SelectDsl<_>` is not satisfied
+   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:83:47
+    |
+ LL |     let _ = users.group_by(name).order_by(id).select(name);
+    |                                               ^^^^^^ the trait `SelectDsl<_>` is not implemented for `SelectStatement<..., ..., ..., ..., ..., ..., ...>`
+    |
+help: the following other types implement trait `SelectDsl<Selection>`
+   --> DIESEL/diesel/diesel/src/query_builder/select_statement/dsl_impls.rs
+    |
+LL | / impl<F, S, D, W, O, LOf, G, H, LC, Selection> SelectDsl<Selection>
+LL | |     for SelectStatement<FromClause<F>, S, D, W, O, LOf, G, H, LC>
+LL | | where
+LL | |     G: ValidGroupByClause,
+...   |
+LL | |     <Selection as ValidGrouping<G::Expressions>>::IsAggregate:
+LL | |         MixedAggregates<<O as ValidGrouping<G::Expressions>>::IsAggregate>,
+    | |___________________________________________________________________________^ `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
+...
+LL | / impl<S, D, W, O, LOf, G, H, LC, Selection> SelectDsl<Selection>
+LL | |     for SelectStatement<NoFromClause, S, D, W, O, LOf, G, H, LC>
+LL | | where
+LL | |     G: ValidGroupByClause,
+LL | |     Selection: SelectableExpression<NoFromClause> + ValidGrouping<G::Expressions>,
+LL | |     SelectStatement<NoFromClause, SelectClause<Selection>, D, W, O, LOf, G, H, LC>: Selec...
+LL | |     D: ValidDistinctForGroupBy<Selection, G::Expressions>,
+    | |__________________________________________________________^ `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
+ 
+    
+error[E0271]: type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
+  --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:93:10
+   |
+LL |         .order_by(id);
+   |          ^^^^^^^^ type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
+   |
+note: expected this to be `diesel::expression::is_contained_in_group_by::Yes`
+  --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:5:1
+   |
+ LL | / table! {
+ LL | |     users {
+ LL | |         id -> Integer,
+ LL | |         name -> Text,
+...  |
+LL | | }
+   | |_^
+note: required for `users::columns::id` to implement `ValidGrouping<users::columns::name>`
+  --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:7:9
+   |
+ LL |         id -> Integer,
+   |         ^^
+   = note: associated types for the current `impl` cannot be restricted in `where` clauses
+   = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ...>` to implement `OrderDsl<users::columns::id>`
+
+      = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0271]: type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
+   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:101:10
+    |
+LL |         .then_order_by(id);
+    |          ^^^^^^^^^^^^^ type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
+    |
+note: expected this to be `diesel::expression::is_contained_in_group_by::Yes`
+   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:5:1
+    |
+  LL | / table! {
+  LL | |     users {
+  LL | |         id -> Integer,
+  LL | |         name -> Text,
+...   |
+ LL | | }
+    | |_^
+note: required for `users::columns::id` to implement `ValidGrouping<users::columns::name>`
+   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:7:9
+    |
+  LL |         id -> Integer,
+    |         ^^
+    = note: associated types for the current `impl` cannot be restricted in `where` clauses
+    = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ...>` to implement `ThenOrderDsl<users::columns::id>`
+ 
+        = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0271]: type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
+   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:109:10
+    |
+LL |         .then_order_by(id);
+    |          ^^^^^^^^^^^^^ type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
+    |
+note: expected this to be `diesel::expression::is_contained_in_group_by::Yes`
+   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:5:1
+    |
+  LL | / table! {
+  LL | |     users {
+  LL | |         id -> Integer,
+  LL | |         name -> Text,
+...   |
+ LL | | }
+    | |_^
+note: required for `users::columns::id` to implement `ValidGrouping<users::columns::name>`
+   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:7:9
+    |
+  LL |         id -> Integer,
+    |         ^^
+    = note: associated types for the current `impl` cannot be restricted in `where` clauses
+    = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ...>` to implement `ThenOrderDsl<users::columns::id>`
+ 
+        = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0271]: type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
+   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:113:49
+    |
+LL |     let _ = users.group_by(name).order_by(name).then_order_by(id);
+    |                                                 ^^^^^^^^^^^^^ type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
+    |
+note: expected this to be `diesel::expression::is_contained_in_group_by::Yes`
+   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:5:1
+    |
+  LL | / table! {
+  LL | |     users {
+  LL | |         id -> Integer,
+  LL | |         name -> Text,
+...   |
+ LL | | }
+    | |_^
+note: required for `users::columns::id` to implement `ValidGrouping<users::columns::name>`
+   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:7:9
+    |
+  LL |         id -> Integer,
+    |         ^^
+    = note: associated types for the current `impl` cannot be restricted in `where` clauses
+    = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ...>` to implement `ThenOrderDsl<users::columns::id>`
+ 
+        = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0271]: type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
+   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:117:52
+    |
+LL |     let _ = users.group_by(name).order_by(max(id)).then_order_by(id);
+    |                                                    ^^^^^^^^^^^^^ type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
+    |
+note: expected this to be `diesel::expression::is_contained_in_group_by::Yes`
+   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:5:1
+    |
+  LL | / table! {
+  LL | |     users {
+  LL | |         id -> Integer,
+  LL | |         name -> Text,
+...   |
+ LL | | }
+    | |_^
+note: required for `users::columns::id` to implement `ValidGrouping<users::columns::name>`
+   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:7:9
+    |
+  LL |         id -> Integer,
+    |         ^^
+    = note: associated types for the current `impl` cannot be restricted in `where` clauses
+    = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ...>` to implement `ThenOrderDsl<users::columns::id>`
+ 
+        = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0271]: type mismatch resolving `<(name, hair_color) as IsContainedInGroupBy<id>>::Output == Yes`
+   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:121:48
+    |
+LL |     let _ = users.group_by((name, hair_color)).order_by(id);
+    |                                                ^^^^^^^^ expected `Yes`, found `No`
+    |
+note: required for `users::columns::id` to implement `ValidGrouping<(users::columns::name, users::columns::hair_color)>`
+   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:7:9
+    |
+  LL |         id -> Integer,
+    |         ^^
+    = note: associated types for the current `impl` cannot be restricted in `where` clauses
+    = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ...>` to implement `OrderDsl<users::columns::id>`
+ 
+        = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `id: IsContainedInGroupBy<value>` is not satisfied
+   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:132:10
+    |
+LL |         .order_by(child::value);
+    |          ^^^^^^^^ unsatisfied trait bound
+    |
+help: the trait `diesel::expression::IsContainedInGroupBy<child::columns::value>` is not implemented for `parent::columns::id`
+   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:15:9
+    |
+ LL |         id -> Integer,
+    |         ^^
+    = note: if your query contains columns from several tables in your group by or select clause make sure to call `allow_columns_to_appear_in_same_group_by_clause!` with these columns
+help: `parent::columns::id` implements trait `diesel::expression::IsContainedInGroupBy<T>`
+   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:13:1
+    |
+ LL | / table! {
+ LL | |     parent {
+ LL | |         id -> Integer,
+    | |         ^^
+    | |_________||
+    |           |`diesel::expression::IsContainedInGroupBy<parent::columns::name>`
+    |           `diesel::expression::IsContainedInGroupBy<parent::columns::id>`
+note: required for `child::columns::value` to implement `ValidGrouping<parent::columns::id>`
+   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:24:9
+    |
+ LL |         value -> Text,
+    |         ^^^^^
+    = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ...>` to implement `OrderDsl<child::columns::value>`
+ 
+        = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `id: IsContainedInGroupBy<value>` is not satisfied
+   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:140:10
+    |
+LL |         .then_order_by(child::value);
+    |          ^^^^^^^^^^^^^ unsatisfied trait bound
+    |
+help: the trait `diesel::expression::IsContainedInGroupBy<child::columns::value>` is not implemented for `parent::columns::id`
+   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:15:9
+    |
+ LL |         id -> Integer,
+    |         ^^
+    = note: if your query contains columns from several tables in your group by or select clause make sure to call `allow_columns_to_appear_in_same_group_by_clause!` with these columns
+help: `parent::columns::id` implements trait `diesel::expression::IsContainedInGroupBy<T>`
+   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:13:1
+    |
+ LL | / table! {
+ LL | |     parent {
+ LL | |         id -> Integer,
+    | |         ^^
+    | |_________||
+    |           |`diesel::expression::IsContainedInGroupBy<parent::columns::name>`
+    |           `diesel::expression::IsContainedInGroupBy<parent::columns::id>`
+note: required for `child::columns::value` to implement `ValidGrouping<parent::columns::id>`
+   --> tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.rs:24:9
+    |
+ LL |         value -> Text,
+    |         ^^^^^
+    = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ...>` to implement `ThenOrderDsl<child::columns::value>`
+ 
+        = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/diesel_tests/tests/aggregate_expressions.rs
+++ b/diesel_tests/tests/aggregate_expressions.rs
@@ -356,3 +356,17 @@ fn then_order_by_aggregate() {
         .unwrap();
     assert_eq!(res, Some(2));
 }
+
+#[diesel_test_helper::test]
+fn order_group_by_then_order_by() {
+    let mut conn = connection_with_sean_and_tess_in_users_table();
+
+    let res = users::table
+        .order_by(users::name)
+        .group_by(users::name)
+        .then_order_by(dsl::max(users::id))
+        .select(dsl::max(users::id))
+        .get_result::<Option<i32>>(&mut conn)
+        .unwrap();
+    assert_eq!(res, Some(1));
+}

--- a/diesel_tests/tests/aggregate_expressions.rs
+++ b/diesel_tests/tests/aggregate_expressions.rs
@@ -5,6 +5,251 @@ use diesel::dsl;
 use diesel::prelude::*;
 
 #[diesel_test_helper::test]
+fn order_by_non_aggregate() {
+    let mut conn = connection_with_sean_and_tess_in_users_table();
+    let res = users::table
+        .select(users::id)
+        .order_by(users::name)
+        .load::<i32>(&mut conn)
+        .unwrap();
+    assert_eq!(res, vec![1, 2]);
+}
+
+#[diesel_test_helper::test]
+fn order_by_non_aggregate_before_select() {
+    let mut conn = connection_with_sean_and_tess_in_users_table();
+    let res = users::table
+        .order_by(users::name)
+        .select(users::name)
+        .load::<String>(&mut conn)
+        .unwrap();
+    assert_eq!(res, vec!["Sean", "Tess"]);
+}
+
+#[diesel_test_helper::test]
+fn order_by_grouped_col_before_select() {
+    let mut conn = connection_with_sean_and_tess_in_users_table();
+    let res = users::table
+        .group_by(users::name)
+        .order_by(users::name)
+        .select((users::name, dsl::max(users::id)))
+        .load::<(String, Option<i32>)>(&mut conn)
+        .unwrap();
+    assert_eq!(
+        res,
+        vec![("Sean".to_string(), Some(1)), ("Tess".to_string(), Some(2)),]
+    );
+}
+
+#[diesel_test_helper::test]
+fn order_by_aggregate_before_select() {
+    let mut conn = connection_with_sean_and_tess_in_users_table();
+    let res = users::table
+        .group_by(users::name)
+        .order_by(dsl::max(users::id))
+        .select((users::name, dsl::max(users::id)))
+        .load::<(String, Option<i32>)>(&mut conn)
+        .unwrap();
+    assert_eq!(
+        res,
+        vec![("Sean".to_string(), Some(1)), ("Tess".to_string(), Some(2)),]
+    );
+}
+
+#[diesel_test_helper::test]
+fn order_by_aggregate_before_grouped_col_select() {
+    let mut conn = connection_with_sean_and_tess_in_users_table();
+    // Ordering by aggregate, selecting only the grouped column
+    let res = users::table
+        .group_by(users::name)
+        .order_by(dsl::max(users::id))
+        .select(users::name)
+        .load::<String>(&mut conn)
+        .unwrap();
+    assert_eq!(res, vec!["Sean", "Tess"]);
+}
+
+#[diesel_test_helper::test]
+fn then_order_by_aggregate_before_select() {
+    let mut conn = connection_with_sean_and_tess_in_users_table();
+    let res = users::table
+        .group_by(users::name)
+        .order_by(users::name)
+        .then_order_by(dsl::max(users::id))
+        .select((users::name, dsl::max(users::id)))
+        .load::<(String, Option<i32>)>(&mut conn)
+        .unwrap();
+    assert_eq!(
+        res,
+        vec![("Sean".to_string(), Some(1)), ("Tess".to_string(), Some(2)),]
+    );
+}
+
+#[diesel_test_helper::test]
+fn then_order_by_grouped_col_after_aggregate_before_select() {
+    let mut conn = connection_with_sean_and_tess_in_users_table();
+    let res = users::table
+        .group_by(users::name)
+        .order_by(dsl::max(users::id))
+        .then_order_by(users::name)
+        .select((users::name, dsl::max(users::id)))
+        .load::<(String, Option<i32>)>(&mut conn)
+        .unwrap();
+    assert_eq!(
+        res,
+        vec![("Sean".to_string(), Some(1)), ("Tess".to_string(), Some(2)),]
+    );
+}
+
+#[diesel_test_helper::test]
+fn then_order_by_grouped_col_after_aggregate_select_first() {
+    let mut conn = connection_with_sean_and_tess_in_users_table();
+    let res = users::table
+        .group_by(users::name)
+        .select((users::name, dsl::max(users::id)))
+        .order_by(dsl::max(users::id))
+        .then_order_by(users::name)
+        .load::<(String, Option<i32>)>(&mut conn)
+        .unwrap();
+    assert_eq!(
+        res,
+        vec![("Sean".to_string(), Some(1)), ("Tess".to_string(), Some(2)),]
+    );
+}
+
+#[diesel_test_helper::test]
+fn order_by_aggregate_after_select_with_group_by() {
+    let mut conn = connection_with_sean_and_tess_in_users_table();
+    let res = users::table
+        .group_by(users::name)
+        .select((users::name, dsl::max(users::id)))
+        .order_by(dsl::max(users::id))
+        .load::<(String, Option<i32>)>(&mut conn)
+        .unwrap();
+    assert_eq!(
+        res,
+        vec![("Sean".to_string(), Some(1)), ("Tess".to_string(), Some(2)),]
+    );
+}
+
+#[diesel_test_helper::test]
+fn then_order_by_aggregate_after_select_with_group_by() {
+    let mut conn = connection_with_sean_and_tess_in_users_table();
+    let res = users::table
+        .group_by(users::name)
+        .select((users::name, dsl::max(users::id)))
+        .order_by(users::name)
+        .then_order_by(dsl::max(users::id))
+        .load::<(String, Option<i32>)>(&mut conn)
+        .unwrap();
+    assert_eq!(
+        res,
+        vec![("Sean".to_string(), Some(1)), ("Tess".to_string(), Some(2)),]
+    );
+}
+
+#[diesel_test_helper::test]
+fn order_by_aggregate_multi_col_group_by_before_select() {
+    let mut conn = connection_with_sean_and_tess_in_users_table();
+    let res = users::table
+        .group_by((users::name, users::hair_color))
+        .order_by(dsl::max(users::id))
+        .select((users::name, dsl::max(users::id)))
+        .load::<(String, Option<i32>)>(&mut conn)
+        .unwrap();
+    assert_eq!(
+        res,
+        vec![("Sean".to_string(), Some(1)), ("Tess".to_string(), Some(2)),]
+    );
+}
+
+#[diesel_test_helper::test]
+fn order_by_aggregate_with_left_join_and_group_by() {
+    let mut conn = connection_with_sean_and_tess_in_users_table();
+    diesel::insert_into(posts::table)
+        .values([
+            (posts::user_id.eq(1), posts::title.eq("Sean post 1")),
+            (posts::user_id.eq(1), posts::title.eq("Sean post 2")),
+            (posts::user_id.eq(2), posts::title.eq("Tess post 1")),
+        ])
+        .execute(&mut conn)
+        .unwrap();
+    let res = users::table
+        .left_join(posts::table)
+        .group_by(users::id)
+        .order_by(dsl::count(posts::id.nullable()))
+        .select((users::id, dsl::count(posts::id.nullable())))
+        .load::<(i32, i64)>(&mut conn)
+        .unwrap();
+    assert_eq!(res, vec![(2, 1), (1, 2)]);
+}
+
+#[diesel_test_helper::test]
+fn order_by_grouped_col_with_left_join_before_select() {
+    let mut conn = connection_with_sean_and_tess_in_users_table();
+    diesel::insert_into(posts::table)
+        .values([
+            (posts::user_id.eq(1), posts::title.eq("Sean post 1")),
+            (posts::user_id.eq(1), posts::title.eq("Sean post 2")),
+            (posts::user_id.eq(2), posts::title.eq("Tess post 1")),
+        ])
+        .execute(&mut conn)
+        .unwrap();
+    let res = users::table
+        .left_join(posts::table)
+        .group_by(users::id)
+        .order_by(users::id)
+        .select((users::id, dsl::count(posts::id.nullable())))
+        .load::<(i32, i64)>(&mut conn)
+        .unwrap();
+    assert_eq!(res, vec![(1, 2), (2, 1)]);
+}
+
+#[diesel_test_helper::test]
+fn then_order_by_aggregate_with_left_join() {
+    let mut conn = connection_with_sean_and_tess_in_users_table();
+    diesel::insert_into(posts::table)
+        .values([
+            (posts::user_id.eq(1), posts::title.eq("Sean post 1")),
+            (posts::user_id.eq(1), posts::title.eq("Sean post 2")),
+            (posts::user_id.eq(2), posts::title.eq("Tess post 1")),
+        ])
+        .execute(&mut conn)
+        .unwrap();
+    let res = users::table
+        .left_join(posts::table)
+        .group_by(users::id)
+        .order_by(users::id)
+        .then_order_by(dsl::count(posts::id.nullable()))
+        .select((users::id, dsl::count(posts::id.nullable())))
+        .load::<(i32, i64)>(&mut conn)
+        .unwrap();
+    assert_eq!(res, vec![(1, 2), (2, 1)]);
+}
+
+#[diesel_test_helper::test]
+fn then_order_by_grouped_col_after_aggregate_with_left_join() {
+    let mut conn = connection_with_sean_and_tess_in_users_table();
+    diesel::insert_into(posts::table)
+        .values([
+            (posts::user_id.eq(1), posts::title.eq("Sean post 1")),
+            (posts::user_id.eq(1), posts::title.eq("Sean post 2")),
+            (posts::user_id.eq(2), posts::title.eq("Tess post 1")),
+        ])
+        .execute(&mut conn)
+        .unwrap();
+    let res = users::table
+        .left_join(posts::table)
+        .group_by(users::id)
+        .order_by(dsl::count(posts::id.nullable()))
+        .then_order_by(users::id)
+        .select((users::id, dsl::count(posts::id.nullable())))
+        .load::<(i32, i64)>(&mut conn)
+        .unwrap();
+    assert_eq!(res, vec![(2, 1), (1, 2)]);
+}
+
+#[diesel_test_helper::test]
 fn count_distinct() {
     let mut conn = connection_with_sean_and_tess_in_users_table();
     diesel::insert_into(posts::table)
@@ -88,13 +333,12 @@ fn order_by_aggregate_with_aggregate_select() {
 #[diesel_test_helper::test]
 fn order_by_group_by_column_with_aggregate_select() {
     let mut conn = connection_with_sean_and_tess_in_users_table();
-    let mut res = users::table
+    let res = users::table
         .group_by(users::name)
         .select((users::name, dsl::max(users::id)))
         .order_by(users::name)
         .load::<(String, Option<i32>)>(&mut conn)
         .unwrap();
-    res.sort();
     assert_eq!(
         res,
         vec![("Sean".to_string(), Some(1)), ("Tess".to_string(), Some(2)),]


### PR DESCRIPTION
Since `v2.3.8`, calling `order_by()` or `then_order_by()` with an aggregate expression on a query that has a `group_by()` clause incorrectly failed to compile, even though the resulting SQL is valid. The check introduced in `v2.3.8` validated the `SELECT` clause against the `ORDER BY` expression at `order_by()` call time, which blocked valid patterns like:

```rust
table.group_by(col).order_by(max(other_col)).select(...)
```

The fix splits the `OrderDsl` and `ThenOrderDsl` impls into two variants: one for `NoGroupByClause` (preserves the existing `MixedAggregates` check) and one for `GroupByClause<GB>` (only requires the `ORDER BY` expression to satisfy `ValidGrouping<GB>`, i.e. be a grouped column or aggregate).

Closes https://github.com/diesel-rs/diesel/issues/5057