### PR TITLE
Document the threading and reentrancy guarantees of on_commit

### DIFF
--- a/diesel/src/sqlite/connection/hooks.rs
+++ b/diesel/src/sqlite/connection/hooks.rs
@@ -12,8 +12,12 @@ impl SqliteConnection {
     /// Only one commit hook can be active at a time per connection.
     /// Registering a new one replaces the previous.
     ///
-    /// The callback must not use the database connection. Panics in the
-    /// callback abort the process.
+    /// The callback runs synchronously as part of the committing
+    /// `sqlite3_step()` call, on the thread performing the commit, so it is
+    /// never invoked concurrently. Per SQLite, the callback must not use the
+    /// connection that triggered it (running any SQL, including a `SELECT`,
+    /// counts as use) and is not reentrant. A panic in the callback aborts the
+    /// process.
     ///
     /// See: [`sqlite3_commit_hook`](https://www.sqlite.org/c3ref/commit_hook.html)
     ///


### PR DESCRIPTION
Follow-up to the review discussion on #5077: documents in `on_commit`'s rustdoc that the callback runs synchronously during the commit (never invoked concurrently), must not use the connection that triggered it (even a `SELECT` counts), and is not reentrant, per the SQLite `sqlite3_commit_hook` documentation.
