### PR TITLE
fix(sqlite): support batch insert with explicit RETURNING clause (rebased #5038)

### DIFF
--- a/diesel/src/query_builder/insert_statement/insert_with_default_for_sqlite.rs
+++ b/diesel/src/query_builder/insert_statement/insert_with_default_for_sqlite.rs
@@ -3,6 +3,7 @@ use crate::insertable::{
     CanInsertInSingleQuery, ColumnInsertValue, DefaultableColumnInsertValue, InsertValues,
 };
 use crate::prelude::*;
+use crate::query_builder::returning_clause::ReturningClause;
 use crate::query_builder::debug_query::DebugBinds;
 use crate::query_builder::upsert::on_conflict_clause::OnConflictValues;
 use crate::query_builder::{
@@ -341,6 +342,30 @@ where
     }
 }
 
+impl<'query, V, T, QId, Op, Ret, O, U, B, const STATIC_QUERY_ID: bool>
+    LoadQuery<'query, SqliteConnection, U, B>
+    for InsertStatement<
+        T,
+        BatchInsert<Vec<ValuesClause<V, T>>, T, QId, STATIC_QUERY_ID>,
+        Op,
+        ReturningClause<Ret>,
+    >
+where
+    T: QuerySource,
+    V: ContainsDefaultableValue<Out = O>,
+    O: Default,
+    (O, Self): LoadQuery<'query, SqliteConnection, U, B>,
+{
+    type RowIter<'conn> = <(O, Self) as LoadQuery<'query, SqliteConnection, U, B>>::RowIter<'conn>;
+
+    fn internal_load(self, conn: &mut SqliteConnection) -> QueryResult<Self::RowIter<'_>> {
+        <(O, Self) as LoadQuery<'query, SqliteConnection, U, B>>::internal_load(
+            (O::default(), self),
+            conn,
+        )
+    }
+}
+
 impl<'query, V, T, QId, Op, O, U, B, Target, ConflictOpt, const STATIC_QUERY_ID: bool>
     LoadQuery<'query, SqliteConnection, U, B>
     for InsertStatement<
@@ -351,6 +376,34 @@ impl<'query, V, T, QId, Op, O, U, B, Target, ConflictOpt, const STATIC_QUERY_ID:
             ConflictOpt,
         >,
         Op,
+    >
+where
+    T: QuerySource,
+    V: ContainsDefaultableValue<Out = O>,
+    O: Default,
+    (O, Self): LoadQuery<'query, SqliteConnection, U, B>,
+{
+    type RowIter<'conn> = <(O, Self) as LoadQuery<'query, SqliteConnection, U, B>>::RowIter<'conn>;
+
+    fn internal_load(self, conn: &mut SqliteConnection) -> QueryResult<Self::RowIter<'_>> {
+        <(O, Self) as LoadQuery<'query, SqliteConnection, U, B>>::internal_load(
+            (O::default(), self),
+            conn,
+        )
+    }
+}
+
+impl<'query, V, T, QId, Op, Ret, O, U, B, Target, ConflictOpt, const STATIC_QUERY_ID: bool>
+    LoadQuery<'query, SqliteConnection, U, B>
+    for InsertStatement<
+        T,
+        OnConflictValues<
+            BatchInsert<Vec<ValuesClause<V, T>>, T, QId, STATIC_QUERY_ID>,
+            Target,
+            ConflictOpt,
+        >,
+        Op,
+        ReturningClause<Ret>,
     >
 where
     T: QuerySource,
@@ -379,6 +432,29 @@ where
     O: Default,
     InsertStatement<T, BatchInsert<Vec<ValuesClause<V, T>>, T, QId, STATIC_QUERY_ID>, Op>:
         RunQueryDsl<SqliteConnection>,
+{
+}
+
+impl<V, T, QId, Op, Ret, O, const STATIC_QUERY_ID: bool> RunQueryDsl<SqliteConnection>
+    for (
+        O,
+        InsertStatement<
+            T,
+            BatchInsert<Vec<ValuesClause<V, T>>, T, QId, STATIC_QUERY_ID>,
+            Op,
+            ReturningClause<Ret>,
+        >,
+    )
+where
+    T: QuerySource,
+    V: ContainsDefaultableValue<Out = O>,
+    O: Default,
+    InsertStatement<
+        T,
+        BatchInsert<Vec<ValuesClause<V, T>>, T, QId, STATIC_QUERY_ID>,
+        Op,
+        ReturningClause<Ret>,
+    >: RunQueryDsl<SqliteConnection>,
 {
 }
 
@@ -412,6 +488,38 @@ where
 {
 }
 
+impl<V, T, QId, Op, Ret, O, Target, ConflictOpt, const STATIC_QUERY_ID: bool>
+    RunQueryDsl<SqliteConnection>
+    for (
+        O,
+        InsertStatement<
+            T,
+            OnConflictValues<
+                BatchInsert<Vec<ValuesClause<V, T>>, T, QId, STATIC_QUERY_ID>,
+                Target,
+                ConflictOpt,
+            >,
+            Op,
+            ReturningClause<Ret>,
+        >,
+    )
+where
+    T: QuerySource,
+    V: ContainsDefaultableValue<Out = O>,
+    O: Default,
+    InsertStatement<
+        T,
+        OnConflictValues<
+            BatchInsert<Vec<ValuesClause<V, T>>, T, QId, STATIC_QUERY_ID>,
+            Target,
+            ConflictOpt,
+        >,
+        Op,
+        ReturningClause<Ret>,
+    >: RunQueryDsl<SqliteConnection>,
+{
+}
+
 #[diagnostic::do_not_recommend]
 impl<'query, V, T, QId, Op, U, B, const STATIC_QUERY_ID: bool>
     LoadQuery<'query, SqliteConnection, U, B>
@@ -423,6 +531,58 @@ where
     T: Table + Copy + QueryId + 'static,
     Op: Copy + QueryId + QueryFragment<Sqlite>,
     InsertStatement<T, ValuesClause<V, T>, Op>: LoadQuery<'query, SqliteConnection, U, B>,
+    Self: RunQueryDsl<SqliteConnection>,
+{
+    type RowIter<'conn> = alloc::vec::IntoIter<QueryResult<U>>;
+
+    fn internal_load(self, conn: &mut SqliteConnection) -> QueryResult<Self::RowIter<'_>> {
+        let (Yes, query) = self;
+
+        conn.transaction(|conn| {
+            let mut results = Vec::with_capacity(query.records.values.len());
+
+            for record in query.records.values {
+                let stmt =
+                    InsertStatement::new(query.target, record, query.operator, query.returning);
+
+                let result = stmt
+                    .internal_load(conn)?
+                    .next()
+                    .ok_or(crate::result::Error::NotFound)?;
+
+                match &result {
+                    Ok(_) | Err(crate::result::Error::DeserializationError(_)) => {
+                        results.push(result)
+                    }
+                    Err(_) => {
+                        result?;
+                    }
+                };
+            }
+
+            Ok(results.into_iter())
+        })
+    }
+}
+
+#[diagnostic::do_not_recommend]
+impl<'query, V, T, QId, Op, Ret, U, B, const STATIC_QUERY_ID: bool>
+    LoadQuery<'query, SqliteConnection, U, B>
+    for (
+        Yes,
+        InsertStatement<
+            T,
+            BatchInsert<Vec<ValuesClause<V, T>>, T, QId, STATIC_QUERY_ID>,
+            Op,
+            ReturningClause<Ret>,
+        >,
+    )
+where
+    T: Table + Copy + QueryId + 'static,
+    Op: Copy + QueryId + QueryFragment<Sqlite>,
+    ReturningClause<Ret>: Copy,
+    InsertStatement<T, ValuesClause<V, T>, Op, ReturningClause<Ret>>:
+        LoadQuery<'query, SqliteConnection, U, B>,
     Self: RunQueryDsl<SqliteConnection>,
 {
     type RowIter<'conn> = alloc::vec::IntoIter<QueryResult<U>>;
@@ -480,6 +640,79 @@ where
     ConflictOpt: Copy,
     InsertStatement<T, OnConflictValues<ValuesClause<V, T>, Target, ConflictOpt>, Op>:
         LoadQuery<'query, SqliteConnection, U, B>,
+    Self: RunQueryDsl<SqliteConnection>,
+{
+    type RowIter<'conn> = alloc::vec::IntoIter<QueryResult<U>>;
+
+    fn internal_load(self, conn: &mut SqliteConnection) -> QueryResult<Self::RowIter<'_>> {
+        let (Yes, query) = self;
+
+        conn.transaction(|conn| {
+            let mut results = Vec::with_capacity(query.records.values.values.len());
+
+            for record in query.records.values.values {
+                let stmt = InsertStatement {
+                    operator: query.operator,
+                    target: query.target,
+                    records: OnConflictValues {
+                        values: record,
+                        target: query.records.target,
+                        action: query.records.action,
+                        where_clause: query.records.where_clause,
+                    },
+                    returning: query.returning,
+                    into_clause: query.into_clause,
+                };
+
+                let result = stmt
+                    .internal_load(conn)?
+                    .next()
+                    .ok_or(crate::result::Error::NotFound)?;
+
+                match &result {
+                    Ok(_) | Err(crate::result::Error::DeserializationError(_)) => {
+                        results.push(result)
+                    }
+                    Err(_) => {
+                        result?;
+                    }
+                };
+            }
+
+            Ok(results.into_iter())
+        })
+    }
+}
+
+#[diagnostic::do_not_recommend]
+impl<'query, V, T, QId, Op, Ret, U, B, Target, ConflictOpt, const STATIC_QUERY_ID: bool>
+    LoadQuery<'query, SqliteConnection, U, B>
+    for (
+        Yes,
+        InsertStatement<
+            T,
+            OnConflictValues<
+                BatchInsert<Vec<ValuesClause<V, T>>, T, QId, STATIC_QUERY_ID>,
+                Target,
+                ConflictOpt,
+            >,
+            Op,
+            ReturningClause<Ret>,
+        >,
+    )
+where
+    T: Table + Copy + QueryId + 'static,
+    T::FromClause: Copy,
+    Op: Copy,
+    ReturningClause<Ret>: Copy,
+    Target: Copy,
+    ConflictOpt: Copy,
+    InsertStatement<
+        T,
+        OnConflictValues<ValuesClause<V, T>, Target, ConflictOpt>,
+        Op,
+        ReturningClause<Ret>,
+    >: LoadQuery<'query, SqliteConnection, U, B>,
     Self: RunQueryDsl<SqliteConnection>,
 {
     type RowIter<'conn> = alloc::vec::IntoIter<QueryResult<U>>;
@@ -692,6 +925,45 @@ where
 }
 
 #[diagnostic::do_not_recommend]
+impl<'query, V, T, QId, Op, Ret, U, B, const STATIC_QUERY_ID: bool>
+    LoadQuery<'query, SqliteConnection, U, B>
+    for (
+        No,
+        InsertStatement<T, BatchInsert<V, T, QId, STATIC_QUERY_ID>, Op, ReturningClause<Ret>>,
+    )
+where
+    T: Table + QueryId + 'static,
+    InsertStatement<
+        T,
+        SqliteBatchInsertWrapper<V, T, QId, STATIC_QUERY_ID>,
+        Op,
+        ReturningClause<Ret>,
+    >: LoadQuery<'query, SqliteConnection, U, B>,
+    Self: RunQueryDsl<SqliteConnection>,
+{
+    type RowIter<'conn> = <InsertStatement<
+        T,
+        SqliteBatchInsertWrapper<V, T, QId, STATIC_QUERY_ID>,
+        Op,
+        ReturningClause<Ret>,
+    > as LoadQuery<'query, SqliteConnection, U, B>>::RowIter<'conn>;
+
+    fn internal_load(self, conn: &mut SqliteConnection) -> QueryResult<Self::RowIter<'_>> {
+        let (No, query) = self;
+
+        let query = InsertStatement {
+            records: SqliteBatchInsertWrapper(query.records),
+            operator: query.operator,
+            target: query.target,
+            returning: query.returning,
+            into_clause: query.into_clause,
+        };
+
+        query.internal_load(conn)
+    }
+}
+
+#[diagnostic::do_not_recommend]
 impl<'query, V, T, QId, Op, U, B, Target, ConflictOpt, const STATIC_QUERY_ID: bool>
     LoadQuery<'query, SqliteConnection, U, B>
     for (
@@ -715,6 +987,55 @@ where
         T,
         OnConflictValues<SqliteBatchInsertWrapper<V, T, QId, STATIC_QUERY_ID>, Target, ConflictOpt>,
         Op,
+    > as LoadQuery<'query, SqliteConnection, U, B>>::RowIter<'conn>;
+
+    fn internal_load(self, conn: &mut SqliteConnection) -> QueryResult<Self::RowIter<'_>> {
+        let (No, query) = self;
+
+        let query = InsertStatement {
+            operator: query.operator,
+            target: query.target,
+            records: OnConflictValues {
+                values: SqliteBatchInsertWrapper(query.records.values),
+                target: query.records.target,
+                action: query.records.action,
+                where_clause: query.records.where_clause,
+            },
+            returning: query.returning,
+            into_clause: query.into_clause,
+        };
+
+        query.internal_load(conn)
+    }
+}
+
+#[diagnostic::do_not_recommend]
+impl<'query, V, T, QId, Op, Ret, U, B, Target, ConflictOpt, const STATIC_QUERY_ID: bool>
+    LoadQuery<'query, SqliteConnection, U, B>
+    for (
+        No,
+        InsertStatement<
+            T,
+            OnConflictValues<BatchInsert<V, T, QId, STATIC_QUERY_ID>, Target, ConflictOpt>,
+            Op,
+            ReturningClause<Ret>,
+        >,
+    )
+where
+    T: Table + QueryId + 'static,
+    InsertStatement<
+        T,
+        OnConflictValues<SqliteBatchInsertWrapper<V, T, QId, STATIC_QUERY_ID>, Target, ConflictOpt>,
+        Op,
+        ReturningClause<Ret>,
+    >: LoadQuery<'query, SqliteConnection, U, B>,
+    Self: RunQueryDsl<SqliteConnection>,
+{
+    type RowIter<'conn> = <InsertStatement<
+        T,
+        OnConflictValues<SqliteBatchInsertWrapper<V, T, QId, STATIC_QUERY_ID>, Target, ConflictOpt>,
+        Op,
+        ReturningClause<Ret>,
     > as LoadQuery<'query, SqliteConnection, U, B>>::RowIter<'conn>;
 
     fn internal_load(self, conn: &mut SqliteConnection) -> QueryResult<Self::RowIter<'_>> {

--- a/diesel/src/query_builder/insert_statement/insert_with_default_for_sqlite.rs
+++ b/diesel/src/query_builder/insert_statement/insert_with_default_for_sqlite.rs
@@ -3,8 +3,8 @@ use crate::insertable::{
     CanInsertInSingleQuery, ColumnInsertValue, DefaultableColumnInsertValue, InsertValues,
 };
 use crate::prelude::*;
-use crate::query_builder::returning_clause::ReturningClause;
 use crate::query_builder::debug_query::DebugBinds;
+use crate::query_builder::returning::ReturningClause;
 use crate::query_builder::upsert::on_conflict_clause::OnConflictValues;
 use crate::query_builder::{
     AstPass, DebugQuery, QueryBuilder, QueryFragment, QueryId, ValuesClause,

--- a/diesel_compile_tests/tests/fail/broken_queryable_by_name.stderr
+++ b/diesel_compile_tests/tests/fail/broken_queryable_by_name.stderr
@@ -164,6 +164,15 @@ help: the following other types implement trait `LoadQuery<'query, Conn, U, B>`
  LL | |     (O, Self): LoadQuery<'query, SqliteConnection, U, B>,
      | |_________________________________________________________^ `InsertStatement<T, ..., ...>`
 ...
+ LL | / impl<'query, V, T, QId, Op, Ret, O, U, B, const STATIC_QUERY_ID: bool>
+ LL | |     LoadQuery<'query, SqliteConnection, U, B>
+ LL | |     for InsertStatement<
+ LL | |         T,
+...    |
+ LL | |     O: Default,
+ LL | |     (O, Self): LoadQuery<'query, SqliteConnection, U, B>,
+     | |_________________________________________________________^ `InsertStatement<T, ..., ..., ...>`
+...
  LL | / impl<'query, V, T, QId, Op, O, U, B, Target, ConflictOpt, const STATIC_QUERY_ID: bool>
  LL | |     LoadQuery<'query, SqliteConnection, U, B>
  LL | |     for InsertStatement<
@@ -172,6 +181,15 @@ help: the following other types implement trait `LoadQuery<'query, Conn, U, B>`
  LL | |     O: Default,
  LL | |     (O, Self): LoadQuery<'query, SqliteConnection, U, B>,
      | |_________________________________________________________^ `InsertStatement<T, ..., ...>`
+...
+ LL | / impl<'query, V, T, QId, Op, Ret, O, U, B, Target, ConflictOpt, const STATIC_QUERY_ID: bool>
+ LL | |     LoadQuery<'query, SqliteConnection, U, B>
+ LL | |     for InsertStatement<
+ LL | |         T,
+...    |
+ LL | |     O: Default,
+ LL | |     (O, Self): LoadQuery<'query, SqliteConnection, U, B>,
+     | |_________________________________________________________^ `InsertStatement<T, ..., ..., ...>`
      = note: required for `SqlQuery` to implement `LoadQuery<'_, _, User>`
 note: required by a bound in `load`
     --> DIESEL/diesel/diesel/src/query_dsl/mod.rs

--- a/diesel_tests/tests/insert.rs
+++ b/diesel_tests/tests/insert.rs
@@ -496,6 +496,53 @@ fn insert_records_with_custom_returning_clause() {
     assert_eq!(expected_users, inserted_users);
 }
 
+// regression test for https://github.com/diesel-rs/diesel/issues/4989
+#[diesel_test_helper::test]
+#[cfg(feature = "returning_clauses_for_sqlite_3_35")]
+fn batch_insert_with_custom_returning_clause_sqlite() {
+    use crate::schema::users::dsl::*;
+
+    let connection = &mut connection();
+    let new_users: &[_] = &[
+        NewUser::new("Sean", Some("Black")),
+        NewUser::new("Tess", None),
+    ];
+
+    let inserted_users = insert_into(users)
+        .values(new_users)
+        .returning((name, hair_color))
+        .get_results::<(String, Option<String>)>(connection)
+        .unwrap();
+    let expected_users = vec![
+        ("Sean".to_string(), Some("Black".to_string())),
+        ("Tess".to_string(), None),
+    ];
+
+    assert_eq!(expected_users, inserted_users);
+}
+
+// regression test for https://github.com/diesel-rs/diesel/issues/4989
+#[diesel_test_helper::test]
+#[cfg(feature = "returning_clauses_for_sqlite_3_35")]
+fn batch_insert_with_returning_id_sqlite() {
+    use crate::schema::users::dsl::*;
+
+    let connection = &mut connection();
+    let new_users: &[_] = &[
+        NewUser::new("Sean", Some("Black")),
+        NewUser::new("Tess", None),
+        NewUser::new("Jim", Some("Brown")),
+    ];
+
+    let inserted_ids = insert_into(users)
+        .values(new_users)
+        .returning(id)
+        .get_results::<i32>(connection)
+        .unwrap();
+
+    assert_eq!(inserted_ids.len(), 3);
+}
+
 #[diesel_test_helper::test]
 #[cfg(not(feature = "mysql"))] // FIXME: Figure out how to handle tests that modify schema
 fn batch_insert_with_defaults() {


### PR DESCRIPTION
This rebases #5038 by @zacharyftw onto current `main` and fixes the build break that was reddening its rustfmt and clippy job.

The original PR imported `ReturningClause` from `crate::query_builder::returning_clause`, which is not a valid module path, so the crate did not compile under the `sqlite` and `returning_clauses_for_sqlite_3_35` features. This branch points the import at `crate::query_builder::returning` (the module that re-exports `ReturningClause`) and fixes the import ordering so rustfmt passes. The original commits from @zacharyftw and @weiznich are preserved, with the fix added as a separate commit on top.

Adds `LoadQuery` and `RunQueryDsl` impls for `InsertStatement` with `ReturningClause` on SQLite, enabling batch inserts with an explicit `.returning()` to work with `get_results()`. Previously only the implicit returning path (via `AsQuery` / `NoReturningClause`) was supported for batch inserts on SQLite.

Closes #4989. Supersedes #5038.

Verification:
- `cargo +nightly fmt --all -- --check` clean
- `cargo clippy -p diesel --no-default-features --features "sqlite returning_clauses_for_sqlite_3_35 extras" --all-targets` clean
- The new regression tests `batch_insert_with_custom_returning_clause_sqlite` and `batch_insert_with_returning_id_sqlite` pass