### PR TITLE
Use an in-memory SQLite database in migration doctests to avoid lock races

### DIFF
--- a/diesel_migrations/migrations_macros/src/lib.rs
+++ b/diesel_migrations/migrations_macros/src/lib.rs
@@ -56,7 +56,8 @@ use proc_macro::TokenStream;
 /// #
 /// # #[cfg(feature = "sqlite")]
 /// # fn migration_connection() -> diesel::SqliteConnection {
-/// #    let connection_url = database_url_from_env("SQLITE_DATABASE_URL");
+/// #    // An in-memory database avoids lock races between concurrently running doctests.
+/// #    let connection_url = String::from(":memory:");
 /// #    let mut conn = diesel::SqliteConnection::establish(&connection_url).unwrap();
 /// #    conn.begin_test_transaction().unwrap();
 /// #    conn

--- a/diesel_migrations/src/combined_migrations.rs
+++ b/diesel_migrations/src/combined_migrations.rs
@@ -23,8 +23,10 @@ use diesel::migration::{Migration, MigrationSource};
 ///
 /// # #[cfg(feature = "postgres")]
 /// # let connection_url = database_url_from_env("PG_DATABASE_URL");
+/// # // An in-memory database avoids lock races between concurrently running doctests
+/// # // and keeps this example's partially applied migrations out of the shared test database.
 /// # #[cfg(feature = "sqlite")]
-/// # let connection_url = database_url_from_env("SQLITE_DATABASE_URL");
+/// # let connection_url = String::from(":memory:");
 /// # #[cfg(feature = "mysql")]
 /// # let connection_url = database_url_from_env("MYSQL_DATABASE_URL");
 /// # #[cfg(feature = "postgres")]

--- a/diesel_migrations/src/rust_migrations.rs
+++ b/diesel_migrations/src/rust_migrations.rs
@@ -40,8 +40,9 @@ use crate::MigrationError;
 ///
 /// # #[cfg(feature = "postgres")]
 /// # let connection_url = database_url_from_env("PG_DATABASE_URL");
+/// # // An in-memory database avoids lock races between concurrently running doctests.
 /// # #[cfg(feature = "sqlite")]
-/// # let connection_url = database_url_from_env("SQLITE_DATABASE_URL");
+/// # let connection_url = String::from(":memory:");
 /// # #[cfg(feature = "mysql")]
 /// # let connection_url = database_url_from_env("MYSQL_DATABASE_URL");
 /// # #[cfg(feature = "postgres")]

--- a/diesel_migrations/src/rust_migrations.rs
+++ b/diesel_migrations/src/rust_migrations.rs
@@ -40,7 +40,8 @@ use crate::MigrationError;
 ///
 /// # #[cfg(feature = "postgres")]
 /// # let connection_url = database_url_from_env("PG_DATABASE_URL");
-/// # // An in-memory database avoids lock races between concurrently running doctests.
+/// # // An in-memory database avoids lock races between concurrently running doctests
+/// # // and keeps this example's applied migrations out of the shared test database.
 /// # #[cfg(feature = "sqlite")]
 /// # let connection_url = String::from(":memory:");
 /// # #[cfg(feature = "mysql")]


### PR DESCRIPTION
The `RustMigrationSource` and `CombinedMigrationSource` doctests both run migrations against the shared `SQLITE_DATABASE_URL` file. When they run concurrently, one can fail with `DatabaseError(Unknown, "database is locked")`. This recently happened on the `(beta, sqlite, ubuntu-latest)` job in [a run for #4975](https://github.com/diesel-rs/diesel/actions/runs/27028692179/job/79775677160) and in [a merge queue run for #4981](https://github.com/diesel-rs/diesel/actions/runs/27015995452/job/79731459600).

This PR switches the sqlite branch of both doctests to a private in-memory database, making the race impossible. It also keeps the partially applied migrations of the `CombinedMigrationSource` example out of the shared test database.