### PR TITLE
feat(sqlite): add json_replace, jsonb_replace, json_set, and jsonb_set functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 * Added `SqliteConnection::with_raw_connection` to provide safe, callback-based access to the raw `*mut sqlite3` handle for advanced SQLite C APIs (session extension, hooks, etc.)
 * Added `json_extract` and `jsonb_extract` SQL function support for the SQLite backend
 * Added `json_insert` and `jsonb_insert` SQL function support for the SQLite backend
+* Added `json_replace`, `jsonb_replace`, `json_set`, and `jsonb_set` SQL function support for the SQLite backend
 * Added `SqliteConnection::get_read_only_blob` method to stream blob's from a SQLite database to Rust via `std::io::Read`
 * Added support for casting to `REAL` in SQLite.
 * Added `ToSql`, `FromSql`, `Queryable`, and `AsExpression` impls for `Rc<T>`, `Arc<T>`, and `Box<T>` (including `Rc/Arc<dyn BoxableExpression>` for cloneable dynamic query fragments and the `<str>` / `<[u8]>` unsized variants).

--- a/diesel/src/reexport_ambiguities.rs
+++ b/diesel/src/reexport_ambiguities.rs
@@ -140,6 +140,12 @@ macro_rules! make_proxy_mod {
             type json_remove_0 = ();
             type json_remove_1 = ();
             type json_remove_2 = ();
+            type json_replace_0 = ();
+            type json_replace_1 = ();
+            type json_replace_2 = ();
+            type json_set_0 = ();
+            type json_set_1 = ();
+            type json_set_2 = ();
             type json_type = ();
             type json_type_with_path = ();
             type json_valid = ();
@@ -165,6 +171,12 @@ macro_rules! make_proxy_mod {
             type jsonb_remove_0 = ();
             type jsonb_remove_1 = ();
             type jsonb_remove_2 = ();
+            type jsonb_replace_0 = ();
+            type jsonb_replace_1 = ();
+            type jsonb_replace_2 = ();
+            type jsonb_set_0 = ();
+            type jsonb_set_1 = ();
+            type jsonb_set_2 = ();
         }
     };
 }

--- a/diesel/src/sqlite/expression/functions.rs
+++ b/diesel/src/sqlite/expression/functions.rs
@@ -2282,6 +2282,288 @@ extern "SQL" {
         value: V,
     ) -> J::Out;
 
+    /// The `json_replace(X,P,V,...)` SQL function takes a single JSON value as its first argument
+    /// followed by zero or more pairs of path and value arguments. It returns a copy of the X
+    /// argument with values V substituted at the paths P, but only where something already exists
+    /// at the path. Paths that select elements not found in X are silently ignored.
+    ///
+    /// The path/value pairs are applied sequentially from left to right.
+    ///
+    /// If the `json_replace(X)` function is called with no path/value pairs, then it returns the
+    /// input X reformatted, with excess whitespace removed.
+    ///
+    /// The `json_replace()` function throws an error if any of the path arguments is not a
+    /// well-formed path.
+    ///
+    /// This function requires at least SQLite 3.38 or newer
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # include!("../../doctest_setup.rs");
+    /// #
+    /// # fn main() {
+    /// #     #[cfg(feature = "serde_json")]
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # #[cfg(feature = "serde_json")]
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use diesel::dsl::*;
+    /// #     use diesel::sql_types::{Integer, Json, Text, Nullable};
+    /// #     use serde_json::json;
+    /// #
+    /// #     let connection = &mut establish_connection();
+    /// #     assert_version!(connection, 3, 38, 0);
+    /// #
+    /// let json = json!({"a": 1, "b": 2});
+    /// let result = diesel::select(json_replace_1::<Json, Integer, _, _, _>(json, "$.a", 99))
+    ///     .get_result::<serde_json::Value>(connection)?;
+    /// assert_eq!(json!({"a": 99, "b": 2}), result);
+    ///
+    /// // A path that does not exist is silently ignored.
+    /// let json = json!({"a": 1});
+    /// let result = diesel::select(json_replace_1::<Json, Integer, _, _, _>(json, "$.b", 2))
+    ///     .get_result::<serde_json::Value>(connection)?;
+    /// assert_eq!(json!({"a": 1}), result);
+    ///
+    /// let json = json!({"a": 1, "b": 2});
+    /// let result = diesel::select(
+    ///     json_replace_2::<Json, Integer, Text, _, _, _, _, _>(json, "$.a", 99, "$.b", "x"),
+    /// )
+    /// .get_result::<serde_json::Value>(connection)?;
+    /// assert_eq!(json!({"a": 99, "b": "x"}), result);
+    ///
+    /// let json = json!({"a": 1});
+    /// let result = diesel::select(json_replace_0::<Json, _>(json))
+    ///     .get_result::<serde_json::Value>(connection)?;
+    /// assert_eq!(json!({"a": 1}), result);
+    ///
+    /// let result = diesel::select(json_replace_1::<Nullable<Json>, Integer, _, _, _>(None::<serde_json::Value>, "$.a", 1))
+    ///     .get_result::<Option<serde_json::Value>>(connection)?;
+    /// assert_eq!(result, None);
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[cfg(feature = "__sqlite-shared")]
+    #[variadic(2)]
+    fn json_replace<
+        J: JsonOrNullableJsonOrJsonbOrNullableJsonb + MaybeNullableValue<Json> + SingleValue,
+        V: NotBlob,
+    >(
+        json: J,
+        path: Text,
+        value: V,
+    ) -> J::Out;
+
+    /// The `jsonb_replace(X,P,V,...)` SQL function works just like the [`json_replace()`](json_replace_1())
+    /// function except that the result is returned in SQLite's private binary JSONB format rather than
+    /// in the standard RFC 8259 text format.
+    ///
+    /// This function requires at least SQLite 3.38 or newer
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # include!("../../doctest_setup.rs");
+    /// #
+    /// # fn main() {
+    /// #     #[cfg(feature = "serde_json")]
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # #[cfg(feature = "serde_json")]
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use diesel::dsl::*;
+    /// #     use diesel::sql_types::{Integer, Jsonb, Text, Nullable};
+    /// #     use serde_json::json;
+    /// #
+    /// #     let connection = &mut establish_connection();
+    /// #     assert_version!(connection, 3, 38, 0);
+    /// #
+    /// let json = json!({"a": 1, "b": 2});
+    /// let result = diesel::select(jsonb_replace_1::<Jsonb, Integer, _, _, _>(json, "$.a", 99))
+    ///     .get_result::<serde_json::Value>(connection)?;
+    /// assert_eq!(json!({"a": 99, "b": 2}), result);
+    ///
+    /// // A path that does not exist is silently ignored.
+    /// let json = json!({"a": 1});
+    /// let result = diesel::select(jsonb_replace_1::<Jsonb, Integer, _, _, _>(json, "$.b", 2))
+    ///     .get_result::<serde_json::Value>(connection)?;
+    /// assert_eq!(json!({"a": 1}), result);
+    ///
+    /// let json = json!({"a": 1});
+    /// let result = diesel::select(jsonb_replace_0::<Jsonb, _>(json))
+    ///     .get_result::<serde_json::Value>(connection)?;
+    /// assert_eq!(json!({"a": 1}), result);
+    ///
+    /// let result = diesel::select(jsonb_replace_1::<Nullable<Jsonb>, Integer, _, _, _>(None::<serde_json::Value>, "$.a", 1))
+    ///     .get_result::<Option<serde_json::Value>>(connection)?;
+    /// assert_eq!(result, None);
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[cfg(feature = "__sqlite-shared")]
+    #[variadic(2)]
+    fn jsonb_replace<
+        J: JsonOrNullableJsonOrJsonbOrNullableJsonb + MaybeNullableValue<Jsonb> + SingleValue,
+        V: NotBlob,
+    >(
+        json: J,
+        path: Text,
+        value: V,
+    ) -> J::Out;
+
+    /// The `json_set(X,P,V,...)` SQL function takes a single JSON value as its first argument
+    /// followed by zero or more pairs of path and value arguments. It returns a copy of the X
+    /// argument with values V inserted or replaced at the paths P. Unlike [`json_replace()`](json_replace_1()),
+    /// `json_set()` also inserts new values where the path does not already exist.
+    ///
+    /// The path/value pairs are applied sequentially from left to right.
+    ///
+    /// A path that ends in `[#]` appends the value to an existing array.
+    ///
+    /// If the `json_set(X)` function is called with no path/value pairs, then it returns the
+    /// input X reformatted, with excess whitespace removed.
+    ///
+    /// The `json_set()` function throws an error if any of the path arguments is not a
+    /// well-formed path.
+    ///
+    /// This function requires at least SQLite 3.38 or newer
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # include!("../../doctest_setup.rs");
+    /// #
+    /// # fn main() {
+    /// #     #[cfg(feature = "serde_json")]
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # #[cfg(feature = "serde_json")]
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use diesel::dsl::*;
+    /// #     use diesel::sql_types::{Integer, Json, Text, Nullable};
+    /// #     use serde_json::json;
+    /// #
+    /// #     let connection = &mut establish_connection();
+    /// #     assert_version!(connection, 3, 38, 0);
+    /// #
+    /// let json = json!({"a": 1});
+    /// let result = diesel::select(json_set_1::<Json, Integer, _, _, _>(json, "$.b", 2))
+    ///     .get_result::<serde_json::Value>(connection)?;
+    /// assert_eq!(json!({"a": 1, "b": 2}), result);
+    ///
+    /// // Existing values are replaced.
+    /// let json = json!({"a": 1});
+    /// let result = diesel::select(json_set_1::<Json, Integer, _, _, _>(json, "$.a", 99))
+    ///     .get_result::<serde_json::Value>(connection)?;
+    /// assert_eq!(json!({"a": 99}), result);
+    ///
+    /// // A path ending in "[#]" appends to an array.
+    /// let json = json!(['a', 'b', 'c']);
+    /// let result = diesel::select(json_set_1::<Json, Text, _, _, _>(json, "$[#]", "d"))
+    ///     .get_result::<serde_json::Value>(connection)?;
+    /// assert_eq!(json!(['a', 'b', 'c', 'd']), result);
+    ///
+    /// let json = json!({"a": 1});
+    /// let result = diesel::select(
+    ///     json_set_2::<Json, Integer, Integer, _, _, _, _, _>(json, "$.b", 2, "$.c", 3),
+    /// )
+    /// .get_result::<serde_json::Value>(connection)?;
+    /// assert_eq!(json!({"a": 1, "b": 2, "c": 3}), result);
+    ///
+    /// let json = json!({"a": 1});
+    /// let result = diesel::select(json_set_0::<Json, _>(json))
+    ///     .get_result::<serde_json::Value>(connection)?;
+    /// assert_eq!(json!({"a": 1}), result);
+    ///
+    /// let result = diesel::select(json_set_1::<Nullable<Json>, Integer, _, _, _>(None::<serde_json::Value>, "$.b", 1))
+    ///     .get_result::<Option<serde_json::Value>>(connection)?;
+    /// assert_eq!(result, None);
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[cfg(feature = "__sqlite-shared")]
+    #[variadic(2)]
+    fn json_set<
+        J: JsonOrNullableJsonOrJsonbOrNullableJsonb + MaybeNullableValue<Json> + SingleValue,
+        V: NotBlob,
+    >(
+        json: J,
+        path: Text,
+        value: V,
+    ) -> J::Out;
+
+    /// The `jsonb_set(X,P,V,...)` SQL function works just like the [`json_set()`](json_set_1())
+    /// function except that the result is returned in SQLite's private binary JSONB format rather than
+    /// in the standard RFC 8259 text format.
+    ///
+    /// This function requires at least SQLite 3.38 or newer
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # include!("../../doctest_setup.rs");
+    /// #
+    /// # fn main() {
+    /// #     #[cfg(feature = "serde_json")]
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # #[cfg(feature = "serde_json")]
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use diesel::dsl::*;
+    /// #     use diesel::sql_types::{Integer, Jsonb, Text, Nullable};
+    /// #     use serde_json::json;
+    /// #
+    /// #     let connection = &mut establish_connection();
+    /// #     assert_version!(connection, 3, 38, 0);
+    /// #
+    /// let json = json!({"a": 1});
+    /// let result = diesel::select(jsonb_set_1::<Jsonb, Integer, _, _, _>(json, "$.b", 2))
+    ///     .get_result::<serde_json::Value>(connection)?;
+    /// assert_eq!(json!({"a": 1, "b": 2}), result);
+    ///
+    /// // Existing values are replaced.
+    /// let json = json!({"a": 1});
+    /// let result = diesel::select(jsonb_set_1::<Jsonb, Integer, _, _, _>(json, "$.a", 99))
+    ///     .get_result::<serde_json::Value>(connection)?;
+    /// assert_eq!(json!({"a": 99}), result);
+    ///
+    /// // A path ending in "[#]" appends to an array.
+    /// let json = json!(['a', 'b', 'c']);
+    /// let result = diesel::select(jsonb_set_1::<Jsonb, Text, _, _, _>(json, "$[#]", "d"))
+    ///     .get_result::<serde_json::Value>(connection)?;
+    /// assert_eq!(json!(['a', 'b', 'c', 'd']), result);
+    ///
+    /// let json = json!({"a": 1});
+    /// let result = diesel::select(jsonb_set_0::<Jsonb, _>(json))
+    ///     .get_result::<serde_json::Value>(connection)?;
+    /// assert_eq!(json!({"a": 1}), result);
+    ///
+    /// let result = diesel::select(jsonb_set_1::<Nullable<Jsonb>, Integer, _, _, _>(None::<serde_json::Value>, "$.b", 1))
+    ///     .get_result::<Option<serde_json::Value>>(connection)?;
+    /// assert_eq!(result, None);
+    /// #
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[cfg(feature = "__sqlite-shared")]
+    #[variadic(2)]
+    fn jsonb_set<
+        J: JsonOrNullableJsonOrJsonbOrNullableJsonb + MaybeNullableValue<Jsonb> + SingleValue,
+        V: NotBlob,
+    >(
+        json: J,
+        path: Text,
+        value: V,
+    ) -> J::Out;
+
     /// Applies an RFC 7396 MergePatch `patch` to the input JSON `target` and
     /// returns the patched JSON value.
     ///

--- a/diesel_derives/tests/auto_type.rs
+++ b/diesel_derives/tests/auto_type.rs
@@ -630,6 +630,42 @@ fn sqlite_variadic_functions() -> _ {
             sqlite_extras::text,
             sqlite_extras::text,
         ),
+        json_replace_0(sqlite_extras::json),
+        json_replace_1(sqlite_extras::jsonb, sqlite_extras::text, sqlite_extras::id),
+        json_replace_2(
+            sqlite_extras::json,
+            sqlite_extras::text,
+            sqlite_extras::id,
+            sqlite_extras::text,
+            sqlite_extras::json,
+        ),
+        jsonb_replace_0(sqlite_extras::jsonb),
+        jsonb_replace_1(sqlite_extras::json, sqlite_extras::text, sqlite_extras::id),
+        jsonb_replace_2(
+            sqlite_extras::jsonb,
+            sqlite_extras::text,
+            sqlite_extras::id,
+            sqlite_extras::text,
+            sqlite_extras::json,
+        ),
+        json_set_0(sqlite_extras::json),
+        json_set_1(sqlite_extras::jsonb, sqlite_extras::text, sqlite_extras::id),
+        json_set_2(
+            sqlite_extras::json,
+            sqlite_extras::text,
+            sqlite_extras::id,
+            sqlite_extras::text,
+            sqlite_extras::json,
+        ),
+        jsonb_set_0(sqlite_extras::jsonb),
+        jsonb_set_1(sqlite_extras::json, sqlite_extras::text, sqlite_extras::id),
+        jsonb_set_2(
+            sqlite_extras::jsonb,
+            sqlite_extras::text,
+            sqlite_extras::id,
+            sqlite_extras::text,
+            sqlite_extras::json,
+        ),
     )
 }
 


### PR DESCRIPTION
Closes part of #4366.

Adds `json_replace`, `jsonb_replace`, `json_set`, and `jsonb_set` variadic SQL functions for the SQLite backend, following the same pattern as the recently merged `json_remove`/`jsonb_remove` (PR #4597) and `json_insert`/`jsonb_insert` (PR #5062).

## What's added

**`json_replace(json, path, value, ...)`** — replaces values at existing paths only; silently ignores paths that don't exist. Returns RFC 8259 text JSON.

**`jsonb_replace(json, path, value, ...)`** — same as `json_replace` but returns SQLite binary JSONB.

**`json_set(json, path, value, ...)`** — inserts new values AND replaces existing ones. Supports `[#]` path suffix to append to arrays. Returns RFC 8259 text JSON.

**`jsonb_set(json, path, value, ...)`** — same as `json_set` but returns SQLite binary JSONB.

All four use `#[variadic(2)]` to generate `_0`, `_1`, `_2` variants. Nullability is propagated via `MaybeNullableValue` so a nullable JSON input yields a nullable output. Requires SQLite ≥ 3.38.

## Changes

- `diesel/src/sqlite/expression/functions.rs` — function definitions with doc examples
- `diesel/src/reexport_ambiguities.rs` — proxy type entries for the generated variants
- `diesel_derives/tests/auto_type.rs` — `#[auto_type]` inference tests
- `CHANGELOG.md` — entry under Unreleased → Added

## AI disclosure

This PR was developed with AI assistance (Claude). I have reviewed all generated code, understand what it does, and verified it follows the existing patterns in the codebase (matching `json_insert`/`jsonb_insert`). The implementation is minimal and focused solely on adding the four missing functions.