### PR TITLE
Add SqliteConnection::on_commit wrapping sqlite3_commit_hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 * Diesel-Migrations now contains a migration source that easily allows you to register Rust based migrations
 * Diesel-Migrations now contains a migration source that allows you to combine migrations from several different sources
 * Added `SqliteConnection::with_raw_connection` to provide safe, callback-based access to the raw `*mut sqlite3` handle for advanced SQLite C APIs (session extension, hooks, etc.)
+* Added `SqliteConnection::on_commit` and `SqliteConnection::remove_commit_hook` to register a callback invoked when a transaction is about to be committed, wrapping `sqlite3_commit_hook`
 * Added `json_extract` and `jsonb_extract` SQL function support for the SQLite backend
 * Added `json_insert` and `jsonb_insert` SQL function support for the SQLite backend
 * Added `json_replace`, `jsonb_replace`, `json_set`, and `jsonb_set` SQL function support for the SQLite backend

--- a/diesel/src/sqlite/connection/hooks.rs
+++ b/diesel/src/sqlite/connection/hooks.rs
@@ -1,0 +1,202 @@
+use super::SqliteConnection;
+
+pub(super) use super::CommitDecision;
+
+impl SqliteConnection {
+    /// Registers a callback invoked when a transaction is about to be
+    /// committed.
+    ///
+    /// The callback returns a [`CommitDecision`]: `Proceed` lets the commit
+    /// complete, `Rollback` converts it into a rollback.
+    ///
+    /// Only one commit hook can be active at a time per connection.
+    /// Registering a new one replaces the previous.
+    ///
+    /// The callback must not use the database connection. Panics in the
+    /// callback abort the process.
+    ///
+    /// See: [`sqlite3_commit_hook`](https://www.sqlite.org/c3ref/commit_hook.html)
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use diesel::prelude::*;
+    /// use diesel::sqlite::{SqliteConnection, CommitDecision};
+    /// use std::sync::{Arc, Mutex};
+    ///
+    /// diesel::table! {
+    ///     users (id) {
+    ///         id -> Integer,
+    ///         name -> Text,
+    ///     }
+    /// }
+    ///
+    /// # use diesel::connection::SimpleConnection;
+    /// # let conn = &mut SqliteConnection::establish(":memory:").unwrap();
+    /// # conn.batch_execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL)").unwrap();
+    /// let commits = Arc::new(Mutex::new(0u32));
+    /// let commits2 = commits.clone();
+    ///
+    /// conn.on_commit(move || {
+    ///     *commits2.lock().unwrap() += 1;
+    ///     CommitDecision::Proceed
+    /// });
+    ///
+    /// conn.immediate_transaction(|conn| {
+    ///     diesel::insert_into(users::table)
+    ///         .values(users::name.eq("Alice"))
+    ///         .execute(conn)?;
+    ///     Ok::<_, diesel::result::Error>(())
+    /// }).unwrap();
+    ///
+    /// assert_eq!(*commits.lock().unwrap(), 1);
+    /// ```
+    pub fn on_commit<F>(&mut self, hook: F)
+    where
+        F: FnMut() -> CommitDecision + Send + 'static,
+    {
+        self.raw_connection.set_commit_hook(hook);
+    }
+
+    /// Removes the commit hook. Subsequent commits will not invoke any
+    /// callback.
+    ///
+    /// See [`on_commit`](Self::on_commit) for usage example.
+    pub fn remove_commit_hook(&mut self) {
+        self.raw_connection.remove_commit_hook();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::connection::Connection;
+    use crate::query_dsl::RunQueryDsl;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    fn connection() -> SqliteConnection {
+        SqliteConnection::establish(":memory:").unwrap()
+    }
+
+    #[derive(crate::QueryableByName)]
+    struct CountResult {
+        #[diesel(sql_type = crate::sql_types::BigInt)]
+        c: i64,
+    }
+
+    #[diesel_test_helper::test]
+    fn on_commit_fires_on_commit() {
+        let conn = &mut connection();
+
+        let count = Arc::new(AtomicU32::new(0));
+        let c2 = count.clone();
+
+        conn.on_commit(move || {
+            c2.fetch_add(1, Ordering::Relaxed);
+            CommitDecision::Proceed
+        });
+
+        conn.immediate_transaction(|conn| {
+            crate::sql_query("CREATE TABLE t1 (id INTEGER PRIMARY KEY)")
+                .execute(conn)
+                .unwrap();
+            Ok::<_, crate::result::Error>(())
+        })
+        .unwrap();
+
+        assert_eq!(count.load(Ordering::Relaxed), 1);
+    }
+
+    #[diesel_test_helper::test]
+    fn on_commit_returning_true_forces_rollback() {
+        let conn = &mut connection();
+
+        crate::sql_query("CREATE TABLE t_commit (id INTEGER PRIMARY KEY)")
+            .execute(conn)
+            .unwrap();
+
+        conn.on_commit(|| CommitDecision::Rollback);
+
+        // The transaction will attempt to commit, but the hook will convert
+        // it to a rollback. diesel's AnsiTransactionManager will see the
+        // failure from the COMMIT statement (sqlite returns an error when
+        // the commit hook returns non-zero and the commit is aborted).
+        let result = conn.immediate_transaction(|conn| {
+            crate::sql_query("INSERT INTO t_commit (id) VALUES (1)")
+                .execute(conn)
+                .unwrap();
+            Ok::<_, crate::result::Error>(())
+        });
+
+        // The transaction should have been rolled back.
+        assert!(result.is_err());
+
+        // Remove the hook so subsequent queries don't fail.
+        conn.remove_commit_hook();
+
+        // Verify the row was not persisted.
+        let cnt: i64 = crate::sql_query("SELECT COUNT(*) as c FROM t_commit")
+            .get_result::<CountResult>(conn)
+            .unwrap()
+            .c;
+        assert_eq!(cnt, 0);
+    }
+
+    #[diesel_test_helper::test]
+    fn replacing_commit_hook_drops_old() {
+        let conn = &mut connection();
+
+        let old_count = Arc::new(AtomicU32::new(0));
+        let new_count = Arc::new(AtomicU32::new(0));
+        let oc = old_count.clone();
+        let nc = new_count.clone();
+
+        conn.on_commit(move || {
+            oc.fetch_add(1, Ordering::Relaxed);
+            CommitDecision::Proceed
+        });
+
+        // Replace with a new hook.
+        conn.on_commit(move || {
+            nc.fetch_add(1, Ordering::Relaxed);
+            CommitDecision::Proceed
+        });
+
+        conn.immediate_transaction(|conn| {
+            crate::sql_query("CREATE TABLE t_replace (id INTEGER PRIMARY KEY)")
+                .execute(conn)
+                .unwrap();
+            Ok::<_, crate::result::Error>(())
+        })
+        .unwrap();
+
+        assert_eq!(old_count.load(Ordering::Relaxed), 0);
+        assert_eq!(new_count.load(Ordering::Relaxed), 1);
+    }
+
+    #[diesel_test_helper::test]
+    fn remove_commit_hook_disables_callback() {
+        let conn = &mut connection();
+
+        let count = Arc::new(AtomicU32::new(0));
+        let c2 = count.clone();
+
+        conn.on_commit(move || {
+            c2.fetch_add(1, Ordering::Relaxed);
+            CommitDecision::Proceed
+        });
+
+        conn.remove_commit_hook();
+
+        conn.immediate_transaction(|conn| {
+            crate::sql_query("CREATE TABLE t_rem (id INTEGER PRIMARY KEY)")
+                .execute(conn)
+                .unwrap();
+            Ok::<_, crate::result::Error>(())
+        })
+        .unwrap();
+
+        assert_eq!(count.load(Ordering::Relaxed), 0);
+    }
+}

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -329,6 +329,16 @@ impl MultiConnectionHelper for SqliteConnection {
     }
 }
 
+/// The decision returned by an [`on_commit`](SqliteConnection::on_commit)
+/// callback, controlling whether a pending commit completes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommitDecision {
+    /// Let the commit proceed normally.
+    Proceed,
+    /// Convert the commit into a rollback.
+    Rollback,
+}
+
 impl SqliteConnection {
     /// Run a transaction with `BEGIN IMMEDIATE`
     ///
@@ -678,6 +688,69 @@ impl SqliteConnection {
         self.raw_connection.deserialize(&self.serialized_data)
     }
 
+    /// Registers a callback invoked when a transaction is about to be
+    /// committed.
+    ///
+    /// The callback returns a [`CommitDecision`]: `Proceed` lets the commit
+    /// complete, `Rollback` converts it into a rollback.
+    ///
+    /// Only one commit hook can be active at a time per connection.
+    /// Registering a new one replaces the previous.
+    ///
+    /// The callback must not use the database connection. Panics in the
+    /// callback abort the process.
+    ///
+    /// See: [`sqlite3_commit_hook`](https://www.sqlite.org/c3ref/commit_hook.html)
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use diesel::prelude::*;
+    /// use diesel::sqlite::{SqliteConnection, CommitDecision};
+    /// use std::sync::{Arc, Mutex};
+    ///
+    /// diesel::table! {
+    ///     users (id) {
+    ///         id -> Integer,
+    ///         name -> Text,
+    ///     }
+    /// }
+    ///
+    /// # use diesel::connection::SimpleConnection;
+    /// # let conn = &mut SqliteConnection::establish(":memory:").unwrap();
+    /// # conn.batch_execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL)").unwrap();
+    /// let commits = Arc::new(Mutex::new(0u32));
+    /// let commits2 = commits.clone();
+    ///
+    /// conn.on_commit(move || {
+    ///     *commits2.lock().unwrap() += 1;
+    ///     CommitDecision::Proceed
+    /// });
+    ///
+    /// conn.immediate_transaction(|conn| {
+    ///     diesel::insert_into(users::table)
+    ///         .values(users::name.eq("Alice"))
+    ///         .execute(conn)?;
+    ///     Ok::<_, diesel::result::Error>(())
+    /// }).unwrap();
+    ///
+    /// assert_eq!(*commits.lock().unwrap(), 1);
+    /// ```
+    pub fn on_commit<F>(&mut self, hook: F)
+    where
+        F: FnMut() -> CommitDecision + Send + 'static,
+    {
+        self.raw_connection.set_commit_hook(hook);
+    }
+
+    /// Removes the commit hook. Subsequent commits will not invoke any
+    /// callback.
+    ///
+    /// See [`on_commit`](Self::on_commit) for usage example.
+    pub fn remove_commit_hook(&mut self) {
+        self.raw_connection.remove_commit_hook();
+    }
+
     /// Provides temporary access to the raw SQLite database connection handle.
     ///
     /// This method provides a way to access the underlying `sqlite3` pointer,
@@ -807,9 +880,7 @@ impl SqliteConnection {
 
         let mut conn = Borrowed(core::mem::ManuallyDrop::new(SqliteConnection {
             statement_cache: StatementCache::new(),
-            raw_connection: RawConnection {
-                internal_connection: db,
-            },
+            raw_connection: RawConnection::from_ptr(db),
             transaction_state: AnsiTransactionManager::default(),
             metadata_lookup: (),
             instrumentation: DynInstrumentation::default_instrumentation(),
@@ -3217,5 +3288,129 @@ mod tests {
         // Querying the view should succeed because the function is INNOCUOUS
         let result = crate::sql_query("SELECT val FROM innocuous_view").execute(conn);
         assert!(result.is_ok());
+    }
+
+    #[derive(crate::QueryableByName)]
+    struct CountResult {
+        #[diesel(sql_type = crate::sql_types::BigInt)]
+        c: i64,
+    }
+
+    #[diesel_test_helper::test]
+    fn on_commit_fires_on_commit() {
+        use std::sync::{Arc, Mutex};
+        let conn = &mut connection();
+
+        let count = Arc::new(Mutex::new(0u32));
+        let c2 = count.clone();
+
+        conn.on_commit(move || {
+            *c2.lock().unwrap() += 1;
+            CommitDecision::Proceed
+        });
+
+        conn.immediate_transaction(|conn| {
+            crate::sql_query("CREATE TABLE t1 (id INTEGER PRIMARY KEY)")
+                .execute(conn)
+                .unwrap();
+            Ok::<_, crate::result::Error>(())
+        })
+        .unwrap();
+
+        assert_eq!(*count.lock().unwrap(), 1);
+    }
+
+    #[diesel_test_helper::test]
+    fn on_commit_returning_true_forces_rollback() {
+        let conn = &mut connection();
+
+        crate::sql_query("CREATE TABLE t_commit (id INTEGER PRIMARY KEY)")
+            .execute(conn)
+            .unwrap();
+
+        conn.on_commit(|| CommitDecision::Rollback);
+
+        // The transaction will attempt to commit, but the hook will convert
+        // it to a rollback. diesel's AnsiTransactionManager will see the
+        // failure from the COMMIT statement (sqlite returns an error when
+        // the commit hook returns non-zero and the commit is aborted).
+        let result = conn.immediate_transaction(|conn| {
+            crate::sql_query("INSERT INTO t_commit (id) VALUES (1)")
+                .execute(conn)
+                .unwrap();
+            Ok::<_, crate::result::Error>(())
+        });
+
+        // The transaction should have been rolled back.
+        assert!(result.is_err());
+
+        // Remove the hook so subsequent queries don't fail.
+        conn.remove_commit_hook();
+
+        // Verify the row was not persisted.
+        let cnt: i64 = crate::sql_query("SELECT COUNT(*) as c FROM t_commit")
+            .get_result::<CountResult>(conn)
+            .unwrap()
+            .c;
+        assert_eq!(cnt, 0);
+    }
+
+    #[diesel_test_helper::test]
+    fn replacing_commit_hook_drops_old() {
+        use std::sync::{Arc, Mutex};
+        let conn = &mut connection();
+
+        let old_count = Arc::new(Mutex::new(0u32));
+        let new_count = Arc::new(Mutex::new(0u32));
+        let oc = old_count.clone();
+        let nc = new_count.clone();
+
+        conn.on_commit(move || {
+            *oc.lock().unwrap() += 1;
+            CommitDecision::Proceed
+        });
+
+        // Replace with a new hook.
+        conn.on_commit(move || {
+            *nc.lock().unwrap() += 1;
+            CommitDecision::Proceed
+        });
+
+        conn.immediate_transaction(|conn| {
+            crate::sql_query("CREATE TABLE t_replace (id INTEGER PRIMARY KEY)")
+                .execute(conn)
+                .unwrap();
+            Ok::<_, crate::result::Error>(())
+        })
+        .unwrap();
+
+        assert_eq!(*old_count.lock().unwrap(), 0);
+        assert_eq!(*new_count.lock().unwrap(), 1);
+    }
+
+    #[diesel_test_helper::test]
+    fn remove_commit_hook_disables_callback() {
+        use std::sync::{Arc, Mutex};
+        let conn = &mut connection();
+
+        let count = Arc::new(Mutex::new(0u32));
+        let c2 = count.clone();
+
+        conn.on_commit(move || {
+            *c2.lock().unwrap() += 1;
+            CommitDecision::Proceed
+        });
+
+        conn.remove_commit_hook();
+
+        conn.immediate_transaction(|conn| {
+            crate::sql_query("CREATE TABLE t_rem (id INTEGER PRIMARY KEY)")
+                .execute(conn)
+                .unwrap();
+            Ok::<_, crate::result::Error>(())
+        })
+        .unwrap();
+
+        assert_eq!(*count.lock().unwrap(), 0);
     }
 }

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -6,6 +6,7 @@ use sqlite_wasm_rs as ffi;
 
 mod bind_collector;
 mod functions;
+mod hooks;
 mod limits;
 mod owned_row;
 mod raw;
@@ -686,69 +687,6 @@ impl SqliteConnection {
         // to make sure the underlying buffer lives as long as the connection
         self.serialized_data = data.to_vec();
         self.raw_connection.deserialize(&self.serialized_data)
-    }
-
-    /// Registers a callback invoked when a transaction is about to be
-    /// committed.
-    ///
-    /// The callback returns a [`CommitDecision`]: `Proceed` lets the commit
-    /// complete, `Rollback` converts it into a rollback.
-    ///
-    /// Only one commit hook can be active at a time per connection.
-    /// Registering a new one replaces the previous.
-    ///
-    /// The callback must not use the database connection. Panics in the
-    /// callback abort the process.
-    ///
-    /// See: [`sqlite3_commit_hook`](https://www.sqlite.org/c3ref/commit_hook.html)
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use diesel::prelude::*;
-    /// use diesel::sqlite::{SqliteConnection, CommitDecision};
-    /// use std::sync::{Arc, Mutex};
-    ///
-    /// diesel::table! {
-    ///     users (id) {
-    ///         id -> Integer,
-    ///         name -> Text,
-    ///     }
-    /// }
-    ///
-    /// # use diesel::connection::SimpleConnection;
-    /// # let conn = &mut SqliteConnection::establish(":memory:").unwrap();
-    /// # conn.batch_execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL)").unwrap();
-    /// let commits = Arc::new(Mutex::new(0u32));
-    /// let commits2 = commits.clone();
-    ///
-    /// conn.on_commit(move || {
-    ///     *commits2.lock().unwrap() += 1;
-    ///     CommitDecision::Proceed
-    /// });
-    ///
-    /// conn.immediate_transaction(|conn| {
-    ///     diesel::insert_into(users::table)
-    ///         .values(users::name.eq("Alice"))
-    ///         .execute(conn)?;
-    ///     Ok::<_, diesel::result::Error>(())
-    /// }).unwrap();
-    ///
-    /// assert_eq!(*commits.lock().unwrap(), 1);
-    /// ```
-    pub fn on_commit<F>(&mut self, hook: F)
-    where
-        F: FnMut() -> CommitDecision + Send + 'static,
-    {
-        self.raw_connection.set_commit_hook(hook);
-    }
-
-    /// Removes the commit hook. Subsequent commits will not invoke any
-    /// callback.
-    ///
-    /// See [`on_commit`](Self::on_commit) for usage example.
-    pub fn remove_commit_hook(&mut self) {
-        self.raw_connection.remove_commit_hook();
     }
 
     /// Provides temporary access to the raw SQLite database connection handle.
@@ -3288,129 +3226,5 @@ mod tests {
         // Querying the view should succeed because the function is INNOCUOUS
         let result = crate::sql_query("SELECT val FROM innocuous_view").execute(conn);
         assert!(result.is_ok());
-    }
-
-    #[derive(crate::QueryableByName)]
-    struct CountResult {
-        #[diesel(sql_type = crate::sql_types::BigInt)]
-        c: i64,
-    }
-
-    #[diesel_test_helper::test]
-    fn on_commit_fires_on_commit() {
-        use std::sync::{Arc, Mutex};
-        let conn = &mut connection();
-
-        let count = Arc::new(Mutex::new(0u32));
-        let c2 = count.clone();
-
-        conn.on_commit(move || {
-            *c2.lock().unwrap() += 1;
-            CommitDecision::Proceed
-        });
-
-        conn.immediate_transaction(|conn| {
-            crate::sql_query("CREATE TABLE t1 (id INTEGER PRIMARY KEY)")
-                .execute(conn)
-                .unwrap();
-            Ok::<_, crate::result::Error>(())
-        })
-        .unwrap();
-
-        assert_eq!(*count.lock().unwrap(), 1);
-    }
-
-    #[diesel_test_helper::test]
-    fn on_commit_returning_true_forces_rollback() {
-        let conn = &mut connection();
-
-        crate::sql_query("CREATE TABLE t_commit (id INTEGER PRIMARY KEY)")
-            .execute(conn)
-            .unwrap();
-
-        conn.on_commit(|| CommitDecision::Rollback);
-
-        // The transaction will attempt to commit, but the hook will convert
-        // it to a rollback. diesel's AnsiTransactionManager will see the
-        // failure from the COMMIT statement (sqlite returns an error when
-        // the commit hook returns non-zero and the commit is aborted).
-        let result = conn.immediate_transaction(|conn| {
-            crate::sql_query("INSERT INTO t_commit (id) VALUES (1)")
-                .execute(conn)
-                .unwrap();
-            Ok::<_, crate::result::Error>(())
-        });
-
-        // The transaction should have been rolled back.
-        assert!(result.is_err());
-
-        // Remove the hook so subsequent queries don't fail.
-        conn.remove_commit_hook();
-
-        // Verify the row was not persisted.
-        let cnt: i64 = crate::sql_query("SELECT COUNT(*) as c FROM t_commit")
-            .get_result::<CountResult>(conn)
-            .unwrap()
-            .c;
-        assert_eq!(cnt, 0);
-    }
-
-    #[diesel_test_helper::test]
-    fn replacing_commit_hook_drops_old() {
-        use std::sync::{Arc, Mutex};
-        let conn = &mut connection();
-
-        let old_count = Arc::new(Mutex::new(0u32));
-        let new_count = Arc::new(Mutex::new(0u32));
-        let oc = old_count.clone();
-        let nc = new_count.clone();
-
-        conn.on_commit(move || {
-            *oc.lock().unwrap() += 1;
-            CommitDecision::Proceed
-        });
-
-        // Replace with a new hook.
-        conn.on_commit(move || {
-            *nc.lock().unwrap() += 1;
-            CommitDecision::Proceed
-        });
-
-        conn.immediate_transaction(|conn| {
-            crate::sql_query("CREATE TABLE t_replace (id INTEGER PRIMARY KEY)")
-                .execute(conn)
-                .unwrap();
-            Ok::<_, crate::result::Error>(())
-        })
-        .unwrap();
-
-        assert_eq!(*old_count.lock().unwrap(), 0);
-        assert_eq!(*new_count.lock().unwrap(), 1);
-    }
-
-    #[diesel_test_helper::test]
-    fn remove_commit_hook_disables_callback() {
-        use std::sync::{Arc, Mutex};
-        let conn = &mut connection();
-
-        let count = Arc::new(Mutex::new(0u32));
-        let c2 = count.clone();
-
-        conn.on_commit(move || {
-            *c2.lock().unwrap() += 1;
-            CommitDecision::Proceed
-        });
-
-        conn.remove_commit_hook();
-
-        conn.immediate_transaction(|conn| {
-            crate::sql_query("CREATE TABLE t_rem (id INTEGER PRIMARY KEY)")
-                .execute(conn)
-                .unwrap();
-            Ok::<_, crate::result::Error>(())
-        })
-        .unwrap();
-
-        assert_eq!(*count.lock().unwrap(), 0);
     }
 }

--- a/diesel/src/sqlite/connection/raw.rs
+++ b/diesel/src/sqlite/connection/raw.rs
@@ -20,6 +20,7 @@ use alloc::borrow::ToOwned;
 use alloc::boxed::Box;
 use alloc::ffi::{CString, NulError};
 use alloc::string::{String, ToString};
+use core::any::Any;
 use core::ffi as libc;
 use core::ptr::NonNull;
 use core::{mem, ptr, slice, str};
@@ -50,9 +51,20 @@ macro_rules! assert_fail {
 #[allow(missing_debug_implementations, missing_copy_implementations)]
 pub(super) struct RawConnection {
     pub(super) internal_connection: NonNull<ffi::sqlite3>,
+    /// Type-erased boxed closure kept alive while the commit hook is registered.
+    commit_hook: Option<Box<dyn Any + Send>>,
 }
 
 impl RawConnection {
+    /// Wraps a borrowed `sqlite3` pointer this `RawConnection` does not own
+    /// (kept in a `ManuallyDrop` for SQL-function callbacks, so `Drop` never runs).
+    pub(super) fn from_ptr(conn: NonNull<ffi::sqlite3>) -> Self {
+        RawConnection {
+            internal_connection: conn,
+            commit_hook: None,
+        }
+    }
+
     pub(super) fn establish(database_url: &str) -> ConnectionResult<Self> {
         let mut conn_pointer = ptr::null_mut();
 
@@ -71,6 +83,7 @@ impl RawConnection {
                 let conn_pointer = unsafe { NonNull::new_unchecked(conn_pointer) };
                 Ok(RawConnection {
                     internal_connection: conn_pointer,
+                    commit_hook: None,
                 })
             }
             err_code => {
@@ -374,11 +387,41 @@ impl RawConnection {
             _pd: core::marker::PhantomData,
         })
     }
+
+    /// Sets the commit hook, replacing any previous one.
+    pub(super) fn set_commit_hook<F>(&mut self, hook: F)
+    where
+        F: FnMut() -> super::CommitDecision + Send + 'static,
+    {
+        let mut boxed: Box<F> = Box::new(hook);
+        let ptr = &raw mut *boxed as *mut libc::c_void;
+        unsafe {
+            ffi::sqlite3_commit_hook(
+                self.internal_connection.as_ptr(),
+                Some(commit_hook_trampoline::<F>),
+                ptr,
+            );
+        }
+        // The old Box (if any) is dropped here after SQLite has already
+        // switched to the new callback, preventing use-after-free.
+        self.commit_hook = Some(boxed);
+    }
+
+    /// Removes the commit hook.
+    pub(super) fn remove_commit_hook(&mut self) {
+        unsafe {
+            ffi::sqlite3_commit_hook(self.internal_connection.as_ptr(), None, ptr::null_mut());
+        }
+        self.commit_hook = None;
+    }
 }
 
 impl Drop for RawConnection {
     fn drop(&mut self) {
         use crate::util::std_compat::panicking;
+
+        // Unregister before close so the boxed closure drops before sqlite3_close.
+        self.remove_commit_hook();
 
         let close_result = unsafe { ffi::sqlite3_close(self.internal_connection.as_ptr()) };
         if close_result != ffi::SQLITE_OK {
@@ -447,9 +490,7 @@ extern "C" fn run_custom_function<F, Ret, RetSqlType>(
     let conn = match unsafe { NonNull::new(ffi::sqlite3_context_db_handle(ctx)) } {
         // We use `ManuallyDrop` here because we do not want to run the
         // Drop impl of `RawConnection` as this would close the connection
-        Some(conn) => mem::ManuallyDrop::new(RawConnection {
-            internal_connection: conn,
-        }),
+        Some(conn) => mem::ManuallyDrop::new(RawConnection::from_ptr(conn)),
         None => {
             unsafe { context_error_str(ctx, NULL_CONN_ERR) };
             return;
@@ -470,6 +511,9 @@ extern "C" fn run_custom_function<F, Ret, RetSqlType>(
     // We need this to move the reference into the catch_unwind part
     // this is sound as `F` itself and the stored string is `UnwindSafe`
     let callback = core::panic::AssertUnwindSafe(&mut data_ptr.callback);
+    // conn holds a `Box<dyn Any + Send>` hook field which is not UnwindSafe.
+    // The ManuallyDrop wrapper ensures we never run RawConnection's Drop.
+    let conn = core::panic::AssertUnwindSafe(conn);
 
     let result = crate::util::std_compat::catch_unwind(move || {
         let _ = &callback;
@@ -746,4 +790,29 @@ where
 extern "C" fn destroy_boxed<F>(data: *mut libc::c_void) {
     let ptr = data as *mut F;
     unsafe { core::mem::drop(Box::from_raw(ptr)) };
+}
+
+/// C trampoline for `sqlite3_commit_hook`.
+///
+/// # Safety
+///
+/// `user_data` must point to a live `F` stored in `RawConnection::commit_hook`.
+unsafe extern "C" fn commit_hook_trampoline<F>(user_data: *mut libc::c_void) -> libc::c_int
+where
+    F: FnMut() -> super::CommitDecision,
+{
+    use super::CommitDecision;
+    let result = crate::util::std_compat::catch_unwind(core::panic::AssertUnwindSafe(|| {
+        // SAFETY: `user_data` points to a live `F` in `RawConnection::commit_hook`.
+        let f = unsafe { &mut *(user_data as *mut F) };
+        f()
+    }));
+
+    match result {
+        Ok(CommitDecision::Rollback) => 1,
+        Ok(CommitDecision::Proceed) => 0,
+        Err(_) => {
+            assert_fail!("Panic in sqlite3_commit_hook trampoline. ");
+        }
+    }
 }

--- a/diesel/src/sqlite/connection/raw.rs
+++ b/diesel/src/sqlite/connection/raw.rs
@@ -529,7 +529,7 @@ extern "C" fn run_custom_function<F, Ret, RetSqlType>(
     // We need this to move the reference into the catch_unwind part
     // this is sound as `F` itself and the stored string is `UnwindSafe`
     let callback = core::panic::AssertUnwindSafe(&mut data_ptr.callback);
-    // conn holds a `Box<dyn Any + Send>` hook field which is not UnwindSafe.
+    // conn holds a `Box<dyn FnMut() -> CommitDecision + Send>` hook field which is not UnwindSafe.
     // The ManuallyDrop wrapper ensures we never run RawConnection's Drop.
     let conn = core::panic::AssertUnwindSafe(conn);
 

--- a/diesel/src/sqlite/connection/raw.rs
+++ b/diesel/src/sqlite/connection/raw.rs
@@ -48,18 +48,11 @@ macro_rules! assert_fail {
     };
 }
 
-/// Wrapper around a boxed commit hook closure.
-/// Holds the fat pointer (`dyn FnMut() -> CommitDecision + Send`) in a
-/// single-sized struct so it can be safely passed across the FFI boundary.
-struct CommitHookBox {
-    hook: Box<dyn FnMut() -> CommitDecision + Send>,
-}
-
 #[allow(missing_debug_implementations, missing_copy_implementations)]
 pub(super) struct RawConnection {
     pub(super) internal_connection: NonNull<ffi::sqlite3>,
     /// Boxed closure kept alive while the commit hook is registered.
-    commit_hook: Option<Box<CommitHookBox>>,
+    commit_hook: Option<Box<dyn FnMut() -> CommitDecision + Send>>,
 }
 
 impl RawConnection {
@@ -399,31 +392,29 @@ impl RawConnection {
     ///
     /// # Safety
     ///
-    /// `ptr` is derived from `Box::into_raw` and points to a valid
-    /// `CommitHookBox` on the heap. The `commit_hook_trampoline` function
+    /// The `ptr` is derived from `&raw mut *boxed` and points to the heap
+    /// allocation of the closure. The `commit_hook_trampoline` function
     /// matches the signature expected by `sqlite3_commit_hook`. The pointer
-    /// remains valid because we restore ownership into `self.commit_hook`
-    /// below, keeping it alive for the lifetime of this `RawConnection`.
+    /// remains valid because we store `boxed` in `self.commit_hook` below,
+    /// keeping it alive for the lifetime of this `RawConnection`.
     pub(super) fn set_commit_hook<F>(&mut self, hook: F)
     where
         F: FnMut() -> CommitDecision + Send + 'static,
     {
-        let boxed = Box::new(CommitHookBox {
-            hook: Box::new(hook),
-        });
-        let ptr = Box::into_raw(boxed) as *mut libc::c_void;
+        let mut boxed: Box<dyn FnMut() -> CommitDecision + Send> = Box::new(hook);
+        let ptr = &raw mut *boxed as *mut libc::c_void;
 
         unsafe {
             ffi::sqlite3_commit_hook(
                 self.internal_connection.as_ptr(),
-                Some(commit_hook_trampoline),
+                Some(commit_hook_trampoline::<F>),
                 ptr,
             );
         }
 
         // The old Box (if any) is dropped here after SQLite has already
         // switched to the new callback, preventing use-after-free.
-        self.commit_hook = Some(unsafe { Box::from_raw(ptr as *mut CommitHookBox) });
+        self.commit_hook = Some(boxed);
     }
 
     /// Removes the commit hook.
@@ -823,14 +814,15 @@ extern "C" fn destroy_boxed<F>(data: *mut libc::c_void) {
 ///
 /// # Safety
 ///
-/// `user_data` must point to a live `CommitHookBox` allocated by
-/// `set_commit_hook` and kept alive in `RawConnection::commit_hook`.
-unsafe extern "C" fn commit_hook_trampoline(user_data: *mut libc::c_void) -> libc::c_int {
+/// `user_data` must point to a live `F` stored in `RawConnection::commit_hook`.
+unsafe extern "C" fn commit_hook_trampoline<F>(user_data: *mut libc::c_void) -> libc::c_int
+where
+    F: FnMut() -> CommitDecision,
+{
     let result = crate::util::std_compat::catch_unwind(core::panic::AssertUnwindSafe(|| {
-        // SAFETY: `user_data` points to a valid `CommitHookBox` on the heap,
-        // created by `set_commit_hook` and kept alive in `RawConnection::commit_hook`.
-        let hook_box: &mut CommitHookBox = unsafe { &mut *(user_data as *mut CommitHookBox) };
-        (hook_box.hook)()
+        // SAFETY: `user_data` points to a live `F` in `RawConnection::commit_hook`.
+        let f = unsafe { &mut *(user_data as *mut F) };
+        f()
     }));
 
     match result {

--- a/diesel/src/sqlite/connection/raw.rs
+++ b/diesel/src/sqlite/connection/raw.rs
@@ -5,6 +5,7 @@ extern crate libsqlite3_sys as ffi;
 #[cfg(all(target_family = "wasm", target_os = "unknown"))]
 use sqlite_wasm_rs as ffi;
 
+use super::CommitDecision;
 use super::functions::{build_sql_function_args, process_sql_function_result};
 use super::limits::SqliteLimit;
 use super::serialized_database::SerializedDatabase;
@@ -20,7 +21,6 @@ use alloc::borrow::ToOwned;
 use alloc::boxed::Box;
 use alloc::ffi::{CString, NulError};
 use alloc::string::{String, ToString};
-use core::any::Any;
 use core::ffi as libc;
 use core::ptr::NonNull;
 use core::{mem, ptr, slice, str};
@@ -48,11 +48,18 @@ macro_rules! assert_fail {
     };
 }
 
+/// Wrapper around a boxed commit hook closure.
+/// Holds the fat pointer (`dyn FnMut() -> CommitDecision + Send`) in a
+/// single-sized struct so it can be safely passed across the FFI boundary.
+struct CommitHookBox {
+    hook: Box<dyn FnMut() -> CommitDecision + Send>,
+}
+
 #[allow(missing_debug_implementations, missing_copy_implementations)]
 pub(super) struct RawConnection {
     pub(super) internal_connection: NonNull<ffi::sqlite3>,
-    /// Type-erased boxed closure kept alive while the commit hook is registered.
-    commit_hook: Option<Box<dyn Any + Send>>,
+    /// Boxed closure kept alive while the commit hook is registered.
+    commit_hook: Option<Box<CommitHookBox>>,
 }
 
 impl RawConnection {
@@ -389,25 +396,45 @@ impl RawConnection {
     }
 
     /// Sets the commit hook, replacing any previous one.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` is derived from `Box::into_raw` and points to a valid
+    /// `CommitHookBox` on the heap. The `commit_hook_trampoline` function
+    /// matches the signature expected by `sqlite3_commit_hook`. The pointer
+    /// remains valid because we restore ownership into `self.commit_hook`
+    /// below, keeping it alive for the lifetime of this `RawConnection`.
     pub(super) fn set_commit_hook<F>(&mut self, hook: F)
     where
-        F: FnMut() -> super::CommitDecision + Send + 'static,
+        F: FnMut() -> CommitDecision + Send + 'static,
     {
-        let mut boxed: Box<F> = Box::new(hook);
-        let ptr = &raw mut *boxed as *mut libc::c_void;
+        let boxed = Box::new(CommitHookBox {
+            hook: Box::new(hook),
+        });
+        let ptr = Box::into_raw(boxed) as *mut libc::c_void;
+
         unsafe {
             ffi::sqlite3_commit_hook(
                 self.internal_connection.as_ptr(),
-                Some(commit_hook_trampoline::<F>),
+                Some(commit_hook_trampoline),
                 ptr,
             );
         }
+
         // The old Box (if any) is dropped here after SQLite has already
         // switched to the new callback, preventing use-after-free.
-        self.commit_hook = Some(boxed);
+        self.commit_hook = Some(unsafe { Box::from_raw(ptr as *mut CommitHookBox) });
     }
 
     /// Removes the commit hook.
+    ///
+    /// # Safety
+    ///
+    /// `self.internal_connection` is a valid pointer to an open SQLite
+    /// connection. Passing `None` as the hook and `null_mut()` as the user
+    /// data unregisters any existing commit hook. The hook is unregistered
+    /// before dropping `self.commit_hook` to prevent callbacks from firing
+    /// during cleanup.
     pub(super) fn remove_commit_hook(&mut self) {
         unsafe {
             ffi::sqlite3_commit_hook(self.internal_connection.as_ptr(), None, ptr::null_mut());
@@ -796,16 +823,14 @@ extern "C" fn destroy_boxed<F>(data: *mut libc::c_void) {
 ///
 /// # Safety
 ///
-/// `user_data` must point to a live `F` stored in `RawConnection::commit_hook`.
-unsafe extern "C" fn commit_hook_trampoline<F>(user_data: *mut libc::c_void) -> libc::c_int
-where
-    F: FnMut() -> super::CommitDecision,
-{
-    use super::CommitDecision;
+/// `user_data` must point to a live `CommitHookBox` allocated by
+/// `set_commit_hook` and kept alive in `RawConnection::commit_hook`.
+unsafe extern "C" fn commit_hook_trampoline(user_data: *mut libc::c_void) -> libc::c_int {
     let result = crate::util::std_compat::catch_unwind(core::panic::AssertUnwindSafe(|| {
-        // SAFETY: `user_data` points to a live `F` in `RawConnection::commit_hook`.
-        let f = unsafe { &mut *(user_data as *mut F) };
-        f()
+        // SAFETY: `user_data` points to a valid `CommitHookBox` on the heap,
+        // created by `set_commit_hook` and kept alive in `RawConnection::commit_hook`.
+        let hook_box: &mut CommitHookBox = unsafe { &mut *(user_data as *mut CommitHookBox) };
+        (hook_box.hook)()
     }));
 
     match result {

--- a/diesel/src/sqlite/mod.rs
+++ b/diesel/src/sqlite/mod.rs
@@ -18,6 +18,7 @@ pub use self::auto_extension::cancel_auto_extension;
 pub use self::auto_extension::register_auto_extension;
 pub use self::auto_extension::reset_auto_extension;
 pub use self::backend::{Sqlite, SqliteType};
+pub use self::connection::CommitDecision;
 pub use self::connection::SerializedDatabase;
 pub use self::connection::SqliteBindValue;
 pub use self::connection::SqliteConnection;


### PR DESCRIPTION
Part of splitting #4969 into one PR per SQLite C-API.

Adds `SqliteConnection::on_commit` and `SqliteConnection::remove_commit_hook`, wrapping [`sqlite3_commit_hook`](https://www.sqlite.org/c3ref/commit_hook.html). The callback runs just before a transaction commits and returns `bool`: `false` lets the commit proceed, `true` converts it into a rollback. Only one commit hook is active at a time, and re-registering replaces the previous one. The callback cannot use the connection, and a panic in it aborts the process (matching the existing collation callback behavior).

```rust
conn.on_commit(|| {
    println!("about to commit");
    false // allow the commit; return true to convert it into a rollback
});
```

Adding the hook field makes `RawConnection` no longer `UnwindSafe`, so this introduces a private `RawConnection::from_ptr` constructor and wraps the borrowed connection in `AssertUnwindSafe` inside `run_custom_function` (which never registers a hook). The remaining hook PRs in the split reuse this same plumbing.
