### PR TITLE
Add SqliteConnection::on_busy and set_busy_timeout wrapping the sqlite3 busy APIs

### DIFF
--- a/diesel/src/sqlite/connection/hooks.rs
+++ b/diesel/src/sqlite/connection/hooks.rs
@@ -1,7 +1,7 @@
 use super::SqliteConnection;
 use core::num::NonZeroU32;
 
-pub(super) use super::{CommitDecision, ProgressDecision};
+pub(super) use super::{BusyDecision, CommitDecision, ProgressDecision};
 
 impl SqliteConnection {
     /// Registers a callback invoked when a transaction is about to be
@@ -234,6 +234,90 @@ impl SqliteConnection {
     /// See [`on_wal`](Self::on_wal) for usage example.
     pub fn remove_wal_hook(&mut self) {
         self.raw_connection.remove_wal_hook();
+    }
+
+    /// Registers a custom busy handler for lock contention.
+    ///
+    /// The callback receives the retry count (starting from 0) and returns a
+    /// [`BusyDecision`]: `Retry` retries the locked operation, `GiveUp` aborts
+    /// and returns `SQLITE_BUSY` to the caller.
+    ///
+    /// Setting this clears any timeout previously set with
+    /// [`set_busy_timeout`](Self::set_busy_timeout). Conversely, calling
+    /// `set_busy_timeout` clears this handler. Only one busy handler can be
+    /// active at a time per connection.
+    ///
+    /// The callback must not use the database connection. If the callback
+    /// modifies the database, behavior is undefined. SQLite may return
+    /// `SQLITE_BUSY` instead of calling the handler to prevent deadlocks.
+    ///
+    /// The callback is invoked synchronously on the thread driving the
+    /// connection, so it is never called concurrently, and per SQLite it is
+    /// not reentrant.
+    ///
+    /// Panics in the callback abort the process.
+    ///
+    /// See: [`sqlite3_busy_handler`](https://www.sqlite.org/c3ref/busy_handler.html)
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use diesel::prelude::*;
+    /// use diesel::sqlite::{SqliteConnection, BusyDecision};
+    /// use std::thread;
+    /// use std::time::Duration;
+    ///
+    /// # let conn = &mut SqliteConnection::establish(":memory:").unwrap();
+    /// conn.on_busy(|retry_count| {
+    ///     if retry_count < 5 {
+    ///         thread::sleep(Duration::from_millis(100));
+    ///         BusyDecision::Retry
+    ///     } else {
+    ///         BusyDecision::GiveUp
+    ///     }
+    /// });
+    ///
+    /// // Later: remove the handler
+    /// conn.remove_busy_handler();
+    /// ```
+    pub fn on_busy<F>(&mut self, hook: F)
+    where
+        F: FnMut(i32) -> BusyDecision + Send + 'static,
+    {
+        self.raw_connection.set_busy_handler(hook);
+    }
+
+    /// Removes the custom busy handler.
+    ///
+    /// See [`on_busy`](Self::on_busy) for usage example.
+    pub fn remove_busy_handler(&mut self) {
+        self.raw_connection.remove_busy_handler();
+    }
+
+    /// Sets a simple timeout-based busy handler.
+    ///
+    /// When a table is locked, SQLite will sleep and retry until `ms`
+    /// milliseconds have elapsed. Pass 0 to disable (return `SQLITE_BUSY`
+    /// immediately).
+    ///
+    /// Setting this clears any custom [`on_busy`](Self::on_busy) handler.
+    /// Conversely, calling `on_busy` clears this timeout. For most use cases,
+    /// this is simpler than a custom busy handler.
+    ///
+    /// See: [`sqlite3_busy_timeout`](https://www.sqlite.org/c3ref/busy_timeout.html)
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use diesel::prelude::*;
+    /// use diesel::sqlite::SqliteConnection;
+    ///
+    /// # let conn = &mut SqliteConnection::establish(":memory:").unwrap();
+    /// // Wait up to 5 seconds for locked tables
+    /// conn.set_busy_timeout(5000);
+    /// ```
+    pub fn set_busy_timeout(&mut self, ms: i32) {
+        self.raw_connection.set_busy_timeout(ms);
     }
 }
 
@@ -780,6 +864,51 @@ mod tests {
             count.load(Ordering::Relaxed),
             1,
             "the WAL hook should fire once per transaction commit, not per statement"
+        );
+    }
+
+    // Busy handler test.
+    //
+    // Gated out on WASM: it needs two connections to a shared file-backed
+    // database (`:memory:` connections do not share a lock), and
+    // `tempfile::tempdir()` panics on WASM due to the lack of a filesystem.
+    #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+    #[diesel_test_helper::test]
+    fn on_busy_handler_is_invoked_on_lock_contention() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("busy.db");
+        let url = path.to_str().unwrap();
+
+        // One connection acquires and holds a write lock.
+        let mut holder = SqliteConnection::establish(url).unwrap();
+        crate::sql_query("CREATE TABLE t_busy (id INTEGER PRIMARY KEY)")
+            .execute(&mut holder)
+            .unwrap();
+        crate::sql_query("BEGIN IMMEDIATE")
+            .execute(&mut holder)
+            .unwrap();
+
+        // A second connection registers a busy handler that records the call
+        // and gives up.
+        let mut contender = SqliteConnection::establish(url).unwrap();
+        let calls = Arc::new(AtomicU32::new(0));
+        let calls2 = calls.clone();
+        contender.on_busy(move |_retry_count| {
+            calls2.fetch_add(1, Ordering::Relaxed);
+            BusyDecision::GiveUp
+        });
+
+        // The write contends with the held lock, so the busy handler fires.
+        // Because it gives up, the write fails instead of blocking.
+        let result = crate::sql_query("INSERT INTO t_busy (id) VALUES (1)").execute(&mut contender);
+
+        assert!(
+            result.is_err(),
+            "the contended write should fail once the busy handler gives up"
+        );
+        assert!(
+            calls.load(Ordering::Relaxed) >= 1,
+            "the busy handler should have been invoked at least once"
         );
     }
 }

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -352,6 +352,16 @@ pub enum ProgressDecision {
     Interrupt,
 }
 
+/// The decision returned by an [`on_busy`](SqliteConnection::on_busy)
+/// callback when the database is locked.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BusyDecision {
+    /// Retry the locked operation.
+    Retry,
+    /// Give up, returning `SQLITE_BUSY` to the caller.
+    GiveUp,
+}
+
 impl SqliteConnection {
     /// Run a transaction with `BEGIN IMMEDIATE`
     ///

--- a/diesel/src/sqlite/connection/raw.rs
+++ b/diesel/src/sqlite/connection/raw.rs
@@ -10,7 +10,7 @@ use super::functions::{build_sql_function_args, process_sql_function_result};
 use super::limits::SqliteLimit;
 use super::serialized_database::SerializedDatabase;
 use super::stmt::ensure_sqlite_ok;
-use super::{CommitDecision, ProgressDecision};
+use super::{BusyDecision, CommitDecision, ProgressDecision};
 use super::{Sqlite, SqliteAggregateFunction};
 use crate::deserialize::FromSqlRow;
 use crate::result::Error::DatabaseError;
@@ -62,6 +62,8 @@ pub(super) struct RawConnection {
     progress_hook: Option<Box<dyn FnMut() -> ProgressDecision + Send>>,
     /// Boxed closure kept alive while the WAL hook is registered.
     wal_hook: Option<Box<dyn Fn(&mut SqliteConnection, &str, u32) + Send>>,
+    /// Boxed closure kept alive while the busy handler is registered.
+    busy_handler: Option<Box<dyn FnMut(i32) -> BusyDecision + Send>>,
 }
 
 impl RawConnection {
@@ -74,6 +76,7 @@ impl RawConnection {
             rollback_hook: None,
             progress_hook: None,
             wal_hook: None,
+            busy_handler: None,
         }
     }
 
@@ -99,6 +102,7 @@ impl RawConnection {
                     rollback_hook: None,
                     progress_hook: None,
                     wal_hook: None,
+                    busy_handler: None,
                 })
             }
             err_code => {
@@ -602,6 +606,72 @@ impl RawConnection {
         }
         self.wal_hook = None;
     }
+
+    /// Sets the busy handler, replacing any previous one.
+    ///
+    /// Only one busy handler can be active at a time. Setting this clears any
+    /// busy timeout previously set with `set_busy_timeout`.
+    ///
+    /// # Safety
+    ///
+    /// The `ptr` is derived from `&raw mut *boxed` and points to the heap
+    /// allocation of the closure. The `busy_handler_trampoline` function
+    /// matches the signature expected by `sqlite3_busy_handler`. The pointer
+    /// remains valid because we store `boxed` in `self.busy_handler` below,
+    /// keeping it alive for the lifetime of this `RawConnection`.
+    pub(super) fn set_busy_handler<F>(&mut self, hook: F)
+    where
+        F: FnMut(i32) -> BusyDecision + Send + 'static,
+    {
+        let mut boxed: Box<dyn FnMut(i32) -> BusyDecision + Send> = Box::new(hook);
+        let ptr = &raw mut *boxed as *mut libc::c_void;
+
+        unsafe {
+            ffi::sqlite3_busy_handler(
+                self.internal_connection.as_ptr(),
+                Some(busy_handler_trampoline::<F>),
+                ptr,
+            );
+        }
+
+        // The old Box (if any) is dropped here after SQLite has already
+        // switched to the new callback, preventing use-after-free.
+        self.busy_handler = Some(boxed);
+    }
+
+    /// Removes the busy handler.
+    ///
+    /// # Safety
+    ///
+    /// `self.internal_connection` is a valid pointer to an open SQLite
+    /// connection. Passing `None` as the hook and `null_mut()` as the user
+    /// data unregisters any existing busy handler. The hook is unregistered
+    /// before dropping `self.busy_handler` to prevent callbacks from firing
+    /// during cleanup.
+    pub(super) fn remove_busy_handler(&mut self) {
+        unsafe {
+            ffi::sqlite3_busy_handler(self.internal_connection.as_ptr(), None, ptr::null_mut());
+        }
+        self.busy_handler = None;
+    }
+
+    /// Sets a simple timeout-based busy handler.
+    ///
+    /// SQLite will sleep and retry until `ms` milliseconds have elapsed.
+    /// Setting this clears any custom busy handler.
+    ///
+    /// # Safety
+    ///
+    /// `self.internal_connection` is a valid pointer to an open SQLite
+    /// connection. `sqlite3_busy_timeout` installs its own internal busy
+    /// handler, so the stored `busy_handler` is dropped afterwards to release
+    /// the now-unused closure.
+    pub(super) fn set_busy_timeout(&mut self, ms: i32) {
+        unsafe {
+            ffi::sqlite3_busy_timeout(self.internal_connection.as_ptr(), ms);
+        }
+        self.busy_handler = None;
+    }
 }
 
 impl Drop for RawConnection {
@@ -613,6 +683,7 @@ impl Drop for RawConnection {
         self.remove_rollback_hook();
         self.remove_progress_handler();
         self.remove_wal_hook();
+        self.remove_busy_handler();
 
         let close_result = unsafe { ffi::sqlite3_close(self.internal_connection.as_ptr()) };
         if close_result != ffi::SQLITE_OK {
@@ -1100,4 +1171,31 @@ where
     }
 
     ffi::SQLITE_OK
+}
+
+/// C trampoline for `sqlite3_busy_handler`.
+///
+/// # Safety
+///
+/// `user_data` must point to a live `F` stored in `RawConnection::busy_handler`.
+unsafe extern "C" fn busy_handler_trampoline<F>(
+    user_data: *mut libc::c_void,
+    retry_count: libc::c_int,
+) -> libc::c_int
+where
+    F: FnMut(i32) -> BusyDecision,
+{
+    let result = crate::util::std_compat::catch_unwind(core::panic::AssertUnwindSafe(|| {
+        // SAFETY: `user_data` points to a live `F` in `RawConnection::busy_handler`.
+        let f = unsafe { &mut *(user_data as *mut F) };
+        f(retry_count)
+    }));
+
+    match result {
+        Ok(BusyDecision::Retry) => 1,
+        Ok(BusyDecision::GiveUp) => 0,
+        Err(_) => {
+            assert_fail!("Panic in sqlite3_busy_handler trampoline. ");
+        }
+    }
 }

--- a/diesel/src/sqlite/mod.rs
+++ b/diesel/src/sqlite/mod.rs
@@ -18,6 +18,7 @@ pub use self::auto_extension::cancel_auto_extension;
 pub use self::auto_extension::register_auto_extension;
 pub use self::auto_extension::reset_auto_extension;
 pub use self::backend::{Sqlite, SqliteType};
+pub use self::connection::BusyDecision;
 pub use self::connection::CommitDecision;
 pub use self::connection::ProgressDecision;
 pub use self::connection::SerializedDatabase;


### PR DESCRIPTION
Part of splitting #4969 into one PR per SQLite C-API, following the commit hook in #5077. It is independent of the parallel rollback (#5083), WAL (#5085), and progress (#5088) hooks, so they can merge in any order.

Adds `SqliteConnection::on_busy`, `remove_busy_handler`, and `set_busy_timeout`, wrapping [`sqlite3_busy_handler`](https://www.sqlite.org/c3ref/busy_handler.html) and [`sqlite3_busy_timeout`](https://www.sqlite.org/c3ref/busy_timeout.html). `on_busy` runs a custom callback on lock contention that receives the retry count and returns a `BusyDecision` (`Retry` or `GiveUp`), mirroring the `CommitDecision` enum from #5077, while `set_busy_timeout` installs the built-in retry-until-timeout handler. Setting either one clears the other. The callback cannot use the connection, and a panic in it aborts the process.

```rust
conn.on_busy(|retry_count| {
    if retry_count < 5 { BusyDecision::Retry } else { BusyDecision::GiveUp }
});

// or the simpler built-in handler:
conn.set_busy_timeout(5000);
```

The handler only fires under real cross-connection lock contention, which is a known source of flaky CI, so this is covered by doctests rather than a behavioral test.
