### PR TITLE
Fix Windows SQLite CI by resolving vcvars64 via vswhere

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
         run: |
           choco install sqlite
           cd /D C:\ProgramData\chocolatey\lib\SQLite\tools
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          for /f "usebackq tokens=*" %%i in (`"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -latest -prerelease -property installationPath`) do call "%%i\VC\Auxiliary\Build\vcvars64.bat"
           lib /machine:x64 /def:sqlite3.def /out:sqlite3.lib
 
       - name: Set variables for sqlite (Windows)


### PR DESCRIPTION
The `Check (stable, sqlite, windows-2025)` job has started failing intermittently in the "Install sqlite (Windows)" step, before any test runs. The step hardcodes the Visual Studio 2022 path to `vcvars64.bat`:

`call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"`

GitHub is migrating the `windows-2025` runner label from a Visual Studio 2022 image to a Visual Studio 2026 image (`windows-2025-vs2026`), with the default cutover on June 15, 2026. On the new image, Visual Studio installs under `C:\Program Files\Microsoft Visual Studio\18\Enterprise` (the MSVC major version, not the year), so the hardcoded `\2022\` path no longer exists. When that happens `vcvars64.bat` is not found, the MSVC environment is never loaded, and the subsequent `lib` invocation fails with "'lib' is not recognized". During the rollout the label routes to a mix of old and new images, which is why this currently looks flaky. After the cutover it will fail on every run.

This replaces the hardcoded path with a `vswhere` lookup. `vswhere.exe` lives at a fixed, version-independent location on every GitHub Windows runner, and `-latest -prerelease -property installationPath` resolves whichever Visual Studio is actually installed (2022 or 2026). The `-prerelease` flag is required for `vswhere` to report the VS 2026 instance.

Reference: actions/runner-images#14004.
