### PR TITLE
Fix invalid step-level permissions in doc workflow

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -14,10 +14,12 @@ concurrency:
 
 name: Publish Docs
 jobs:
-  publish_docs:
+  build_docs:
     if: github.repository == 'diesel-rs/diesel'
-    name: Publish Docs
+    name: Build Docs
     runs-on: ubuntu-latest
+    permissions:
+      contents: "read"
     steps:
       - name: Checkout sources
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -27,11 +29,6 @@ jobs:
         uses: Swatinem/rust-cache@f51f967e158417aafa338a1e46ab22095f07aa01 # v2.8.2
         with:
           key: cargo-doc-cargo-${{ hashFiles('**/Cargo.toml') }}
-      - name: Get the branch name
-        id: current_branch
-        shell: bash
-        run: |
-          echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
       - name: Install rust toolchain
         run: rustup update nightly
       - name: Install dependencies
@@ -43,11 +40,37 @@ jobs:
           RUSTFLAGS: "--cfg diesel_docsrs"
           RUSTDOCFLAGS: "--cfg diesel_docsrs  -Z unstable-options --generate-link-to-definition --generate-macro-expansion"
         run: cargo +nightly doc --manifest-path diesel/Cargo.toml --features "postgres sqlite mysql extras i-implement-a-third-party-backend-and-opt-into-breaking-changes" --workspace
+      - name: Upload documentation artifact
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: documentation
+          path: target/doc
+          retention-days: 1
 
+  publish_docs:
+    if: github.repository == 'diesel-rs/diesel'
+    name: Publish Docs
+    needs: build_docs
+    runs-on: ubuntu-latest
+    permissions:
+      contents: "write"
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+      - name: Get the branch name
+        id: current_branch
+        shell: bash
+        run: |
+          echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
+      - name: Download documentation artifact
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: documentation
+          path: target/doc
       - name: Publish documentation
         if: success()
-        permissions:
-          contents: "write"
         uses: JamesIves/github-pages-deploy-action@9d877eea73427180ae43cf98e8914934fe157a1a # v4.7.6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The "Publish Docs" workflow fails to start on every push that evaluates it (reported as a startup failure: "This run likely failed because of a workflow file issue"), including the merge queue on `main`.

The cause is a step-level `permissions:` block on the "Publish documentation" step, added in 6745d0fc5. `permissions:` is only valid at the [workflow level or the job level](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions), not on a step, so the whole workflow file is invalid and no run can start.

This moves the `contents: write` grant up to the `publish_docs` job (the job that pushes to `gh-pages`), keeping the workflow-level `contents: read` default.
