### PR TITLE
Fix several potential panics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 * `Bpchar` is now a distinct PostgreSQL SQL type (previously a hidden alias for `Varchar`). Binds on `CHAR(N)` / `BPCHAR` columns are now sent with OID 1042, allowing PostgreSQL to use the column's index instead of casting it to text.
 * Fix non-deterministic test failures on PostgreSQL caused by loading rows without `ORDER BY` and assuming insertion order
 * `diesel_derives` does now correctly handle feature flag unification in mixed build/target dependency situations
+* Fixed several panics in the serialization and deserialization code for PostgreSQL and MySQL
+* Tighten requirements for `SqliteConnection::deserialize_readonly_database` to closely match the upstream requirements
 
 ### Changed
 

--- a/diesel/src/mysql/connection/bind.rs
+++ b/diesel/src/mysql/connection/bind.rs
@@ -63,15 +63,15 @@ impl OutputBinds {
     pub(super) fn from_output_types(
         types: &[Option<MysqlType>],
         metadata: &StatementMetadata,
-    ) -> Self {
+    ) -> Result<Self, Box<dyn core::error::Error + Send + Sync>> {
         let data = metadata
             .fields()
             .iter()
             .zip(types.iter().copied().chain(core::iter::repeat(None)))
             .map(|(field, tpe)| BindData::for_output(tpe, field))
-            .collect();
+            .collect::<Result<Vec<_>, _>>()?;
 
-        Self(Binds { data })
+        Ok(Self(Binds { data }))
     }
 
     pub(super) fn populate_dynamic_buffers(&mut self, stmt: &StatementUse<'_>) -> QueryResult<()> {
@@ -127,6 +127,7 @@ impl Index<usize> for OutputBinds {
 }
 
 bitflags::bitflags! {
+    /// See https://dev.mysql.com/doc/dev/mysql-server/latest/group__group__cs__column__definition__flags.html
     #[derive(Clone, Copy, Debug)]
     pub(crate) struct Flags: u32 {
         const NOT_NULL_FLAG = 1;
@@ -143,25 +144,33 @@ bitflags::bitflags! {
         const SET_FLAG = 2_048;
         const NO_DEFAULT_VALUE_FLAG = 4_096;
         const ON_UPDATE_NOW_FLAG = 8_192;
-        const NUM_FLAG = 32_768;
         const PART_KEY_FLAG = 16_384;
-        const GROUP_FLAG = (1 << 28);
+        const NUM_FLAG = 32_768;
         const UNIQUE_FLAG = 65_536;
         const BINCMP_FLAG = 131_072;
         const GET_FIXED_FIELDS_FLAG = (1<<18);
         const FIELD_IN_PART_FUNC_FLAG = (1 << 19);
+        const FIELD_IN_ADD_INDEX = (1 << 20);
+        const FIELD_IS_RENAMED = (1 << 21);
+        const FIELD_FLAGS_STORAGE_MEDIA = 22;
+        const FIELD_FLAGS_COLUMN_FORMAT = 24;
+        const FIELD_IS_DROPPED = (1 << 26);
         const EXPLICIT_NULL_FLAG = (1 << 27);
+        const GROUP_FLAG = (1 << 28);
         const NOT_SECONDARY_FLAG = (1 << 29);
+        const FIELD_IS_INVISIBLE = (1 << 30);
     }
 }
 
-impl From<u32> for Flags {
-    fn from(flags: u32) -> Self {
-        Flags::from_bits(flags).expect(
+impl TryFrom<u32> for Flags {
+    type Error = Box<dyn core::error::Error + Send + Sync>;
+    fn try_from(flags: u32) -> Result<Self, Self::Error> {
+        Flags::from_bits(flags).ok_or_else(|| {
             "We encountered an unknown type flag while parsing \
              Mysql's type information. If you see this error message \
-             please open an issue at diesels github page.",
-        )
+             please open an issue at diesels github page."
+                .into()
+        })
     }
 }
 
@@ -248,7 +257,10 @@ impl BindData {
         }
     }
 
-    fn for_output(tpe: Option<MysqlType>, metadata: &MysqlFieldMetadata<'_>) -> Self {
+    fn for_output(
+        tpe: Option<MysqlType>,
+        metadata: &MysqlFieldMetadata<'_>,
+    ) -> Result<Self, Box<dyn core::error::Error + Send + Sync>> {
         let (tpe, flags) = if let Some(tpe) = tpe {
             match (tpe, metadata.field_type()) {
                 // Those are types where we handle the conversion in diesel itself
@@ -372,15 +384,15 @@ impl BindData {
                 | (MysqlType::Enum, ffi::enum_field_types::MYSQL_TYPE_BLOB)
                 | (MysqlType::Enum, ffi::enum_field_types::MYSQL_TYPE_VAR_STRING)
                 | (MysqlType::Enum, ffi::enum_field_types::MYSQL_TYPE_STRING) => {
-                    (metadata.field_type(), metadata.flags())
+                    (metadata.field_type(), metadata.flags()?)
                 }
 
                 (tpe, _) => tpe.into(),
             }
         } else {
-            (metadata.field_type(), metadata.flags())
+            (metadata.field_type(), metadata.flags()?)
         };
-        Self::from_tpe_and_flags((tpe, flags))
+        Ok(Self::from_tpe_and_flags((tpe, flags)))
     }
 
     fn from_tpe_and_flags((tpe, flags): (ffi::enum_field_types, Flags)) -> Self {
@@ -942,7 +954,8 @@ mod tests {
 
         let metadata = stmt.metadata().unwrap();
         let mut output_binds =
-            OutputBinds::from_output_types(&vec![None; metadata.fields().len()], &metadata);
+            OutputBinds::from_output_types(&vec![None; metadata.fields().len()], &metadata)
+                .unwrap();
         let stmt = stmt.execute_statement(&mut output_binds).unwrap();
         stmt.populate_row_buffers(&mut output_binds).unwrap();
 

--- a/diesel/src/mysql/connection/stmt/iterator.rs
+++ b/diesel/src/mysql/connection/stmt/iterator.rs
@@ -24,7 +24,8 @@ impl<'a> StatementIterator<'a> {
     ) -> QueryResult<Self> {
         let metadata = stmt.metadata()?;
 
-        let mut output_binds = OutputBinds::from_output_types(types, &metadata);
+        let mut output_binds = OutputBinds::from_output_types(types, &metadata)
+            .map_err(crate::result::Error::DeserializationError)?;
 
         let mut stmt = stmt.execute_statement(&mut output_binds)?;
         let size = unsafe { stmt.result_size() }?;

--- a/diesel/src/mysql/connection/stmt/metadata.rs
+++ b/diesel/src/mysql/connection/stmt/metadata.rs
@@ -58,7 +58,9 @@ impl MysqlFieldMetadata<'_> {
         self.0.type_
     }
 
-    pub(in crate::mysql::connection) fn flags(&self) -> Flags {
-        Flags::from(self.0.flags)
+    pub(in crate::mysql::connection) fn flags(
+        &self,
+    ) -> Result<Flags, Box<dyn core::error::Error + Send + Sync>> {
+        Flags::try_from(self.0.flags)
     }
 }

--- a/diesel/src/pg/types/array.rs
+++ b/diesel/src/pg/types/array.rs
@@ -118,7 +118,12 @@ where
             })
             .collect::<deserialize::Result<Vec<_>>>()?;
 
-        let data = (0..dims.iter().product::<usize>())
+        let max_dim = dims
+            .iter()
+            .try_fold(1_usize, |a, b| a.checked_mul(*b))
+            .ok_or("Overflow while deserializing package size")?;
+
+        let data = (0..max_dim)
             .map(|_| -> deserialize::Result<T> {
                 let elem_size = bytes.read_i32::<NetworkEndian>()?;
                 if has_null && elem_size == -1 {

--- a/diesel/src/pg/types/numeric.rs
+++ b/diesel/src/pg/types/numeric.rs
@@ -82,69 +82,82 @@ mod bigdecimal {
 
     // that should likely be a `TryFrom` impl
     // TODO: diesel 3.0
+    // This now mostly exists for backward compatibility
+    // Our own `ToSql` impls don't call it anymore in favour of calling
+    // the failable inner function instead
     #[cfg(all(feature = "postgres_backend", feature = "numeric"))]
     impl<'a> From<&'a BigDecimal> for PgNumeric {
-        // NOTE(clippy): No `std::ops::MulAssign` impl for `BigInt`
-        // NOTE(clippy): Clippy suggests to replace the `.take_while(|i| i.is_zero())`
-        // with `.take_while(Zero::is_zero)`, but that's a false positive.
-        // The closure gets an `&&i16` due to autoderef `<i16 as Zero>::is_zero(&self) -> bool`
-        // is called. There is no impl for `&i16` that would work with this closure.
-        #[allow(clippy::assign_op_pattern, clippy::redundant_closure)]
         fn from(decimal: &'a BigDecimal) -> Self {
-            let (mut integer, scale) = decimal.as_bigint_and_exponent();
+            try_convert_decimal_to_pg_numeric(decimal)
+                .expect("Failed to convert BigDecimal to PgNumeric")
+        }
+    }
 
-            // Handling of negative scale
-            let scale = if scale < 0 {
-                for _ in 0..(-scale) {
-                    integer = integer * 10;
-                }
-                0
-            } else {
-                scale
-                    .try_into()
-                    .expect("Scale is expected to be 16bit large")
-            };
+    // NOTE(clippy): No `std::ops::MulAssign` impl for `BigInt`
+    // NOTE(clippy): Clippy suggests to replace the `.take_while(|i| i.is_zero())`
+    // with `.take_while(Zero::is_zero)`, but that's a false positive.
+    // The closure gets an `&&i16` due to autoderef `<i16 as Zero>::is_zero(&self) -> bool`
+    // is called. There is no impl for `&i16` that would work with this closure.
+    #[allow(clippy::assign_op_pattern, clippy::redundant_closure)]
+    #[cfg(all(feature = "postgres_backend", feature = "numeric"))]
+    fn try_convert_decimal_to_pg_numeric(
+        decimal: &BigDecimal,
+    ) -> Result<PgNumeric, Box<dyn core::error::Error + Send + Sync>> {
+        let (mut integer, scale) = decimal.as_bigint_and_exponent();
 
-            integer = integer.abs();
-
-            // Ensure that the decimal will always lie on a digit boundary
-            for _ in 0..(4 - scale % 4) {
+        // Handling of negative scale
+        let scale = if scale < 0 {
+            for _ in 0..(-scale) {
                 integer = integer * 10;
             }
-            let integer = integer.to_biguint().expect("integer is always positive");
+            0
+        } else {
+            scale
+                .try_into()
+                .map_err(|_| "Scale is expected to be 16bit large")?
+        };
 
-            let mut digits = ToBase10000(Some(integer)).collect::<Vec<_>>();
-            digits.reverse();
-            let digits_after_decimal = scale / 4 + 1;
-            let weight = i16::try_from(digits.len())
-                .expect("Max digit number is expected to fit into 16 bit")
-                - i16::try_from(digits_after_decimal)
-                    .expect("Max digit number is expected to fit into 16 bit")
-                - 1;
+        integer = integer.abs();
 
-            let unnecessary_zeroes = digits.iter().rev().take_while(|i| i.is_zero()).count();
-
-            let relevant_digits = digits.len() - unnecessary_zeroes;
-            digits.truncate(relevant_digits);
-
-            match decimal.sign() {
-                Sign::Plus => PgNumeric::Positive {
-                    digits,
-                    scale,
-                    weight,
-                },
-                Sign::Minus => PgNumeric::Negative {
-                    digits,
-                    scale,
-                    weight,
-                },
-                Sign::NoSign => PgNumeric::Positive {
-                    digits: vec![0],
-                    scale: 0,
-                    weight: 0,
-                },
-            }
+        // Ensure that the decimal will always lie on a digit boundary
+        for _ in 0..(4 - scale % 4) {
+            integer = integer * 10;
         }
+        let integer = integer.to_biguint().ok_or("integer is always positive")?;
+
+        let mut digits = ToBase10000(Some(integer)).collect::<Vec<_>>();
+        digits.reverse();
+        let digits_after_decimal = scale / 4 + 1;
+        let weight = i16::try_from(digits.len())
+            .map_err(|_| "Max digit number is expected to fit into 16 bit")?
+            - i16::try_from(digits_after_decimal)
+                .map_err(|_| "Max digit number is expected to fit into 16 bit")?
+            - 1;
+
+        let unnecessary_zeroes = digits.iter().rev().take_while(|i| i.is_zero()).count();
+
+        let relevant_digits = digits.len() - unnecessary_zeroes;
+        digits.truncate(relevant_digits);
+
+        let result = match decimal.sign() {
+            Sign::Plus => PgNumeric::Positive {
+                digits,
+                scale,
+                weight,
+            },
+            Sign::Minus => PgNumeric::Negative {
+                digits,
+                scale,
+                weight,
+            },
+            Sign::NoSign => PgNumeric::Positive {
+                digits: vec![0],
+                scale: 0,
+                weight: 0,
+            },
+        };
+
+        Ok(result)
     }
 
     #[cfg(all(feature = "postgres_backend", feature = "numeric"))]
@@ -157,7 +170,7 @@ mod bigdecimal {
     #[cfg(all(feature = "postgres_backend", feature = "numeric"))]
     impl ToSql<Numeric, Pg> for BigDecimal {
         fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, Pg>) -> serialize::Result {
-            let numeric = PgNumeric::from(self);
+            let numeric = try_convert_decimal_to_pg_numeric(self)?;
             ToSql::<Numeric, Pg>::to_sql(&numeric, &mut out.reborrow())
         }
     }
@@ -178,6 +191,8 @@ mod bigdecimal {
 
     #[cfg(test)]
     mod tests {
+        use crate::query_builder::ByteWrapper;
+
         use super::*;
         use std::str::FromStr;
 
@@ -359,6 +374,18 @@ mod bigdecimal {
             };
             let res: BigDecimal = pg_numeric.try_into().unwrap();
             assert_eq!(res, expected);
+        }
+
+        #[diesel_test_helper::test]
+        fn bigdecimal_with_huge_scale_errors() {
+            let huge_scale = "0.".to_string() + &"0".repeat(70_000) + "1";
+            let decimal = BigDecimal::from_str(&huge_scale).unwrap();
+            let mut v = Vec::new();
+            let output = ByteWrapper(&mut v);
+
+            let mut output = Output::test(output);
+            let r = <BigDecimal as ToSql<Numeric, Pg>>::to_sql(&decimal, &mut output);
+            assert!(r.is_err());
         }
     }
 }

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -1718,7 +1718,7 @@ mod tests {
             .execute(conn);
 
         let db = conn.serialize_database_to_buffer();
-        // only get a valid header, but append grabage
+        // only get a valid header, but append garbage
         let mut bad_buffer = db[..100].to_vec();
         bad_buffer.extend(b"whatever");
         conn.deserialize_readonly_database_from_buffer(&bad_buffer)
@@ -1732,7 +1732,7 @@ mod tests {
             "database disk image is malformed"
         );
 
-        // only get a valid header, but append grabage
+        // only get a valid header, but append garbage
         let mut size_fitting_bad_buffer = db[..100].to_vec();
         size_fitting_bad_buffer.extend(
             core::iter::repeat(b"abcdefghij")

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -185,7 +185,9 @@ pub struct SqliteConnection {
     // This field needs to come after the RawConnection
     // as we need to make sure the data are still there until the
     // connection is dropped
-    serialized_data: Vec<u8>,
+    //
+    // We are not allowed to modify the inner buffer until the database connection is dropped
+    serialized_data: Vec<Vec<u8>>,
 }
 
 // This relies on the invariant that RawConnection or Statement are never
@@ -682,11 +684,23 @@ impl SqliteConnection {
     /// #
     /// # }
     /// ```
+    // TODO: Diesel 3.0 This signature needs to change, we want to expose more options (schema name, readonly)
+    // and also ensure that this is not as unsafe as the current construct anymore. Maybe just accept a owned buffer or static pointer
+    // only instead? (So `Cow<'static, [u8]>`?)
+    #[allow(unsafe_code)]
     pub fn deserialize_readonly_database_from_buffer(&mut self, data: &[u8]) -> QueryResult<()> {
         // we copy the buffer here
         // to make sure the underlying buffer lives as long as the connection
-        self.serialized_data = data.to_vec();
-        self.raw_connection.deserialize(&self.serialized_data)
+        self.serialized_data.push(data.to_vec());
+        let last = self
+            .serialized_data
+            .last()
+            .expect("We literally pushed it above, so it's there");
+        unsafe {
+            // SAFETY: We store the buffer inside of the connection and we never touch it until
+            // we drop the connection
+            self.raw_connection.deserialize(last)
+        }
     }
 
     /// Provides temporary access to the raw SQLite database connection handle.
@@ -1658,25 +1672,80 @@ mod tests {
         let _ = crate::sql_query("INSERT INTO users (name, email) VALUES ('John Doe', 'john.doe@example.com'), ('Jane Doe', 'jane.doe@example.com')")
             .execute(conn1);
 
-        let serialized_database = conn1.serialize_database_to_buffer();
+        for _i in 0..2 {
+            let serialized_database = conn1.serialize_database_to_buffer();
+            let conn2 = &mut connection();
+            conn2
+                .deserialize_readonly_database_from_buffer(serialized_database.as_slice())
+                .unwrap();
 
-        let conn2 = &mut connection();
-        conn2
-            .deserialize_readonly_database_from_buffer(serialized_database.as_slice())
+            let query =
+                sql::<(Integer, Text, Text)>("SELECT id, name, email FROM users ORDER BY id");
+            let actual_users = query.load::<(i32, String, String)>(conn2).unwrap();
+
+            assert_eq!(expected_users, actual_users);
+            // drop the database here
+            // and requery the database to make sure the database owns
+            // required data
+            std::mem::drop(serialized_database);
+            let query =
+                sql::<(Integer, Text, Text)>("SELECT id, name, email FROM users ORDER BY id");
+            let actual_users = query.load::<(i32, String, String)>(conn2).unwrap();
+
+            assert_eq!(expected_users, actual_users);
+        }
+    }
+
+    #[diesel_test_helper::test]
+    fn database_deserialize_random_bytes() {
+        let buffer = vec![0, 1, 2, 3, 4];
+        let conn = &mut SqliteConnection::establish(":memory:").unwrap();
+
+        conn.deserialize_readonly_database_from_buffer(&buffer)
             .unwrap();
 
-        let query = sql::<(Integer, Text, Text)>("SELECT id, name, email FROM users ORDER BY id");
-        let actual_users = query.load::<(i32, String, String)>(conn2).unwrap();
+        let r = sql::<Integer>("SELECT id FROM users").load::<i32>(conn);
 
-        assert_eq!(expected_users, actual_users);
-        // drop the database here
-        // and requery the database to make sure the database owns
-        // required data
-        std::mem::drop(serialized_database);
-        let query = sql::<(Integer, Text, Text)>("SELECT id, name, email FROM users ORDER BY id");
-        let actual_users = query.load::<(i32, String, String)>(conn2).unwrap();
+        assert!(r.is_err());
+        assert_eq!(r.unwrap_err().to_string(), "file is not a database");
 
-        assert_eq!(expected_users, actual_users);
+        let conn = &mut SqliteConnection::establish(":memory:").unwrap();
+
+        let _ =
+            crate::sql_query("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, email TEXT)")
+                .execute(conn);
+        let _ = crate::sql_query("INSERT INTO users (name, email) VALUES ('John Doe', 'john.doe@example.com'), ('Jane Doe', 'jane.doe@example.com')")
+            .execute(conn);
+
+        let db = conn.serialize_database_to_buffer();
+        // only get a valid header, but append grabage
+        let mut bad_buffer = db[..100].to_vec();
+        bad_buffer.extend(b"whatever");
+        conn.deserialize_readonly_database_from_buffer(&bad_buffer)
+            .unwrap();
+
+        let r = sql::<Integer>("SELECT id FROM users").load::<i32>(conn);
+
+        assert!(r.is_err());
+        assert_eq!(
+            r.unwrap_err().to_string(),
+            "database disk image is malformed"
+        );
+
+        // only get a valid header, but append grabage
+        let mut size_fitting_bad_buffer = db[..100].to_vec();
+        size_fitting_bad_buffer.extend(
+            core::iter::repeat(b"abcdefghij")
+                .flatten()
+                .take(db.len() - 100),
+        );
+        let r = conn.deserialize_readonly_database_from_buffer(&size_fitting_bad_buffer);
+
+        assert!(r.is_err());
+        assert_eq!(
+            r.unwrap_err().to_string(),
+            "database disk image is malformed"
+        );
     }
 
     #[diesel_test_helper::test]

--- a/diesel/src/sqlite/connection/raw.rs
+++ b/diesel/src/sqlite/connection/raw.rs
@@ -261,7 +261,11 @@ impl RawConnection {
         }
     }
 
-    pub(super) fn deserialize(&mut self, data: &[u8]) -> QueryResult<()> {
+    // SAFETY:
+    // Any caller must ensure that the provided data buffer is valid and not modified until the database connection is closed
+    // Sqlite's documentation states:
+    // Applications must not modify the buffer P or invalidate it before the database connection D is closed.
+    pub(super) unsafe fn deserialize(&mut self, data: &[u8]) -> QueryResult<()> {
         let db_size = data
             .len()
             .try_into()


### PR DESCRIPTION
This PR contains a number of minor fixes for panics and other potential issues:

* https://github.com/diesel-rs/diesel/commit/c406699d970fe9f694480429ac673c42653c2c15 makes the Mysql field flag parsing code a bit more robust and adds missing flags there
* https://github.com/diesel-rs/diesel/commit/3516e5da59691a918afd7dcf918041adf7c78b12 fixes a potential panic in the bigdecimal serialization code for the PostgreSQL backend
* https://github.com/diesel-rs/diesel/commit/38bc8809fadc25b214c034614749915557ed3ca6 fixes a potential panic in the array deserialization code for the PostgreSQL backend
* https://github.com/diesel-rs/diesel/commit/d9eefeec586924b2b337c7cbdc40d18835012cdd hardens how we handle `SqliteConnection::deserialize_readonly_database` to closely match upstream requirements

-->

- [x] I checked for similar changes and make sure to reference them
- [x] I included a changelog entry for relevant new features or changes
