### PR TITLE
Add `SqliteConnection::on_rollback` wrapping `sqlite3_rollback_hook`

### DIFF
--- a/diesel/src/sqlite/connection/hooks.rs
+++ b/diesel/src/sqlite/connection/hooks.rs
@@ -65,6 +65,62 @@ impl SqliteConnection {
     pub fn remove_commit_hook(&mut self) {
         self.raw_connection.remove_commit_hook();
     }
+
+    /// Registers a callback invoked after a transaction is rolled back.
+    ///
+    /// This is **not** invoked for the implicit rollback that occurs when
+    /// the connection is closed. It **is** invoked when a commit hook forces
+    /// a rollback by returning [`CommitDecision::Rollback`].
+    ///
+    /// Only one rollback hook can be active at a time per connection.
+    /// Registering a new one replaces the previous.
+    ///
+    /// The callback must not use the database connection. It is invoked
+    /// synchronously on the thread driving the connection, so it is never
+    /// called concurrently, and like the commit hook it is not reentrant.
+    /// Panics in the callback abort the process.
+    ///
+    /// See: [`sqlite3_rollback_hook`](https://www.sqlite.org/c3ref/commit_hook.html)
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use diesel::prelude::*;
+    /// use diesel::sqlite::SqliteConnection;
+    /// use std::sync::Arc;
+    /// use std::sync::atomic::{AtomicU32, Ordering};
+    ///
+    /// # use diesel::connection::SimpleConnection;
+    /// # let conn = &mut SqliteConnection::establish(":memory:").unwrap();
+    /// # conn.batch_execute("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL)").unwrap();
+    /// let rollbacks = Arc::new(AtomicU32::new(0));
+    /// let rb2 = rollbacks.clone();
+    ///
+    /// conn.on_rollback(move || {
+    ///     rb2.fetch_add(1, Ordering::Relaxed);
+    /// });
+    ///
+    /// // Force a rollback by returning an error.
+    /// let _ = conn.immediate_transaction(|_conn| {
+    ///     Err::<(), _>(diesel::result::Error::RollbackTransaction)
+    /// });
+    ///
+    /// assert_eq!(rollbacks.load(Ordering::Relaxed), 1);
+    /// ```
+    pub fn on_rollback<F>(&mut self, hook: F)
+    where
+        F: FnMut() + Send + 'static,
+    {
+        self.raw_connection.set_rollback_hook(hook);
+    }
+
+    /// Removes the rollback hook. Subsequent rollbacks will not invoke any
+    /// callback.
+    ///
+    /// See [`on_rollback`](Self::on_rollback) for usage example.
+    pub fn remove_rollback_hook(&mut self) {
+        self.raw_connection.remove_rollback_hook();
+    }
 }
 
 #[cfg(test)]
@@ -196,6 +252,112 @@ mod tests {
             Ok::<_, crate::result::Error>(())
         })
         .unwrap();
+
+        assert_eq!(count.load(Ordering::Relaxed), 0);
+    }
+
+    #[diesel_test_helper::test]
+    fn on_rollback_fires_on_explicit_rollback() {
+        let conn = &mut connection();
+
+        crate::sql_query("CREATE TABLE t_rb (id INTEGER PRIMARY KEY)")
+            .execute(conn)
+            .unwrap();
+
+        let count = Arc::new(AtomicU32::new(0));
+        let c2 = count.clone();
+
+        conn.on_rollback(move || {
+            c2.fetch_add(1, Ordering::Relaxed);
+        });
+
+        // Force a rollback by returning Err from the transaction closure.
+        let _ = conn.immediate_transaction(|conn| {
+            crate::sql_query("INSERT INTO t_rb (id) VALUES (1)")
+                .execute(conn)
+                .unwrap();
+            Err::<(), _>(crate::result::Error::RollbackTransaction)
+        });
+
+        assert_eq!(count.load(Ordering::Relaxed), 1);
+    }
+
+    #[diesel_test_helper::test]
+    fn on_rollback_fires_when_commit_hook_forces_rollback() {
+        let conn = &mut connection();
+
+        crate::sql_query("CREATE TABLE t_rb2 (id INTEGER PRIMARY KEY)")
+            .execute(conn)
+            .unwrap();
+
+        let rb_count = Arc::new(AtomicU32::new(0));
+        let rb2 = rb_count.clone();
+
+        conn.on_commit(|| CommitDecision::Rollback);
+        conn.on_rollback(move || {
+            rb2.fetch_add(1, Ordering::Relaxed);
+        });
+
+        let _ = conn.immediate_transaction(|conn| {
+            crate::sql_query("INSERT INTO t_rb2 (id) VALUES (1)")
+                .execute(conn)
+                .unwrap();
+            Ok::<_, crate::result::Error>(())
+        });
+
+        // Rollback hook should have fired.
+        assert_eq!(rb_count.load(Ordering::Relaxed), 1);
+
+        conn.remove_commit_hook();
+        conn.remove_rollback_hook();
+
+        // Verify the row was not persisted.
+        let cnt: i64 = crate::sql_query("SELECT COUNT(*) as c FROM t_rb2")
+            .get_result::<CountResult>(conn)
+            .unwrap()
+            .c;
+        assert_eq!(cnt, 0);
+    }
+
+    #[diesel_test_helper::test]
+    fn on_rollback_does_not_fire_on_connection_close() {
+        let count = Arc::new(AtomicU32::new(0));
+        let c2 = count.clone();
+
+        {
+            let conn = &mut connection();
+            conn.on_rollback(move || {
+                c2.fetch_add(1, Ordering::Relaxed);
+            });
+            // conn is dropped here: implicit close, not a rollback.
+        }
+
+        assert_eq!(count.load(Ordering::Relaxed), 0);
+    }
+
+    #[diesel_test_helper::test]
+    fn remove_rollback_hook_disables_callback() {
+        let conn = &mut connection();
+
+        crate::sql_query("CREATE TABLE t_rem_rb (id INTEGER PRIMARY KEY)")
+            .execute(conn)
+            .unwrap();
+
+        let count = Arc::new(AtomicU32::new(0));
+        let c2 = count.clone();
+
+        conn.on_rollback(move || {
+            c2.fetch_add(1, Ordering::Relaxed);
+        });
+
+        conn.remove_rollback_hook();
+
+        let _ = conn.immediate_transaction(|conn| {
+            crate::sql_query("INSERT INTO t_rem_rb (id) VALUES (1)")
+                .execute(conn)
+                .unwrap();
+            Err::<(), _>(crate::result::Error::RollbackTransaction)
+        });
 
         assert_eq!(count.load(Ordering::Relaxed), 0);
     }

--- a/diesel/src/sqlite/connection/raw.rs
+++ b/diesel/src/sqlite/connection/raw.rs
@@ -53,6 +53,8 @@ pub(super) struct RawConnection {
     pub(super) internal_connection: NonNull<ffi::sqlite3>,
     /// Boxed closure kept alive while the commit hook is registered.
     commit_hook: Option<Box<dyn FnMut() -> CommitDecision + Send>>,
+    /// Boxed closure kept alive while the rollback hook is registered.
+    rollback_hook: Option<Box<dyn FnMut() + Send>>,
 }
 
 impl RawConnection {
@@ -62,6 +64,7 @@ impl RawConnection {
         RawConnection {
             internal_connection: conn,
             commit_hook: None,
+            rollback_hook: None,
         }
     }
 
@@ -84,6 +87,7 @@ impl RawConnection {
                 Ok(RawConnection {
                     internal_connection: conn_pointer,
                     commit_hook: None,
+                    rollback_hook: None,
                 })
             }
             err_code => {
@@ -432,6 +436,51 @@ impl RawConnection {
         }
         self.commit_hook = None;
     }
+
+    /// Sets the rollback hook, replacing any previous one.
+    ///
+    /// # Safety
+    ///
+    /// The `ptr` is derived from `&raw mut *boxed` and points to the heap
+    /// allocation of the closure. The `rollback_hook_trampoline` function
+    /// matches the signature expected by `sqlite3_rollback_hook`. The pointer
+    /// remains valid because we store `boxed` in `self.rollback_hook` below,
+    /// keeping it alive for the lifetime of this `RawConnection`.
+    pub(super) fn set_rollback_hook<F>(&mut self, hook: F)
+    where
+        F: FnMut() + Send + 'static,
+    {
+        let mut boxed: Box<dyn FnMut() + Send> = Box::new(hook);
+        let ptr = &raw mut *boxed as *mut libc::c_void;
+
+        unsafe {
+            ffi::sqlite3_rollback_hook(
+                self.internal_connection.as_ptr(),
+                Some(rollback_hook_trampoline::<F>),
+                ptr,
+            );
+        }
+
+        // The old Box (if any) is dropped here after SQLite has already
+        // switched to the new callback, preventing use-after-free.
+        self.rollback_hook = Some(boxed);
+    }
+
+    /// Removes the rollback hook.
+    ///
+    /// # Safety
+    ///
+    /// `self.internal_connection` is a valid pointer to an open SQLite
+    /// connection. Passing `None` as the hook and `null_mut()` as the user
+    /// data unregisters any existing rollback hook. The hook is unregistered
+    /// before dropping `self.rollback_hook` to prevent callbacks from firing
+    /// during cleanup.
+    pub(super) fn remove_rollback_hook(&mut self) {
+        unsafe {
+            ffi::sqlite3_rollback_hook(self.internal_connection.as_ptr(), None, ptr::null_mut());
+        }
+        self.rollback_hook = None;
+    }
 }
 
 impl Drop for RawConnection {
@@ -440,6 +489,7 @@ impl Drop for RawConnection {
 
         // Unregister before close so the boxed closure drops before sqlite3_close.
         self.remove_commit_hook();
+        self.remove_rollback_hook();
 
         let close_result = unsafe { ffi::sqlite3_close(self.internal_connection.as_ptr()) };
         if close_result != ffi::SQLITE_OK {
@@ -831,5 +881,25 @@ where
         Err(_) => {
             assert_fail!("Panic in sqlite3_commit_hook trampoline. ");
         }
+    }
+}
+
+/// C trampoline for `sqlite3_rollback_hook`.
+///
+/// # Safety
+///
+/// `user_data` must point to a live `F` stored in `RawConnection::rollback_hook`.
+unsafe extern "C" fn rollback_hook_trampoline<F>(user_data: *mut libc::c_void)
+where
+    F: FnMut(),
+{
+    let result = crate::util::std_compat::catch_unwind(core::panic::AssertUnwindSafe(|| {
+        // SAFETY: `user_data` points to a live `F` in `RawConnection::rollback_hook`.
+        let f = unsafe { &mut *(user_data as *mut F) };
+        f();
+    }));
+
+    if result.is_err() {
+        assert_fail!("Panic in sqlite3_rollback_hook trampoline. ");
     }
 }


### PR DESCRIPTION
Part of splitting #4969 into one PR per SQLite C-API, following the commit hook in #5077.

Adds `SqliteConnection::on_rollback` and `SqliteConnection::remove_rollback_hook`, wrapping [`sqlite3_rollback_hook`](https://www.sqlite.org/c3ref/commit_hook.html). The callback fires after a transaction is rolled back. Only one rollback hook is active at a time, and re-registering replaces the previous one. The callback cannot use the connection, and a panic in it aborts the process.

```rust
conn.on_rollback(|| {
    println!("transaction rolled back");
});
```
