### PR TITLE
Add `SqliteConnection::on_authorize` wrapping `sqlite3_set_authorizer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 * Diesel-Migrations now contains a migration source that allows you to combine migrations from several different sources
 * Added `SqliteConnection::with_raw_connection` to provide safe, callback-based access to the raw `*mut sqlite3` handle for advanced SQLite C APIs (session extension, hooks, etc.)
 * Added `SqliteConnection::on_commit` and `SqliteConnection::remove_commit_hook` to register a callback invoked when a transaction is about to be committed, wrapping `sqlite3_commit_hook`
+* Added `SqliteConnection::on_authorize` and `SqliteConnection::remove_authorizer` to register an authorizer callback that allows, denies, or ignores SQL actions during statement compilation, wrapping `sqlite3_set_authorizer`, along with the `AuthorizerContext` and `AuthorizerDecision` types
 * Added `json_extract` and `jsonb_extract` SQL function support for the SQLite backend
 * Added `json_insert` and `jsonb_insert` SQL function support for the SQLite backend
 * Added `json_replace`, `jsonb_replace`, `json_set`, and `jsonb_set` SQL function support for the SQLite backend

--- a/diesel/src/connection/statement_cache/mod.rs
+++ b/diesel/src/connection/statement_cache/mod.rs
@@ -183,6 +183,15 @@ where
         }
     }
 
+    /// Removes all cached statements so subsequent queries are re-prepared,
+    /// while keeping the configured caching strategy.
+    // Currently used only by the SQLite authorizer, so it is compiled only for
+    // backends that provide that caller.
+    #[cfg(feature = "__sqlite-shared")]
+    pub(crate) fn clear(&mut self) {
+        self.cache.clear();
+    }
+
     /// Setting custom caching strategy. It is used in tests, to verify caching logic
     #[allow(dead_code)]
     pub(crate) fn set_strategy<Strategy>(&mut self, s: Strategy)

--- a/diesel/src/connection/statement_cache/strategy.rs
+++ b/diesel/src/connection/statement_cache/strategy.rs
@@ -42,6 +42,13 @@ where
         &mut self,
         key: StatementCacheKey<DB>,
     ) -> LookupStatementResult<'_, DB, Statement>;
+
+    /// Removes all cached statements so that subsequent queries are re-prepared.
+    // Only reached through `StatementCache::clear`, which is currently used only
+    // by the SQLite authorizer, so it is dead code for backends compiled without
+    // that caller.
+    #[allow(dead_code)]
+    fn clear(&mut self);
 }
 
 /// Cache all (safe) statements for as long as connection is alive.
@@ -82,6 +89,10 @@ where
     fn cache_size(&self) -> CacheSize {
         CacheSize::Unbounded
     }
+
+    fn clear(&mut self) {
+        self.cache.clear();
+    }
 }
 
 /// No statements will be cached,
@@ -107,6 +118,8 @@ where
     fn cache_size(&self) -> CacheSize {
         CacheSize::Disabled
     }
+
+    fn clear(&mut self) {}
 }
 
 #[allow(dead_code)]

--- a/diesel/src/connection/statement_cache/strategy.rs
+++ b/diesel/src/connection/statement_cache/strategy.rs
@@ -47,7 +47,7 @@ where
     // Only reached through `StatementCache::clear`, which is currently used only
     // by the SQLite authorizer, so it is dead code for backends compiled without
     // that caller.
-    #[allow(dead_code)]
+    #[cfg(feature = "__sqlite-shared")]
     fn clear(&mut self);
 }
 
@@ -90,6 +90,7 @@ where
         CacheSize::Unbounded
     }
 
+    #[cfg(feature = "__sqlite-shared")]
     fn clear(&mut self) {
         self.cache.clear();
     }
@@ -119,6 +120,7 @@ where
         CacheSize::Disabled
     }
 
+    #[cfg(feature = "__sqlite-shared")]
     fn clear(&mut self) {}
 }
 

--- a/diesel/src/sqlite/connection/authorizer.rs
+++ b/diesel/src/sqlite/connection/authorizer.rs
@@ -1,0 +1,794 @@
+//! Types for the SQLite authorizer callback.
+//!
+//! See [`sqlite3_set_authorizer`](https://sqlite.org/c3ref/set_authorizer.html)
+//! and the [action code constants](https://sqlite.org/c3ref/c_alter_table.html).
+//!
+//! The authorizer callback receives an [`AuthorizerContext`]. It is an enum
+//! with one variant per SQLite action code, and every variant carries the
+//! arguments for that action under descriptive field names, so there is no
+//! need to consult a table of what each positional argument means.
+//!
+//! Two fields recur across variants. `database` is the name of the database
+//! (`"main"`, `"temp"`, or an `ATTACH` alias) an object lives in, when SQLite
+//! reports it. `accessor` is the name of the inner-most trigger or view
+//! responsible for the access, or `None` when the access is directly from
+//! top-level SQL. A string argument is `None` when SQLite passes `NULL` or a
+//! value that is not valid UTF-8.
+
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+extern crate libsqlite3_sys as ffi;
+
+#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+use sqlite_wasm_rs as ffi;
+
+/// Authorizing a `CREATE INDEX` statement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct CreateIndex<'a> {
+    /// Name of the index being created.
+    pub index: Option<&'a str>,
+    /// Name of the table the index is created on.
+    pub table: Option<&'a str>,
+    /// Database the object lives in (`"main"`, `"temp"`, or an `ATTACH` alias).
+    pub database: Option<&'a str>,
+    /// Inner-most trigger or view responsible for the access, if any.
+    pub accessor: Option<&'a str>,
+}
+
+/// Authorizing a `CREATE TABLE` statement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct CreateTable<'a> {
+    /// Name of the table being created.
+    pub table: Option<&'a str>,
+    /// Database the object lives in (`"main"`, `"temp"`, or an `ATTACH` alias).
+    pub database: Option<&'a str>,
+    /// Inner-most trigger or view responsible for the access, if any.
+    pub accessor: Option<&'a str>,
+}
+
+/// Authorizing a `CREATE TEMP INDEX` statement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct CreateTempIndex<'a> {
+    /// Name of the index being created.
+    pub index: Option<&'a str>,
+    /// Name of the table the index is created on.
+    pub table: Option<&'a str>,
+    /// Database the object lives in (`"main"`, `"temp"`, or an `ATTACH` alias).
+    pub database: Option<&'a str>,
+    /// Inner-most trigger or view responsible for the access, if any.
+    pub accessor: Option<&'a str>,
+}
+
+/// Authorizing a `CREATE TEMP TABLE` statement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct CreateTempTable<'a> {
+    /// Name of the table being created.
+    pub table: Option<&'a str>,
+    /// Database the object lives in (`"main"`, `"temp"`, or an `ATTACH` alias).
+    pub database: Option<&'a str>,
+    /// Inner-most trigger or view responsible for the access, if any.
+    pub accessor: Option<&'a str>,
+}
+
+/// Authorizing a `CREATE TEMP TRIGGER` statement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct CreateTempTrigger<'a> {
+    /// Name of the trigger being created.
+    pub trigger: Option<&'a str>,
+    /// Name of the table the trigger is attached to.
+    pub table: Option<&'a str>,
+    /// Database the object lives in (`"main"`, `"temp"`, or an `ATTACH` alias).
+    pub database: Option<&'a str>,
+    /// Inner-most trigger or view responsible for the access, if any.
+    pub accessor: Option<&'a str>,
+}
+
+/// Authorizing a `CREATE TEMP VIEW` statement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct CreateTempView<'a> {
+    /// Name of the view being created.
+    pub view: Option<&'a str>,
+    /// Database the object lives in (`"main"`, `"temp"`, or an `ATTACH` alias).
+    pub database: Option<&'a str>,
+    /// Inner-most trigger or view responsible for the access, if any.
+    pub accessor: Option<&'a str>,
+}
+
+/// Authorizing a `CREATE TRIGGER` statement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct CreateTrigger<'a> {
+    /// Name of the trigger being created.
+    pub trigger: Option<&'a str>,
+    /// Name of the table the trigger is attached to.
+    pub table: Option<&'a str>,
+    /// Database the object lives in (`"main"`, `"temp"`, or an `ATTACH` alias).
+    pub database: Option<&'a str>,
+    /// Inner-most trigger or view responsible for the access, if any.
+    pub accessor: Option<&'a str>,
+}
+
+/// Authorizing a `CREATE VIEW` statement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct CreateView<'a> {
+    /// Name of the view being created.
+    pub view: Option<&'a str>,
+    /// Database the object lives in (`"main"`, `"temp"`, or an `ATTACH` alias).
+    pub database: Option<&'a str>,
+    /// Inner-most trigger or view responsible for the access, if any.
+    pub accessor: Option<&'a str>,
+}
+
+/// Authorizing a `DELETE` statement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct Delete<'a> {
+    /// Name of the table rows are deleted from.
+    pub table: Option<&'a str>,
+    /// Database the object lives in (`"main"`, `"temp"`, or an `ATTACH` alias).
+    pub database: Option<&'a str>,
+    /// Inner-most trigger or view responsible for the access, if any.
+    pub accessor: Option<&'a str>,
+}
+
+/// Authorizing a `DROP INDEX` statement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct DropIndex<'a> {
+    /// Name of the index being dropped.
+    pub index: Option<&'a str>,
+    /// Name of the table the index belongs to.
+    pub table: Option<&'a str>,
+    /// Database the object lives in (`"main"`, `"temp"`, or an `ATTACH` alias).
+    pub database: Option<&'a str>,
+    /// Inner-most trigger or view responsible for the access, if any.
+    pub accessor: Option<&'a str>,
+}
+
+/// Authorizing a `DROP TABLE` statement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct DropTable<'a> {
+    /// Name of the table being dropped.
+    pub table: Option<&'a str>,
+    /// Database the object lives in (`"main"`, `"temp"`, or an `ATTACH` alias).
+    pub database: Option<&'a str>,
+    /// Inner-most trigger or view responsible for the access, if any.
+    pub accessor: Option<&'a str>,
+}
+
+/// Authorizing a `DROP TEMP INDEX` statement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct DropTempIndex<'a> {
+    /// Name of the index being dropped.
+    pub index: Option<&'a str>,
+    /// Name of the table the index belongs to.
+    pub table: Option<&'a str>,
+    /// Database the object lives in (`"main"`, `"temp"`, or an `ATTACH` alias).
+    pub database: Option<&'a str>,
+    /// Inner-most trigger or view responsible for the access, if any.
+    pub accessor: Option<&'a str>,
+}
+
+/// Authorizing a `DROP TEMP TABLE` statement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct DropTempTable<'a> {
+    /// Name of the table being dropped.
+    pub table: Option<&'a str>,
+    /// Database the object lives in (`"main"`, `"temp"`, or an `ATTACH` alias).
+    pub database: Option<&'a str>,
+    /// Inner-most trigger or view responsible for the access, if any.
+    pub accessor: Option<&'a str>,
+}
+
+/// Authorizing a `DROP TEMP TRIGGER` statement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct DropTempTrigger<'a> {
+    /// Name of the trigger being dropped.
+    pub trigger: Option<&'a str>,
+    /// Name of the table the trigger is attached to.
+    pub table: Option<&'a str>,
+    /// Database the object lives in (`"main"`, `"temp"`, or an `ATTACH` alias).
+    pub database: Option<&'a str>,
+    /// Inner-most trigger or view responsible for the access, if any.
+    pub accessor: Option<&'a str>,
+}
+
+/// Authorizing a `DROP TEMP VIEW` statement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct DropTempView<'a> {
+    /// Name of the view being dropped.
+    pub view: Option<&'a str>,
+    /// Database the object lives in (`"main"`, `"temp"`, or an `ATTACH` alias).
+    pub database: Option<&'a str>,
+    /// Inner-most trigger or view responsible for the access, if any.
+    pub accessor: Option<&'a str>,
+}
+
+/// Authorizing a `DROP TRIGGER` statement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct DropTrigger<'a> {
+    /// Name of the trigger being dropped.
+    pub trigger: Option<&'a str>,
+    /// Name of the table the trigger is attached to.
+    pub table: Option<&'a str>,
+    /// Database the object lives in (`"main"`, `"temp"`, or an `ATTACH` alias).
+    pub database: Option<&'a str>,
+    /// Inner-most trigger or view responsible for the access, if any.
+    pub accessor: Option<&'a str>,
+}
+
+/// Authorizing a `DROP VIEW` statement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct DropView<'a> {
+    /// Name of the view being dropped.
+    pub view: Option<&'a str>,
+    /// Database the object lives in (`"main"`, `"temp"`, or an `ATTACH` alias).
+    pub database: Option<&'a str>,
+    /// Inner-most trigger or view responsible for the access, if any.
+    pub accessor: Option<&'a str>,
+}
+
+/// Authorizing an `INSERT` statement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct Insert<'a> {
+    /// Name of the table rows are inserted into.
+    pub table: Option<&'a str>,
+    /// Database the object lives in (`"main"`, `"temp"`, or an `ATTACH` alias).
+    pub database: Option<&'a str>,
+    /// Inner-most trigger or view responsible for the access, if any.
+    pub accessor: Option<&'a str>,
+}
+
+/// Authorizing a `PRAGMA` statement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct Pragma<'a> {
+    /// Name of the pragma.
+    pub name: Option<&'a str>,
+    /// Argument to the pragma, or `None` when it is queried without one.
+    pub argument: Option<&'a str>,
+    /// Database the object lives in (`"main"`, `"temp"`, or an `ATTACH` alias).
+    pub database: Option<&'a str>,
+    /// Inner-most trigger or view responsible for the access, if any.
+    pub accessor: Option<&'a str>,
+}
+
+/// Authorizing a column read.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct Read<'a> {
+    /// Name of the table being read.
+    pub table: Option<&'a str>,
+    /// Name of the column being read.
+    pub column: Option<&'a str>,
+    /// Database the object lives in (`"main"`, `"temp"`, or an `ATTACH` alias).
+    pub database: Option<&'a str>,
+    /// Inner-most trigger or view responsible for the access, if any.
+    pub accessor: Option<&'a str>,
+}
+
+/// Authorizing a `SELECT` statement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct Select<'a> {
+    /// Inner-most trigger or view responsible for the access, if any.
+    pub accessor: Option<&'a str>,
+}
+
+/// Authorizing a transaction control operation (`BEGIN`, `COMMIT`, `ROLLBACK`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct Transaction<'a> {
+    /// The operation, for example `"BEGIN"`, `"COMMIT"`, or `"ROLLBACK"`.
+    pub operation: Option<&'a str>,
+    /// Inner-most trigger or view responsible for the access, if any.
+    pub accessor: Option<&'a str>,
+}
+
+/// Authorizing an `UPDATE` statement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct Update<'a> {
+    /// Name of the table being updated.
+    pub table: Option<&'a str>,
+    /// Name of the column being updated.
+    pub column: Option<&'a str>,
+    /// Database the object lives in (`"main"`, `"temp"`, or an `ATTACH` alias).
+    pub database: Option<&'a str>,
+    /// Inner-most trigger or view responsible for the access, if any.
+    pub accessor: Option<&'a str>,
+}
+
+/// Authorizing an `ATTACH DATABASE` statement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct Attach<'a> {
+    /// Filename of the database being attached.
+    pub filename: Option<&'a str>,
+    /// Inner-most trigger or view responsible for the access, if any.
+    pub accessor: Option<&'a str>,
+}
+
+/// Authorizing a `DETACH DATABASE` statement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct Detach<'a> {
+    /// Name of the database being detached.
+    pub database: Option<&'a str>,
+    /// Inner-most trigger or view responsible for the access, if any.
+    pub accessor: Option<&'a str>,
+}
+
+/// Authorizing an `ALTER TABLE` statement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct AlterTable<'a> {
+    /// Database the table lives in (`"main"`, `"temp"`, or an `ATTACH` alias).
+    pub database: Option<&'a str>,
+    /// Name of the table being altered.
+    pub table: Option<&'a str>,
+    /// Inner-most trigger or view responsible for the access, if any.
+    pub accessor: Option<&'a str>,
+}
+
+/// Authorizing a `REINDEX` statement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct Reindex<'a> {
+    /// Name of the index being rebuilt.
+    pub index: Option<&'a str>,
+    /// Database the object lives in (`"main"`, `"temp"`, or an `ATTACH` alias).
+    pub database: Option<&'a str>,
+    /// Inner-most trigger or view responsible for the access, if any.
+    pub accessor: Option<&'a str>,
+}
+
+/// Authorizing an `ANALYZE` statement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct Analyze<'a> {
+    /// Name of the table being analyzed.
+    pub table: Option<&'a str>,
+    /// Database the object lives in (`"main"`, `"temp"`, or an `ATTACH` alias).
+    pub database: Option<&'a str>,
+    /// Inner-most trigger or view responsible for the access, if any.
+    pub accessor: Option<&'a str>,
+}
+
+/// Authorizing a `CREATE VIRTUAL TABLE` statement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct CreateVTable<'a> {
+    /// Name of the virtual table being created.
+    pub table: Option<&'a str>,
+    /// Name of the module implementing the virtual table.
+    pub module: Option<&'a str>,
+    /// Database the object lives in (`"main"`, `"temp"`, or an `ATTACH` alias).
+    pub database: Option<&'a str>,
+    /// Inner-most trigger or view responsible for the access, if any.
+    pub accessor: Option<&'a str>,
+}
+
+/// Authorizing a `DROP VIRTUAL TABLE` statement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct DropVTable<'a> {
+    /// Name of the virtual table being dropped.
+    pub table: Option<&'a str>,
+    /// Name of the module implementing the virtual table.
+    pub module: Option<&'a str>,
+    /// Database the object lives in (`"main"`, `"temp"`, or an `ATTACH` alias).
+    pub database: Option<&'a str>,
+    /// Inner-most trigger or view responsible for the access, if any.
+    pub accessor: Option<&'a str>,
+}
+
+/// Authorizing a SQL function call.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct Function<'a> {
+    /// Name of the function being called.
+    pub function: Option<&'a str>,
+    /// Inner-most trigger or view responsible for the access, if any.
+    pub accessor: Option<&'a str>,
+}
+
+/// Authorizing a `SAVEPOINT` operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct Savepoint<'a> {
+    /// The operation, for example `"BEGIN"`, `"RELEASE"`, or `"ROLLBACK"`.
+    pub operation: Option<&'a str>,
+    /// Name of the savepoint.
+    pub name: Option<&'a str>,
+    /// Inner-most trigger or view responsible for the access, if any.
+    pub accessor: Option<&'a str>,
+}
+
+/// Authorizing a recursive `SELECT`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct Recursive<'a> {
+    /// Inner-most trigger or view responsible for the access, if any.
+    pub accessor: Option<&'a str>,
+}
+
+/// An action code SQLite reported that this version of diesel does not model.
+///
+/// The raw arguments are exposed unchanged for forward compatibility.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct Unknown<'a> {
+    /// The raw SQLite action code.
+    pub code: i32,
+    /// The third argument to the authorizer callback, if any.
+    pub arg1: Option<&'a str>,
+    /// The fourth argument to the authorizer callback, if any.
+    pub arg2: Option<&'a str>,
+    /// Database the object lives in (`"main"`, `"temp"`, or an `ATTACH` alias).
+    pub database: Option<&'a str>,
+    /// Inner-most trigger or view responsible for the access, if any.
+    pub accessor: Option<&'a str>,
+}
+
+/// Context information passed to the authorizer callback.
+///
+/// One variant per SQLite action code. Each variant carries the arguments for
+/// that action under descriptive field names, so there is no need to consult a
+/// table of what each positional argument means. The callback is invoked
+/// during SQL statement compilation (not during execution).
+///
+/// Added in SQLite 3.0.0 (June 2004).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum AuthorizerContext<'a> {
+    /// `CREATE INDEX`
+    CreateIndex(CreateIndex<'a>),
+    /// `CREATE TABLE`
+    CreateTable(CreateTable<'a>),
+    /// `CREATE TEMP INDEX`
+    CreateTempIndex(CreateTempIndex<'a>),
+    /// `CREATE TEMP TABLE`
+    CreateTempTable(CreateTempTable<'a>),
+    /// `CREATE TEMP TRIGGER`
+    CreateTempTrigger(CreateTempTrigger<'a>),
+    /// `CREATE TEMP VIEW`
+    CreateTempView(CreateTempView<'a>),
+    /// `CREATE TRIGGER`
+    CreateTrigger(CreateTrigger<'a>),
+    /// `CREATE VIEW`
+    CreateView(CreateView<'a>),
+    /// `DELETE`
+    Delete(Delete<'a>),
+    /// `DROP INDEX`
+    DropIndex(DropIndex<'a>),
+    /// `DROP TABLE`
+    DropTable(DropTable<'a>),
+    /// `DROP TEMP INDEX`
+    DropTempIndex(DropTempIndex<'a>),
+    /// `DROP TEMP TABLE`
+    DropTempTable(DropTempTable<'a>),
+    /// `DROP TEMP TRIGGER`
+    DropTempTrigger(DropTempTrigger<'a>),
+    /// `DROP TEMP VIEW`
+    DropTempView(DropTempView<'a>),
+    /// `DROP TRIGGER`
+    DropTrigger(DropTrigger<'a>),
+    /// `DROP VIEW`
+    DropView(DropView<'a>),
+    /// `INSERT`
+    Insert(Insert<'a>),
+    /// `PRAGMA`
+    Pragma(Pragma<'a>),
+    /// Reading a column value.
+    Read(Read<'a>),
+    /// `SELECT`
+    Select(Select<'a>),
+    /// Transaction control (`BEGIN`, `COMMIT`, `ROLLBACK`).
+    Transaction(Transaction<'a>),
+    /// `UPDATE`
+    Update(Update<'a>),
+    /// `ATTACH DATABASE`
+    Attach(Attach<'a>),
+    /// `DETACH DATABASE`
+    Detach(Detach<'a>),
+    /// `ALTER TABLE`
+    AlterTable(AlterTable<'a>),
+    /// `REINDEX`
+    Reindex(Reindex<'a>),
+    /// `ANALYZE`
+    Analyze(Analyze<'a>),
+    /// `CREATE VIRTUAL TABLE`
+    CreateVTable(CreateVTable<'a>),
+    /// `DROP VIRTUAL TABLE`
+    DropVTable(DropVTable<'a>),
+    /// A SQL function call.
+    Function(Function<'a>),
+    /// `SAVEPOINT`
+    Savepoint(Savepoint<'a>),
+    /// A recursive `SELECT`.
+    Recursive(Recursive<'a>),
+    /// An action code this version of diesel does not model.
+    Unknown(Unknown<'a>),
+}
+
+impl<'a> AuthorizerContext<'a> {
+    /// Returns `true` if this action modifies the database schema.
+    ///
+    /// Schema-modifying actions include creating, dropping, or altering
+    /// tables, indexes, triggers, views, and virtual tables.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use diesel::prelude::*;
+    /// use diesel::sqlite::{SqliteConnection, AuthorizerContext, AuthorizerDecision};
+    ///
+    /// # let conn = &mut SqliteConnection::establish(":memory:").unwrap();
+    /// conn.on_authorize(|ctx| {
+    ///     if ctx.is_schema_modifying() {
+    ///         AuthorizerDecision::Deny
+    ///     } else {
+    ///         AuthorizerDecision::Allow
+    ///     }
+    /// });
+    /// ```
+    pub fn is_schema_modifying(&self) -> bool {
+        matches!(
+            self,
+            Self::CreateIndex(_)
+                | Self::CreateTable(_)
+                | Self::CreateTempIndex(_)
+                | Self::CreateTempTable(_)
+                | Self::CreateTempTrigger(_)
+                | Self::CreateTempView(_)
+                | Self::CreateTrigger(_)
+                | Self::CreateView(_)
+                | Self::CreateVTable(_)
+                | Self::DropIndex(_)
+                | Self::DropTable(_)
+                | Self::DropTempIndex(_)
+                | Self::DropTempTable(_)
+                | Self::DropTempTrigger(_)
+                | Self::DropTempView(_)
+                | Self::DropTrigger(_)
+                | Self::DropView(_)
+                | Self::DropVTable(_)
+                | Self::AlterTable(_)
+        )
+    }
+
+    /// Builds the context from the raw authorizer callback arguments.
+    ///
+    /// `database` is the 5th callback argument (the database name) and
+    /// `accessor` is the 6th (the trigger or view responsible). The `arg1` and
+    /// `arg2` values are the 3rd and 4th arguments, whose meaning depends on
+    /// the action code per the SQLite documentation.
+    pub(crate) fn from_ffi(
+        code: i32,
+        arg1: Option<&'a str>,
+        arg2: Option<&'a str>,
+        database: Option<&'a str>,
+        accessor: Option<&'a str>,
+    ) -> Self {
+        match code {
+            ffi::SQLITE_CREATE_INDEX => Self::CreateIndex(CreateIndex {
+                index: arg1,
+                table: arg2,
+                database,
+                accessor,
+            }),
+            ffi::SQLITE_CREATE_TABLE => Self::CreateTable(CreateTable {
+                table: arg1,
+                database,
+                accessor,
+            }),
+            ffi::SQLITE_CREATE_TEMP_INDEX => Self::CreateTempIndex(CreateTempIndex {
+                index: arg1,
+                table: arg2,
+                database,
+                accessor,
+            }),
+            ffi::SQLITE_CREATE_TEMP_TABLE => Self::CreateTempTable(CreateTempTable {
+                table: arg1,
+                database,
+                accessor,
+            }),
+            ffi::SQLITE_CREATE_TEMP_TRIGGER => Self::CreateTempTrigger(CreateTempTrigger {
+                trigger: arg1,
+                table: arg2,
+                database,
+                accessor,
+            }),
+            ffi::SQLITE_CREATE_TEMP_VIEW => Self::CreateTempView(CreateTempView {
+                view: arg1,
+                database,
+                accessor,
+            }),
+            ffi::SQLITE_CREATE_TRIGGER => Self::CreateTrigger(CreateTrigger {
+                trigger: arg1,
+                table: arg2,
+                database,
+                accessor,
+            }),
+            ffi::SQLITE_CREATE_VIEW => Self::CreateView(CreateView {
+                view: arg1,
+                database,
+                accessor,
+            }),
+            ffi::SQLITE_DELETE => Self::Delete(Delete {
+                table: arg1,
+                database,
+                accessor,
+            }),
+            ffi::SQLITE_DROP_INDEX => Self::DropIndex(DropIndex {
+                index: arg1,
+                table: arg2,
+                database,
+                accessor,
+            }),
+            ffi::SQLITE_DROP_TABLE => Self::DropTable(DropTable {
+                table: arg1,
+                database,
+                accessor,
+            }),
+            ffi::SQLITE_DROP_TEMP_INDEX => Self::DropTempIndex(DropTempIndex {
+                index: arg1,
+                table: arg2,
+                database,
+                accessor,
+            }),
+            ffi::SQLITE_DROP_TEMP_TABLE => Self::DropTempTable(DropTempTable {
+                table: arg1,
+                database,
+                accessor,
+            }),
+            ffi::SQLITE_DROP_TEMP_TRIGGER => Self::DropTempTrigger(DropTempTrigger {
+                trigger: arg1,
+                table: arg2,
+                database,
+                accessor,
+            }),
+            ffi::SQLITE_DROP_TEMP_VIEW => Self::DropTempView(DropTempView {
+                view: arg1,
+                database,
+                accessor,
+            }),
+            ffi::SQLITE_DROP_TRIGGER => Self::DropTrigger(DropTrigger {
+                trigger: arg1,
+                table: arg2,
+                database,
+                accessor,
+            }),
+            ffi::SQLITE_DROP_VIEW => Self::DropView(DropView {
+                view: arg1,
+                database,
+                accessor,
+            }),
+            ffi::SQLITE_INSERT => Self::Insert(Insert {
+                table: arg1,
+                database,
+                accessor,
+            }),
+            ffi::SQLITE_PRAGMA => Self::Pragma(Pragma {
+                name: arg1,
+                argument: arg2,
+                database,
+                accessor,
+            }),
+            ffi::SQLITE_READ => Self::Read(Read {
+                table: arg1,
+                column: arg2,
+                database,
+                accessor,
+            }),
+            ffi::SQLITE_SELECT => Self::Select(Select { accessor }),
+            ffi::SQLITE_TRANSACTION => Self::Transaction(Transaction {
+                operation: arg1,
+                accessor,
+            }),
+            ffi::SQLITE_UPDATE => Self::Update(Update {
+                table: arg1,
+                column: arg2,
+                database,
+                accessor,
+            }),
+            ffi::SQLITE_ATTACH => Self::Attach(Attach {
+                filename: arg1,
+                accessor,
+            }),
+            ffi::SQLITE_DETACH => Self::Detach(Detach {
+                database: arg1,
+                accessor,
+            }),
+            ffi::SQLITE_ALTER_TABLE => Self::AlterTable(AlterTable {
+                database: arg1,
+                table: arg2,
+                accessor,
+            }),
+            ffi::SQLITE_REINDEX => Self::Reindex(Reindex {
+                index: arg1,
+                database,
+                accessor,
+            }),
+            ffi::SQLITE_ANALYZE => Self::Analyze(Analyze {
+                table: arg1,
+                database,
+                accessor,
+            }),
+            ffi::SQLITE_CREATE_VTABLE => Self::CreateVTable(CreateVTable {
+                table: arg1,
+                module: arg2,
+                database,
+                accessor,
+            }),
+            ffi::SQLITE_DROP_VTABLE => Self::DropVTable(DropVTable {
+                table: arg1,
+                module: arg2,
+                database,
+                accessor,
+            }),
+            ffi::SQLITE_FUNCTION => Self::Function(Function {
+                function: arg2,
+                accessor,
+            }),
+            ffi::SQLITE_SAVEPOINT => Self::Savepoint(Savepoint {
+                operation: arg1,
+                name: arg2,
+                accessor,
+            }),
+            ffi::SQLITE_RECURSIVE => Self::Recursive(Recursive { accessor }),
+            other => Self::Unknown(Unknown {
+                code: other,
+                arg1,
+                arg2,
+                database,
+                accessor,
+            }),
+        }
+    }
+}
+
+/// Authorizer callback decision.
+///
+/// Returned by the authorizer callback to indicate whether to allow,
+/// ignore, or deny the requested operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthorizerDecision {
+    /// Allow the operation to proceed (`SQLITE_OK`).
+    Allow,
+    /// Ignore the operation (`SQLITE_IGNORE`).
+    ///
+    /// For `Read` actions, returns `NULL` instead of the column value.
+    /// For other actions, treats the operation as a no-op.
+    Ignore,
+    /// Deny the operation (`SQLITE_DENY`).
+    ///
+    /// Causes the entire SQL statement to fail with an authorization error.
+    Deny,
+}
+
+impl AuthorizerDecision {
+    /// Converts the decision to the FFI return code.
+    pub(crate) fn to_ffi(self) -> i32 {
+        match self {
+            Self::Allow => ffi::SQLITE_OK,
+            Self::Ignore => ffi::SQLITE_IGNORE,
+            Self::Deny => ffi::SQLITE_DENY,
+        }
+    }
+}

--- a/diesel/src/sqlite/connection/hooks.rs
+++ b/diesel/src/sqlite/connection/hooks.rs
@@ -1,6 +1,7 @@
 use super::SqliteConnection;
 use core::num::NonZeroU32;
 
+pub(super) use super::authorizer::{AuthorizerContext, AuthorizerDecision};
 pub(super) use super::{BusyDecision, CommitDecision, ProgressDecision};
 
 impl SqliteConnection {
@@ -318,6 +319,77 @@ impl SqliteConnection {
     /// ```
     pub fn set_busy_timeout(&mut self, ms: i32) {
         self.raw_connection.set_busy_timeout(ms);
+    }
+
+    /// Registers an authorizer callback for SQL compilation access control.
+    /// Added in SQLite 3.0.0 (June 2004).
+    ///
+    /// The callback is invoked during `sqlite3_prepare()` (statement
+    /// compilation) to control access to database objects. It receives
+    /// an [`AuthorizerContext`] describing the operation and returns an
+    /// [`AuthorizerDecision`].
+    ///
+    /// The authorizer is consulted only at statement preparation, so treat it
+    /// as defense-in-depth rather than a complete sandbox. SQLite re-checks
+    /// already-prepared statements when an authorizer is installed. Removing the
+    /// authorizer clears diesel's statement cache so statements prepared while
+    /// it was active are re-prepared without it.
+    ///
+    /// The authorizer may be re-invoked during `sqlite3_step()` if a schema
+    /// change triggers statement recompilation.
+    ///
+    /// The callback must not modify the database connection. It is invoked
+    /// synchronously on the thread driving the connection, so it is never
+    /// called concurrently.
+    ///
+    /// Only one authorizer can be active at a time per connection.
+    /// Registering a new one replaces the previous. Panics in the callback
+    /// abort the process.
+    ///
+    /// See: [`sqlite3_set_authorizer`](https://sqlite.org/c3ref/set_authorizer.html)
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use diesel::prelude::*;
+    /// use diesel::sqlite::{SqliteConnection, AuthorizerContext, AuthorizerDecision};
+    ///
+    /// # let conn = &mut SqliteConnection::establish(":memory:").unwrap();
+    /// conn.on_authorize(|ctx| match ctx {
+    ///     AuthorizerContext::Delete(_) => AuthorizerDecision::Deny,
+    ///     AuthorizerContext::DropTable(_) | AuthorizerContext::DropIndex(_) => {
+    ///         AuthorizerDecision::Deny
+    ///     }
+    ///     _ => AuthorizerDecision::Allow,
+    /// });
+    ///
+    /// // Later: remove the authorizer
+    /// conn.remove_authorizer();
+    /// ```
+    pub fn on_authorize<F>(&mut self, hook: F)
+    where
+        F: FnMut(AuthorizerContext<'_>) -> AuthorizerDecision + Send + 'static,
+    {
+        // No cache clear is needed here. Installing a non-null authorizer makes
+        // SQLite expire every prepared statement on the connection, and because
+        // diesel prepares with `sqlite3_prepare_v3` those statements are
+        // transparently re-prepared under the new authorizer on their next step.
+        self.raw_connection.set_authorizer(hook);
+    }
+
+    /// Removes the authorizer callback.
+    ///
+    /// See [`on_authorize`](Self::on_authorize) for usage example.
+    pub fn remove_authorizer(&mut self) {
+        self.raw_connection.remove_authorizer();
+        // Removing an authorizer does not expire prepared statements: SQLite
+        // expires them only when a non-null authorizer is installed. A statement
+        // prepared while the authorizer was active can have its decisions
+        // compiled in (an `Ignore` on a column read, for example, bakes a `NULL`
+        // into the statement), and nothing invalidates that cached statement on
+        // removal, so it keeps returning the old result. Clear the cache to force
+        // the next query to re-prepare without the authorizer.
+        self.statement_cache.clear();
     }
 }
 
@@ -909,6 +981,140 @@ mod tests {
         assert!(
             calls.load(Ordering::Relaxed) >= 1,
             "the busy handler should have been invoked at least once"
+        );
+    }
+
+    #[diesel_test_helper::test]
+    fn on_authorize_deny_rejects_statement() {
+        let conn = &mut connection();
+        crate::sql_query("CREATE TABLE auth_basic (id INTEGER PRIMARY KEY)")
+            .execute(conn)
+            .unwrap();
+
+        let calls = Arc::new(AtomicU32::new(0));
+        let calls2 = calls.clone();
+
+        conn.on_authorize(move |_ctx| {
+            calls2.fetch_add(1, Ordering::Relaxed);
+            AuthorizerDecision::Deny
+        });
+
+        // The authorizer is consulted while the statement is prepared, denies
+        // it, and the statement is rejected.
+        let denied = crate::sql_query("SELECT id FROM auth_basic").execute(conn);
+        assert!(denied.is_err(), "a denied statement should fail to prepare");
+        assert!(
+            calls.load(Ordering::Relaxed) > 0,
+            "the authorizer callback should have been invoked"
+        );
+
+        // Removing the authorizer restores access.
+        conn.remove_authorizer();
+        crate::sql_query("SELECT id FROM auth_basic")
+            .execute(conn)
+            .unwrap();
+    }
+
+    #[diesel_test_helper::test]
+    fn remove_authorizer_re_prepares_cached_statements() {
+        use crate::prelude::*;
+        use crate::sqlite::AuthorizerContext;
+
+        crate::table! {
+            auth_ignore_items (id) {
+                id -> Integer,
+            }
+        }
+
+        let conn = &mut connection();
+        crate::sql_query("CREATE TABLE auth_ignore_items (id INTEGER PRIMARY KEY)")
+            .execute(conn)
+            .unwrap();
+        crate::sql_query("INSERT INTO auth_ignore_items (id) VALUES (42)")
+            .execute(conn)
+            .unwrap();
+
+        // An authorizer that ignores column reads. SQLite bakes a NULL
+        // substitution for the column into the prepared (and cached) statement.
+        // A typed query is used because raw `sql_query` is never cached.
+        conn.on_authorize(|ctx| match ctx {
+            AuthorizerContext::Read(_) => AuthorizerDecision::Ignore,
+            _ => AuthorizerDecision::Allow,
+        });
+        let ignored = auth_ignore_items::table
+            .select(auth_ignore_items::id.nullable())
+            .load::<Option<i32>>(conn)
+            .unwrap();
+        assert_eq!(
+            ignored,
+            vec![None],
+            "Ignore substitutes NULL for the column"
+        );
+
+        // SQLite does not expire prepared statements when an authorizer is
+        // removed, so `remove_authorizer` clears diesel's statement cache to
+        // force the cached statement (with its baked-in NULL) to be re-prepared.
+        conn.remove_authorizer();
+        let restored = auth_ignore_items::table
+            .select(auth_ignore_items::id.nullable())
+            .load::<Option<i32>>(conn)
+            .unwrap();
+        assert_eq!(
+            restored,
+            vec![Some(42)],
+            "after removing the authorizer the real value is returned"
+        );
+    }
+
+    #[diesel_test_helper::test]
+    fn on_authorize_re_prepares_cached_statements() {
+        use crate::prelude::*;
+        use crate::sqlite::AuthorizerContext;
+
+        crate::table! {
+            auth_replace_items (id) {
+                id -> Integer,
+            }
+        }
+
+        let conn = &mut connection();
+        crate::sql_query("CREATE TABLE auth_replace_items (id INTEGER PRIMARY KEY)")
+            .execute(conn)
+            .unwrap();
+        crate::sql_query("INSERT INTO auth_replace_items (id) VALUES (42)")
+            .execute(conn)
+            .unwrap();
+
+        // A first authorizer that allows everything. The typed query is
+        // prepared and cached while it is active, returning the real value.
+        conn.on_authorize(|_ctx| AuthorizerDecision::Allow);
+        let allowed = auth_replace_items::table
+            .select(auth_replace_items::id.nullable())
+            .load::<Option<i32>>(conn)
+            .unwrap();
+        assert_eq!(
+            allowed,
+            vec![Some(42)],
+            "the allow-all authorizer returns the real value"
+        );
+
+        // Installing the replacement authorizer expires the cached statement
+        // (SQLite expires all prepared statements when a non-null authorizer is
+        // set), so `sqlite3_prepare_v3` re-prepares it under the new authorizer
+        // and it now yields NULL. This documents that no diesel-side cache clear
+        // is required on the install path.
+        conn.on_authorize(|ctx| match ctx {
+            AuthorizerContext::Read(_) => AuthorizerDecision::Ignore,
+            _ => AuthorizerDecision::Allow,
+        });
+        let ignored = auth_replace_items::table
+            .select(auth_replace_items::id.nullable())
+            .load::<Option<i32>>(conn)
+            .unwrap();
+        assert_eq!(
+            ignored,
+            vec![None],
+            "after replacing the authorizer the new decision takes effect"
         );
     }
 }

--- a/diesel/src/sqlite/connection/hooks.rs
+++ b/diesel/src/sqlite/connection/hooks.rs
@@ -375,6 +375,10 @@ impl SqliteConnection {
         // diesel prepares with `sqlite3_prepare_v3` those statements are
         // transparently re-prepared under the new authorizer on their next step.
         self.raw_connection.set_authorizer(hook);
+        // The public documentation doesn't explicitly state what happens with existing
+        // prepared statements, so rather be safe and nuke them. We don't
+        // expect that people change the authorizer all the time, so this should be fine
+        self.statement_cache.clear();
     }
 
     /// Removes the authorizer callback.

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -4,6 +4,7 @@ extern crate libsqlite3_sys as ffi;
 #[cfg(all(target_family = "wasm", target_os = "unknown"))]
 use sqlite_wasm_rs as ffi;
 
+pub mod authorizer;
 mod bind_collector;
 mod functions;
 mod hooks;
@@ -17,6 +18,7 @@ mod sqlite_value;
 mod statement_iterator;
 mod stmt;
 
+pub use self::authorizer::{AuthorizerContext, AuthorizerDecision};
 pub(in crate::sqlite) use self::bind_collector::SqliteBindCollector;
 pub use self::bind_collector::SqliteBindValue;
 pub use self::limits::SqliteLimit;

--- a/diesel/src/sqlite/connection/raw.rs
+++ b/diesel/src/sqlite/connection/raw.rs
@@ -6,6 +6,7 @@ extern crate libsqlite3_sys as ffi;
 use sqlite_wasm_rs as ffi;
 
 use super::SqliteConnection;
+use super::authorizer::{AuthorizerContext, AuthorizerDecision};
 use super::functions::{build_sql_function_args, process_sql_function_result};
 use super::limits::SqliteLimit;
 use super::serialized_database::SerializedDatabase;
@@ -64,6 +65,8 @@ pub(super) struct RawConnection {
     wal_hook: Option<Box<dyn Fn(&mut SqliteConnection, &str, u32) + Send>>,
     /// Boxed closure kept alive while the busy handler is registered.
     busy_handler: Option<Box<dyn FnMut(i32) -> BusyDecision + Send>>,
+    /// Boxed closure kept alive while the authorizer is registered.
+    authorizer_hook: Option<Box<dyn FnMut(AuthorizerContext<'_>) -> AuthorizerDecision + Send>>,
 }
 
 impl RawConnection {
@@ -77,6 +80,7 @@ impl RawConnection {
             progress_hook: None,
             wal_hook: None,
             busy_handler: None,
+            authorizer_hook: None,
         }
     }
 
@@ -103,6 +107,7 @@ impl RawConnection {
                     progress_hook: None,
                     wal_hook: None,
                     busy_handler: None,
+                    authorizer_hook: None,
                 })
             }
             err_code => {
@@ -672,6 +677,53 @@ impl RawConnection {
         }
         self.busy_handler = None;
     }
+
+    /// Sets the authorizer callback, replacing any previous one. Only one
+    /// can be active at a time per connection.
+    ///
+    /// # Safety
+    ///
+    /// The `ptr` is derived from `&raw mut *boxed` and points to the heap
+    /// allocation of the closure. The `authorizer_trampoline` function
+    /// matches the signature expected by `sqlite3_set_authorizer`. The pointer
+    /// remains valid because we store `boxed` in `self.authorizer_hook` below,
+    /// keeping it alive for the lifetime of this `RawConnection`.
+    pub(super) fn set_authorizer<F>(&mut self, hook: F)
+    where
+        F: FnMut(AuthorizerContext<'_>) -> AuthorizerDecision + Send + 'static,
+    {
+        let mut boxed: Box<dyn FnMut(AuthorizerContext<'_>) -> AuthorizerDecision + Send> =
+            Box::new(hook);
+        let ptr = &raw mut *boxed as *mut libc::c_void;
+
+        unsafe {
+            ffi::sqlite3_set_authorizer(
+                self.internal_connection.as_ptr(),
+                Some(authorizer_trampoline::<F>),
+                ptr,
+            );
+        }
+
+        // The old Box (if any) is dropped here after SQLite has already
+        // switched to the new callback, preventing use-after-free.
+        self.authorizer_hook = Some(boxed);
+    }
+
+    /// Removes the authorizer callback.
+    ///
+    /// # Safety
+    ///
+    /// `self.internal_connection` is a valid pointer to an open SQLite
+    /// connection. Passing `None` as the callback and `null_mut()` as the
+    /// user data unregisters any existing authorizer. The authorizer is
+    /// unregistered before dropping `self.authorizer_hook` to prevent
+    /// callbacks from firing during cleanup.
+    pub(super) fn remove_authorizer(&mut self) {
+        unsafe {
+            ffi::sqlite3_set_authorizer(self.internal_connection.as_ptr(), None, ptr::null_mut());
+        }
+        self.authorizer_hook = None;
+    }
 }
 
 impl Drop for RawConnection {
@@ -684,6 +736,7 @@ impl Drop for RawConnection {
         self.remove_progress_handler();
         self.remove_wal_hook();
         self.remove_busy_handler();
+        self.remove_authorizer();
 
         let close_result = unsafe { ffi::sqlite3_close(self.internal_connection.as_ptr()) };
         if close_result != ffi::SQLITE_OK {
@@ -1196,6 +1249,59 @@ where
         Ok(BusyDecision::GiveUp) => 0,
         Err(_) => {
             assert_fail!("Panic in sqlite3_busy_handler trampoline. ");
+        }
+    }
+}
+
+/// C trampoline for `sqlite3_set_authorizer`.
+///
+/// # Safety
+///
+/// `user_data` must point to a live `F` stored in `RawConnection::authorizer_hook`.
+unsafe extern "C" fn authorizer_trampoline<F>(
+    user_data: *mut libc::c_void,
+    action_code: libc::c_int,
+    arg1: *const libc::c_char,
+    arg2: *const libc::c_char,
+    db_name: *const libc::c_char,
+    accessor: *const libc::c_char,
+) -> libc::c_int
+where
+    F: FnMut(AuthorizerContext<'_>) -> AuthorizerDecision,
+{
+    // Convert a nullable C string argument to `Option<&str>`. A null pointer or
+    // a non-UTF-8 string both map to `None`. The borrow is tied to this call via
+    // the generic lifetime, and the resulting `&str` only lives inside the
+    // `AuthorizerContext` passed to the callback, which cannot escape the call.
+    fn to_str<'a>(ptr: *const libc::c_char) -> Option<&'a str> {
+        if ptr.is_null() {
+            None
+        } else {
+            // SAFETY: per the `sqlite3_set_authorizer` contract a non-null
+            // pointer is a valid C string for the duration of the call.
+            unsafe { CStr::from_ptr(ptr) }.to_str().ok()
+        }
+    }
+
+    let result = crate::util::std_compat::catch_unwind(core::panic::AssertUnwindSafe(|| {
+        // SAFETY: `user_data` points to a live `F` in `RawConnection::authorizer_hook`.
+        let f = unsafe { &mut *(user_data as *mut F) };
+
+        let ctx = AuthorizerContext::from_ffi(
+            action_code,
+            to_str(arg1),
+            to_str(arg2),
+            to_str(db_name),
+            to_str(accessor),
+        );
+
+        f(ctx)
+    }));
+
+    match result {
+        Ok(decision) => decision.to_ffi(),
+        Err(_) => {
+            assert_fail!("Panic in sqlite3_set_authorizer trampoline. ");
         }
     }
 }

--- a/diesel/src/sqlite/mod.rs
+++ b/diesel/src/sqlite/mod.rs
@@ -26,7 +26,9 @@ pub use self::connection::SqliteBindValue;
 pub use self::connection::SqliteConnection;
 pub use self::connection::SqliteLimit;
 pub use self::connection::SqliteValue;
+pub use self::connection::authorizer;
 pub use self::connection::sqlite_blob::SqliteReadOnlyBlob;
+pub use self::connection::{AuthorizerContext, AuthorizerDecision};
 #[cfg(feature = "__sqlite-shared")]
 pub use self::function_behavior::SqliteFunctionBehavior;
 pub use self::query_builder::SqliteQueryBuilder;


### PR DESCRIPTION
This adds `on_authorize` and `remove_authorizer` (and the `AuthorizerAction`, `AuthorizerContext`, and `AuthorizerDecision` types) to register an authorizer that allows, denies, or ignores SQL actions at compile time. It continues the per-API split of #4969.

The callback is `FnMut` and must not use the connection, like the commit and rollback hooks, so it needs no `RefCell`. Action codes map to a `#[non_exhaustive]` enum with an `Unknown(i32)` arm, and the trampoline maps null or non-UTF-8 arguments to `None` instead of aborting.

It also reaches into the shared statement cache: `remove_authorizer` clears diesel's prepared-statement cache so a statement compiled under an `IGNORE` authorizer does not keep its baked-in `NULL` after removal. That is the part I would appreciate a careful review of, since it is the only change outside the SQLite hook code.
