### PR TITLE
Harden CI against transient crates.io download failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,14 @@ name: CI Tests
 permissions:
   contents: "read"
 
+env:
+  CARGO_NET_RETRY: 10
+  RUSTUP_MAX_RETRIES: 10
+  # Force HTTP/1.1 for crates.io downloads: HTTP/2 multiplexing against the
+  # CDN intermittently drops connections mid-stream (SSL "unexpected eof"),
+  # and cargo does not retry those, so CARGO_NET_RETRY alone cannot recover.
+  CARGO_HTTP_MULTIPLEXING: "false"
+
 # See: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency.
 # This will ensure that only one commit will be running tests at a time on each PR.
 concurrency:


### PR DESCRIPTION
The recurring CI failures (#5077, and the first run on this PR) are `SSL_read: unexpected eof` errors during the crates.io sparse-index fetch. cargo does not treat these as retryable, so `CARGO_NET_RETRY` alone does not catch them: on this PR's run it failed in 38 ms with no retry despite `CARGO_NET_RETRY: 10` being set.

This adds a top-level `env:` block to `ci.yml`. `CARGO_HTTP_MULTIPLEXING: false` forces HTTP/1.1 instead of the HTTP/2 multiplexing that causes these mid-stream EOFs against the crates.io CDN, and `CARGO_NET_RETRY: 10` / `RUSTUP_MAX_RETRIES: 10` cover the error classes cargo and rustup do retry. No change to build behavior.