### PR TITLE
Add `SqliteConnection::on_progress` wrapping `sqlite3_progress_handler`

### DIFF
--- a/diesel/src/sqlite/connection/hooks.rs
+++ b/diesel/src/sqlite/connection/hooks.rs
@@ -1,6 +1,7 @@
 use super::SqliteConnection;
+use core::num::NonZeroU32;
 
-pub(super) use super::CommitDecision;
+pub(super) use super::{CommitDecision, ProgressDecision};
 
 impl SqliteConnection {
     /// Registers a callback invoked when a transaction is about to be
@@ -124,6 +125,66 @@ impl SqliteConnection {
     /// See [`on_rollback`](Self::on_rollback) for usage example.
     pub fn remove_rollback_hook(&mut self) {
         self.raw_connection.remove_rollback_hook();
+    }
+
+    /// Registers a progress handler that can interrupt long-running queries.
+    ///
+    /// The callback is invoked periodically while a query runs. `n` is the
+    /// approximate number of virtual-machine instructions between callbacks. It
+    /// is a [`NonZeroU32`] so the handler cannot be disabled implicitly by
+    /// passing zero. Use [`remove_progress_handler`](Self::remove_progress_handler)
+    /// to disable it. Since SQLite 3.41.0 the callback may also fire during
+    /// statement preparation.
+    ///
+    /// The callback returns a [`ProgressDecision`]: `Continue` lets the query
+    /// keep executing, `Interrupt` aborts it (causes `SQLITE_INTERRUPT`).
+    ///
+    /// Only one progress handler can be active at a time per connection.
+    /// Registering a new one replaces the previous.
+    ///
+    /// The callback must not use the database connection. It is invoked
+    /// synchronously on the thread driving the connection, so it is never
+    /// called concurrently. Panics in the callback abort the process.
+    ///
+    /// See: [`sqlite3_progress_handler`](https://www.sqlite.org/c3ref/progress_handler.html)
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use diesel::prelude::*;
+    /// use diesel::sqlite::{SqliteConnection, ProgressDecision};
+    /// use std::num::NonZeroU32;
+    /// use std::sync::Arc;
+    /// use std::sync::atomic::{AtomicBool, Ordering};
+    ///
+    /// # let conn = &mut SqliteConnection::establish(":memory:").unwrap();
+    /// let cancelled = Arc::new(AtomicBool::new(false));
+    /// let cancelled2 = cancelled.clone();
+    ///
+    /// conn.on_progress(NonZeroU32::new(1000).unwrap(), move || {
+    ///     if cancelled2.load(Ordering::Relaxed) {
+    ///         ProgressDecision::Interrupt
+    ///     } else {
+    ///         ProgressDecision::Continue
+    ///     }
+    /// });
+    ///
+    /// // Later: remove the handler.
+    /// conn.remove_progress_handler();
+    /// ```
+    pub fn on_progress<F>(&mut self, n: NonZeroU32, hook: F)
+    where
+        F: FnMut() -> ProgressDecision + Send + 'static,
+    {
+        self.raw_connection.set_progress_handler(n, hook);
+    }
+
+    /// Removes the progress handler. Subsequent queries will not invoke any
+    /// callback.
+    ///
+    /// See [`on_progress`](Self::on_progress) for usage example.
+    pub fn remove_progress_handler(&mut self) {
+        self.raw_connection.remove_progress_handler();
     }
 }
 
@@ -364,5 +425,37 @@ mod tests {
         });
 
         assert_eq!(count.load(Ordering::Relaxed), 0);
+    }
+
+    // A recursive CTE heavy enough that the progress handler fires while it runs.
+    const HEAVY_QUERY: &str = "WITH RECURSIVE c(x) AS \
+        (SELECT 1 UNION ALL SELECT x + 1 FROM c WHERE x < 100000) SELECT count(*) FROM c";
+
+    #[diesel_test_helper::test]
+    fn on_progress_interrupts_query() {
+        let conn = &mut connection();
+
+        conn.on_progress(NonZeroU32::new(1).unwrap(), || ProgressDecision::Interrupt);
+
+        let result = crate::sql_query(HEAVY_QUERY).execute(conn);
+        assert!(
+            result.is_err(),
+            "the query should be interrupted by the progress handler"
+        );
+    }
+
+    #[diesel_test_helper::test]
+    fn remove_progress_handler_stops_interruption() {
+        let conn = &mut connection();
+
+        conn.on_progress(NonZeroU32::new(1).unwrap(), || ProgressDecision::Interrupt);
+        conn.remove_progress_handler();
+
+        // With the handler removed the same query runs to completion.
+        let result = crate::sql_query(HEAVY_QUERY).execute(conn);
+        assert!(
+            result.is_ok(),
+            "the query should complete after the handler is removed"
+        );
     }
 }

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -342,6 +342,16 @@ pub enum CommitDecision {
     Rollback,
 }
 
+/// The decision returned by an [`on_progress`](SqliteConnection::on_progress)
+/// callback, controlling whether a long-running query keeps executing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProgressDecision {
+    /// Let the query continue executing.
+    Continue,
+    /// Interrupt the query (causes `SQLITE_INTERRUPT`).
+    Interrupt,
+}
+
 impl SqliteConnection {
     /// Run a transaction with `BEGIN IMMEDIATE`
     ///

--- a/diesel/src/sqlite/connection/raw.rs
+++ b/diesel/src/sqlite/connection/raw.rs
@@ -5,11 +5,11 @@ extern crate libsqlite3_sys as ffi;
 #[cfg(all(target_family = "wasm", target_os = "unknown"))]
 use sqlite_wasm_rs as ffi;
 
-use super::CommitDecision;
 use super::functions::{build_sql_function_args, process_sql_function_result};
 use super::limits::SqliteLimit;
 use super::serialized_database::SerializedDatabase;
 use super::stmt::ensure_sqlite_ok;
+use super::{CommitDecision, ProgressDecision};
 use super::{Sqlite, SqliteAggregateFunction};
 use crate::deserialize::FromSqlRow;
 use crate::result::Error::DatabaseError;
@@ -22,6 +22,7 @@ use alloc::boxed::Box;
 use alloc::ffi::{CString, NulError};
 use alloc::string::{String, ToString};
 use core::ffi as libc;
+use core::num::NonZeroU32;
 use core::ptr::NonNull;
 use core::{mem, ptr, slice, str};
 
@@ -55,6 +56,8 @@ pub(super) struct RawConnection {
     commit_hook: Option<Box<dyn FnMut() -> CommitDecision + Send>>,
     /// Boxed closure kept alive while the rollback hook is registered.
     rollback_hook: Option<Box<dyn FnMut() + Send>>,
+    /// Boxed closure kept alive while the progress handler is registered.
+    progress_hook: Option<Box<dyn FnMut() -> ProgressDecision + Send>>,
 }
 
 impl RawConnection {
@@ -65,6 +68,7 @@ impl RawConnection {
             internal_connection: conn,
             commit_hook: None,
             rollback_hook: None,
+            progress_hook: None,
         }
     }
 
@@ -88,6 +92,7 @@ impl RawConnection {
                     internal_connection: conn_pointer,
                     commit_hook: None,
                     rollback_hook: None,
+                    progress_hook: None,
                 })
             }
             err_code => {
@@ -485,6 +490,64 @@ impl RawConnection {
         }
         self.rollback_hook = None;
     }
+
+    /// Sets the progress handler, replacing any previous one.
+    ///
+    /// `n` is the approximate number of VM instructions between callbacks.
+    ///
+    /// # Safety
+    ///
+    /// The `ptr` is derived from `&raw mut *boxed` and points to the heap
+    /// allocation of the closure. The `progress_handler_trampoline` function
+    /// matches the signature expected by `sqlite3_progress_handler`. The
+    /// pointer remains valid because we store `boxed` in `self.progress_hook`
+    /// below, keeping it alive for the lifetime of this `RawConnection`.
+    pub(super) fn set_progress_handler<F>(&mut self, n: NonZeroU32, hook: F)
+    where
+        F: FnMut() -> ProgressDecision + Send + 'static,
+    {
+        let mut boxed: Box<dyn FnMut() -> ProgressDecision + Send> = Box::new(hook);
+        let ptr = &raw mut *boxed as *mut libc::c_void;
+
+        // `sqlite3_progress_handler` takes a c_int. A value above `i32::MAX`
+        // would wrap to a non-positive number and disable the handler, so clamp
+        // it to `i32::MAX` instead.
+        let n = i32::try_from(n.get()).unwrap_or(i32::MAX);
+
+        unsafe {
+            ffi::sqlite3_progress_handler(
+                self.internal_connection.as_ptr(),
+                n,
+                Some(progress_handler_trampoline::<F>),
+                ptr,
+            );
+        }
+
+        // The old Box (if any) is dropped here after SQLite has already
+        // switched to the new callback, preventing use-after-free.
+        self.progress_hook = Some(boxed);
+    }
+
+    /// Removes the progress handler.
+    ///
+    /// # Safety
+    ///
+    /// `self.internal_connection` is a valid pointer to an open SQLite
+    /// connection. Passing `None` as the handler and `null_mut()` as the user
+    /// data unregisters any existing progress handler. The handler is
+    /// unregistered before dropping `self.progress_hook` to prevent callbacks
+    /// from firing during cleanup.
+    pub(super) fn remove_progress_handler(&mut self) {
+        unsafe {
+            ffi::sqlite3_progress_handler(
+                self.internal_connection.as_ptr(),
+                0,
+                None,
+                ptr::null_mut(),
+            );
+        }
+        self.progress_hook = None;
+    }
 }
 
 impl Drop for RawConnection {
@@ -494,6 +557,7 @@ impl Drop for RawConnection {
         // Unregister before close so the boxed closure drops before sqlite3_close.
         self.remove_commit_hook();
         self.remove_rollback_hook();
+        self.remove_progress_handler();
 
         let close_result = unsafe { ffi::sqlite3_close(self.internal_connection.as_ptr()) };
         if close_result != ffi::SQLITE_OK {
@@ -905,5 +969,29 @@ where
 
     if result.is_err() {
         assert_fail!("Panic in sqlite3_rollback_hook trampoline. ");
+    }
+}
+
+/// C trampoline for `sqlite3_progress_handler`.
+///
+/// # Safety
+///
+/// `user_data` must point to a live `F` stored in `RawConnection::progress_hook`.
+unsafe extern "C" fn progress_handler_trampoline<F>(user_data: *mut libc::c_void) -> libc::c_int
+where
+    F: FnMut() -> ProgressDecision,
+{
+    let result = crate::util::std_compat::catch_unwind(core::panic::AssertUnwindSafe(|| {
+        // SAFETY: `user_data` points to a live `F` in `RawConnection::progress_hook`.
+        let f = unsafe { &mut *(user_data as *mut F) };
+        f()
+    }));
+
+    match result {
+        Ok(ProgressDecision::Interrupt) => 1,
+        Ok(ProgressDecision::Continue) => 0,
+        Err(_) => {
+            assert_fail!("Panic in sqlite3_progress_handler trampoline. ");
+        }
     }
 }

--- a/diesel/src/sqlite/mod.rs
+++ b/diesel/src/sqlite/mod.rs
@@ -19,6 +19,7 @@ pub use self::auto_extension::register_auto_extension;
 pub use self::auto_extension::reset_auto_extension;
 pub use self::backend::{Sqlite, SqliteType};
 pub use self::connection::CommitDecision;
+pub use self::connection::ProgressDecision;
 pub use self::connection::SerializedDatabase;
 pub use self::connection::SqliteBindValue;
 pub use self::connection::SqliteConnection;


### PR DESCRIPTION
Part of splitting #4969 into one PR per SQLite C-API, following the commit hook in #5077. It is independent of the parallel rollback (#5083) and WAL (#5085) hooks, so they can merge in any order.

Adds `SqliteConnection::on_progress` and `SqliteConnection::remove_progress_handler`, wrapping [`sqlite3_progress_handler`](https://www.sqlite.org/c3ref/progress_handler.html). The callback fires roughly every `n` virtual-machine instructions while a query runs and returns a `ProgressDecision` (`Continue` or `Interrupt`), mirroring the `CommitDecision` enum from #5077. Only one handler is active at a time, and re-registering replaces the previous one. The callback cannot use the connection, and a panic in it aborts the process.

```rust
// fire every ~1000 VM instructions; return Interrupt to abort the query
conn.on_progress(1000, || ProgressDecision::Continue);
```
