### PR TITLE
Add `SqliteConnection::on_trace` wrapping `sqlite3_trace_v2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 * Added `SqliteConnection::with_raw_connection` to provide safe, callback-based access to the raw `*mut sqlite3` handle for advanced SQLite C APIs (session extension, hooks, etc.)
 * Added `SqliteConnection::on_commit` and `SqliteConnection::remove_commit_hook` to register a callback invoked when a transaction is about to be committed, wrapping `sqlite3_commit_hook`
 * Added `SqliteConnection::on_authorize` and `SqliteConnection::remove_authorizer` to register an authorizer callback that allows, denies, or ignores SQL actions during statement compilation, wrapping `sqlite3_set_authorizer`, along with the `AuthorizerContext` and `AuthorizerDecision` types
+* Added `SqliteConnection::on_trace` and `SqliteConnection::remove_trace` to register a callback for SQL execution tracing (statement, profile, and row events), wrapping `sqlite3_trace_v2`, along with the `SqliteTraceEvent` and `SqliteTraceFlags` types
 * Added `json_extract` and `jsonb_extract` SQL function support for the SQLite backend
 * Added `json_insert` and `jsonb_insert` SQL function support for the SQLite backend
 * Added `json_replace`, `jsonb_replace`, `json_set`, and `jsonb_set` SQL function support for the SQLite backend

--- a/diesel/src/sqlite/connection/hooks.rs
+++ b/diesel/src/sqlite/connection/hooks.rs
@@ -3,6 +3,7 @@ use core::num::NonZeroU32;
 
 pub(super) use super::authorizer::{AuthorizerContext, AuthorizerDecision};
 pub(super) use super::{BusyDecision, CommitDecision, ProgressDecision};
+use super::{SqliteTraceEvent, SqliteTraceFlags};
 
 impl SqliteConnection {
     /// Registers a callback invoked when a transaction is about to be
@@ -394,6 +395,57 @@ impl SqliteConnection {
         // removal, so it keeps returning the old result. Clear the cache to force
         // the next query to re-prepare without the authorizer.
         self.statement_cache.clear();
+    }
+
+    /// Registers a trace callback for SQL execution monitoring.
+    ///
+    /// The callback receives the [`SqliteTraceEvent`]s selected by the
+    /// [`SqliteTraceFlags`] mask. `ROW` fires once per returned row, so prefer
+    /// `STMT`/`PROFILE` for most logging.
+    ///
+    /// Only one trace callback can be active at a time per connection.
+    /// Registering a new one replaces the previous.
+    ///
+    /// The callback must not use the database connection. It is invoked
+    /// synchronously on the thread driving the connection, so it is never
+    /// called concurrently. Panics in the callback abort the process.
+    ///
+    /// See: [`sqlite3_trace_v2`](https://sqlite.org/c3ref/trace_v2.html)
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use diesel::prelude::*;
+    /// use diesel::sqlite::{SqliteConnection, SqliteTraceFlags, SqliteTraceEvent};
+    ///
+    /// # let conn = &mut SqliteConnection::establish(":memory:").unwrap();
+    /// conn.on_trace(SqliteTraceFlags::STMT | SqliteTraceFlags::PROFILE, |event| {
+    ///     match event {
+    ///         SqliteTraceEvent::Statement { sql, readonly, .. } => {
+    ///             println!("Executing ({}): {}", if readonly { "read" } else { "write" }, sql);
+    ///         }
+    ///         SqliteTraceEvent::Profile { sql, duration_ns, .. } => {
+    ///             println!("{} took {} ns", sql, duration_ns);
+    ///         }
+    ///         _ => {}
+    ///     }
+    /// });
+    ///
+    /// // Later: remove the trace callback
+    /// conn.remove_trace();
+    /// ```
+    pub fn on_trace<F>(&mut self, mask: SqliteTraceFlags, hook: F)
+    where
+        F: FnMut(SqliteTraceEvent<'_>) + Send + 'static,
+    {
+        self.raw_connection.set_trace(mask, hook);
+    }
+
+    /// Removes the trace callback.
+    ///
+    /// See [`on_trace`](Self::on_trace) for usage example.
+    pub fn remove_trace(&mut self) {
+        self.raw_connection.remove_trace();
     }
 }
 
@@ -1119,6 +1171,84 @@ mod tests {
             ignored,
             vec![None],
             "after replacing the authorizer the new decision takes effect"
+        );
+    }
+
+    #[diesel_test_helper::test]
+    fn on_trace_reports_statement_and_profile() {
+        use std::sync::Mutex;
+
+        let conn = &mut connection();
+        crate::sql_query("CREATE TABLE t_trace (id INTEGER PRIMARY KEY)")
+            .execute(conn)
+            .unwrap();
+
+        // (sql, readonly) for Statement events, and the SQL of Profile events.
+        let stmts: Arc<Mutex<Vec<(String, bool)>>> = Arc::new(Mutex::new(Vec::new()));
+        let profiled: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let stmts2 = stmts.clone();
+        let profiled2 = profiled.clone();
+
+        conn.on_trace(
+            SqliteTraceFlags::STMT | SqliteTraceFlags::PROFILE,
+            move |event| match event {
+                SqliteTraceEvent::Statement { sql, readonly } => {
+                    stmts2.lock().unwrap().push((sql.to_owned(), readonly));
+                }
+                SqliteTraceEvent::Profile { sql, .. } => {
+                    profiled2.lock().unwrap().push(sql.to_owned());
+                }
+                _ => {}
+            },
+        );
+
+        crate::sql_query("SELECT id FROM t_trace")
+            .execute(conn)
+            .unwrap();
+        crate::sql_query("INSERT INTO t_trace (id) VALUES (1)")
+            .execute(conn)
+            .unwrap();
+
+        let stmts = stmts.lock().unwrap();
+        assert!(
+            stmts
+                .iter()
+                .any(|(sql, ro)| sql.contains("SELECT id FROM t_trace") && *ro),
+            "the SELECT should be traced and reported read-only"
+        );
+        assert!(
+            stmts
+                .iter()
+                .any(|(sql, ro)| sql.contains("INSERT INTO t_trace") && !*ro),
+            "the INSERT should be traced and reported not read-only"
+        );
+        assert!(
+            !profiled.lock().unwrap().is_empty(),
+            "at least one Profile event should have fired"
+        );
+    }
+
+    #[diesel_test_helper::test]
+    fn remove_trace_stops_events() {
+        use std::sync::atomic::AtomicUsize;
+
+        let conn = &mut connection();
+        let count: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
+        let count2 = count.clone();
+
+        conn.on_trace(SqliteTraceFlags::STMT, move |_event| {
+            count2.fetch_add(1, Ordering::Relaxed);
+        });
+        crate::sql_query("SELECT 1").execute(conn).unwrap();
+        let after_first = count.load(Ordering::Relaxed);
+        assert!(after_first > 0, "trace should fire while registered");
+
+        conn.remove_trace();
+        crate::sql_query("SELECT 1").execute(conn).unwrap();
+        assert_eq!(
+            count.load(Ordering::Relaxed),
+            after_first,
+            "no trace events should fire after remove_trace"
         );
     }
 }

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -17,6 +17,7 @@ pub(in crate::sqlite) mod sqlite_blob;
 mod sqlite_value;
 mod statement_iterator;
 mod stmt;
+mod trace;
 
 pub use self::authorizer::{AuthorizerContext, AuthorizerDecision};
 pub(in crate::sqlite) use self::bind_collector::SqliteBindCollector;
@@ -24,6 +25,7 @@ pub use self::bind_collector::SqliteBindValue;
 pub use self::limits::SqliteLimit;
 pub use self::serialized_database::SerializedDatabase;
 pub use self::sqlite_value::SqliteValue;
+pub use self::trace::{SqliteTraceEvent, SqliteTraceFlags};
 
 use self::raw::RawConnection;
 use self::statement_iterator::*;

--- a/diesel/src/sqlite/connection/raw.rs
+++ b/diesel/src/sqlite/connection/raw.rs
@@ -1404,12 +1404,14 @@ where
             TRACE_PROFILE => {
                 // p = sqlite3_stmt*, x = sqlite3_int64* (nanoseconds).
                 let stmt_ptr = p as *mut ffi::sqlite3_stmt;
-                let duration_ns = if x.is_null() {
-                    0
-                } else {
+                let duration_ns = unsafe {
                     // x points to a sqlite3_int64. The duration is non-negative.
-                    unsafe { (*(x as *const ffi::sqlite3_int64)).cast_unsigned() }
-                };
+                    (x as *const ffi::sqlite3_int64).as_ref()
+                }
+                .copied()
+                .unwrap_or_default()
+                .cast_unsigned();
+
                 let readonly =
                     !stmt_ptr.is_null() && unsafe { ffi::sqlite3_stmt_readonly(stmt_ptr) != 0 };
                 let sql_ptr = if stmt_ptr.is_null() {

--- a/diesel/src/sqlite/connection/raw.rs
+++ b/diesel/src/sqlite/connection/raw.rs
@@ -11,6 +11,7 @@ use super::functions::{build_sql_function_args, process_sql_function_result};
 use super::limits::SqliteLimit;
 use super::serialized_database::SerializedDatabase;
 use super::stmt::ensure_sqlite_ok;
+use super::trace::{SqliteTraceEvent, SqliteTraceFlags, TRACE_PROFILE, TRACE_ROW, TRACE_STMT};
 use super::{BusyDecision, CommitDecision, ProgressDecision};
 use super::{Sqlite, SqliteAggregateFunction};
 use crate::deserialize::FromSqlRow;
@@ -67,6 +68,8 @@ pub(super) struct RawConnection {
     busy_handler: Option<Box<dyn FnMut(i32) -> BusyDecision + Send>>,
     /// Boxed closure kept alive while the authorizer is registered.
     authorizer_hook: Option<Box<dyn FnMut(AuthorizerContext<'_>) -> AuthorizerDecision + Send>>,
+    /// Boxed closure kept alive while the trace callback is registered.
+    trace_hook: Option<Box<dyn FnMut(SqliteTraceEvent<'_>) + Send>>,
 }
 
 impl RawConnection {
@@ -81,6 +84,7 @@ impl RawConnection {
             wal_hook: None,
             busy_handler: None,
             authorizer_hook: None,
+            trace_hook: None,
         }
     }
 
@@ -108,6 +112,7 @@ impl RawConnection {
                     wal_hook: None,
                     busy_handler: None,
                     authorizer_hook: None,
+                    trace_hook: None,
                 })
             }
             err_code => {
@@ -724,6 +729,55 @@ impl RawConnection {
         }
         self.authorizer_hook = None;
     }
+
+    /// Sets a trace callback, replacing any previous one.
+    ///
+    /// The callback is invoked for SQL execution tracing based on the
+    /// provided event mask.
+    ///
+    /// # Safety
+    ///
+    /// The `ptr` is derived from `&raw mut *boxed` and points to the heap
+    /// allocation of the closure. The `trace_trampoline` function matches the
+    /// signature expected by `sqlite3_trace_v2`. The pointer remains valid
+    /// because we store `boxed` in `self.trace_hook` below, keeping it alive
+    /// for the lifetime of this `RawConnection`.
+    pub(super) fn set_trace<F>(&mut self, mask: SqliteTraceFlags, hook: F)
+    where
+        F: FnMut(SqliteTraceEvent<'_>) + Send + 'static,
+    {
+        let mut boxed: Box<dyn FnMut(SqliteTraceEvent<'_>) + Send> = Box::new(hook);
+        let ptr = &raw mut *boxed as *mut libc::c_void;
+
+        unsafe {
+            ffi::sqlite3_trace_v2(
+                self.internal_connection.as_ptr(),
+                mask.bits(),
+                Some(trace_trampoline::<F>),
+                ptr,
+            );
+        }
+
+        // The old Box (if any) is dropped here after SQLite has already
+        // switched to the new callback, preventing use-after-free.
+        self.trace_hook = Some(boxed);
+    }
+
+    /// Removes the trace callback.
+    ///
+    /// # Safety
+    ///
+    /// `self.internal_connection` is a valid pointer to an open SQLite
+    /// connection. Passing a mask of `0`, `None` as the callback, and
+    /// `null_mut()` as the user data unregisters any existing trace callback.
+    /// The callback is unregistered before dropping `self.trace_hook` to
+    /// prevent callbacks from firing during cleanup.
+    pub(super) fn remove_trace(&mut self) {
+        unsafe {
+            ffi::sqlite3_trace_v2(self.internal_connection.as_ptr(), 0, None, ptr::null_mut());
+        }
+        self.trace_hook = None;
+    }
 }
 
 impl Drop for RawConnection {
@@ -737,6 +791,7 @@ impl Drop for RawConnection {
         self.remove_wal_hook();
         self.remove_busy_handler();
         self.remove_authorizer();
+        self.remove_trace();
 
         let close_result = unsafe { ffi::sqlite3_close(self.internal_connection.as_ptr()) };
         if close_result != ffi::SQLITE_OK {
@@ -1304,4 +1359,87 @@ where
             assert_fail!("Panic in sqlite3_set_authorizer trampoline. ");
         }
     }
+}
+
+/// C trampoline for `sqlite3_trace_v2`.
+///
+/// # Safety
+///
+/// `user_data` must point to a live `F` stored in `RawConnection::trace_hook`.
+unsafe extern "C" fn trace_trampoline<F>(
+    event_code: libc::c_uint,
+    user_data: *mut libc::c_void,
+    p: *mut libc::c_void,
+    x: *mut libc::c_void,
+) -> libc::c_int
+where
+    F: FnMut(SqliteTraceEvent<'_>) + Send + 'static,
+{
+    let result = crate::util::std_compat::catch_unwind(core::panic::AssertUnwindSafe(|| {
+        // SAFETY: `user_data` points to a live `F` in `RawConnection::trace_hook`.
+        let f = unsafe { &mut *(user_data as *mut F) };
+
+        // The callback is invoked inside each arm so the lossy `Cow` holding the
+        // SQL text outlives the `&str` borrow handed to it. `TRACE_STMT`,
+        // `TRACE_PROFILE`, and `TRACE_ROW` are the `u32`-normalized event codes
+        // from the `trace` module, so they match `event_code` directly.
+        match event_code {
+            TRACE_STMT => {
+                // p = sqlite3_stmt*, x = const char* (unexpanded SQL).
+                let stmt_ptr = p as *mut ffi::sqlite3_stmt;
+                let sql_ptr = x as *const libc::c_char;
+                if sql_ptr.is_null() {
+                    return;
+                }
+                // SAFETY: a non-null `x` is a valid C string from SQLite. Use a
+                // lossy conversion so non-UTF-8 SQL cannot abort the process.
+                let sql = unsafe { CStr::from_ptr(sql_ptr) }.to_string_lossy();
+                let readonly =
+                    !stmt_ptr.is_null() && unsafe { ffi::sqlite3_stmt_readonly(stmt_ptr) != 0 };
+                f(SqliteTraceEvent::Statement {
+                    sql: &sql,
+                    readonly,
+                });
+            }
+            TRACE_PROFILE => {
+                // p = sqlite3_stmt*, x = sqlite3_int64* (nanoseconds).
+                let stmt_ptr = p as *mut ffi::sqlite3_stmt;
+                let duration_ns = if x.is_null() {
+                    0
+                } else {
+                    // x points to a sqlite3_int64. The duration is non-negative.
+                    unsafe { (*(x as *const ffi::sqlite3_int64)).cast_unsigned() }
+                };
+                let readonly =
+                    !stmt_ptr.is_null() && unsafe { ffi::sqlite3_stmt_readonly(stmt_ptr) != 0 };
+                let sql_ptr = if stmt_ptr.is_null() {
+                    core::ptr::null()
+                } else {
+                    unsafe { ffi::sqlite3_sql(stmt_ptr) }
+                };
+                // SAFETY: when non-null, `sqlite3_sql` returns a valid C string.
+                let sql = if sql_ptr.is_null() {
+                    Cow::Borrowed("")
+                } else {
+                    unsafe { CStr::from_ptr(sql_ptr) }.to_string_lossy()
+                };
+                f(SqliteTraceEvent::Profile {
+                    sql: &sql,
+                    duration_ns,
+                    readonly,
+                });
+            }
+            TRACE_ROW => f(SqliteTraceEvent::Row),
+            // Unknown or unhandled events are ignored. CLOSE is intentionally
+            // not handled: diesel removes the trace before closing the
+            // connection, so it never fires.
+            _ => {}
+        }
+    }));
+
+    if result.is_err() {
+        assert_fail!("Panic in sqlite3_trace_v2 trampoline. ");
+    }
+
+    0 // Return value is currently unused by SQLite
 }

--- a/diesel/src/sqlite/connection/trace.rs
+++ b/diesel/src/sqlite/connection/trace.rs
@@ -1,0 +1,84 @@
+//! Types for the SQLite trace callback.
+//!
+//! See [`sqlite3_trace_v2`](https://sqlite.org/c3ref/trace_v2.html)
+//! and the [trace event codes](https://sqlite.org/c3ref/c_trace.html).
+
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+extern crate libsqlite3_sys as ffi;
+
+#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+use sqlite_wasm_rs as ffi;
+
+// The `SQLITE_TRACE_*` constants are typed `i32` in old `libsqlite3-sys` and
+// `c_uint` in new ones. Normalize them to `u32` here, the single place these
+// constants are read. The casts are required for the old versions.
+#[allow(clippy::unnecessary_cast)]
+pub(crate) const TRACE_STMT: u32 = ffi::SQLITE_TRACE_STMT as u32;
+#[allow(clippy::unnecessary_cast)]
+pub(crate) const TRACE_PROFILE: u32 = ffi::SQLITE_TRACE_PROFILE as u32;
+#[allow(clippy::unnecessary_cast)]
+pub(crate) const TRACE_ROW: u32 = ffi::SQLITE_TRACE_ROW as u32;
+
+bitflags::bitflags! {
+    /// Trace event mask selecting which events the callback receives.
+    ///
+    /// Added in SQLite 3.14.0 (2016-08-08). Combine flags with `|`, and
+    /// `SqliteTraceFlags::all()` selects every event.
+    ///
+    /// SQLite's `SQLITE_TRACE_CLOSE` event is intentionally not exposed. Diesel
+    /// removes the trace callback before closing the connection, so a close
+    /// event can never reach the callback.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    pub struct SqliteTraceFlags: u32 {
+        /// Statement start: fires when a prepared statement begins executing,
+        /// delivering the SQL text.
+        const STMT = TRACE_STMT;
+        /// Statement profile: fires when a statement finishes, delivering the
+        /// SQL text and the elapsed time in nanoseconds.
+        const PROFILE = TRACE_PROFILE;
+        /// Row: fires for every row a query returns. Very frequent and carries
+        /// no data, so prefer `STMT` and `PROFILE` for most logging.
+        const ROW = TRACE_ROW;
+    }
+}
+
+/// Trace events delivered to the trace callback.
+///
+/// The callback receives one of these events based on the mask
+/// registered with [`on_trace`](crate::sqlite::SqliteConnection::on_trace).
+#[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
+pub enum SqliteTraceEvent<'a> {
+    /// A prepared statement is beginning to execute.
+    #[non_exhaustive]
+    Statement {
+        /// The unexpanded SQL text, with parameter placeholders. For triggers
+        /// and nested statements SQLite may report this as a `-- comment`
+        /// rather than the SQL itself.
+        sql: &'a str,
+        /// Whether the statement is read-only, via
+        /// [`sqlite3_stmt_readonly`](https://sqlite.org/c3ref/stmt_readonly.html)
+        /// (`true` for `SELECT` and read-only `PRAGMA`). Indirect writes, such
+        /// as a user-defined function on another connection or a virtual table
+        /// with side effects, are not detected.
+        readonly: bool,
+    },
+
+    /// A prepared statement has finished executing.
+    #[non_exhaustive]
+    Profile {
+        /// The SQL text of the statement (from `sqlite3_sql`).
+        sql: &'a str,
+        /// Time taken in nanoseconds.
+        duration_ns: u64,
+        /// Whether the statement is read-only. See
+        /// [`SqliteTraceEvent::Statement::readonly`] for details.
+        readonly: bool,
+    },
+
+    /// A row has been returned from a query.
+    ///
+    /// Fires for every returned row and carries no data.
+    #[non_exhaustive]
+    Row,
+}

--- a/diesel/src/sqlite/mod.rs
+++ b/diesel/src/sqlite/mod.rs
@@ -25,6 +25,8 @@ pub use self::connection::SerializedDatabase;
 pub use self::connection::SqliteBindValue;
 pub use self::connection::SqliteConnection;
 pub use self::connection::SqliteLimit;
+pub use self::connection::SqliteTraceEvent;
+pub use self::connection::SqliteTraceFlags;
 pub use self::connection::SqliteValue;
 pub use self::connection::authorizer;
 pub use self::connection::sqlite_blob::SqliteReadOnlyBlob;


### PR DESCRIPTION
This adds `on_trace` and `remove_trace` (and the `SqliteTraceEvent` and `SqliteTraceFlags` types) to register a callback for SQL execution tracing, wrapping `sqlite3_trace_v2`. It continues the per-API split of #4969.

Like the commit and rollback hooks the callback is `FnMut` and must not use the connection, so it is non-reentrant and needs no `RefCell`. Non-UTF-8 SQL is decoded lossily instead of aborting, matching the wal hook, and `SqliteTraceFlags` uses the `bitflags!` macro bound to the `ffi::SQLITE_TRACE_*` constants, like the existing `SqliteFunctionBehavior`.

One deliberate omission worth flagging: I did not expose the `SQLITE_TRACE_CLOSE` event. diesel unregisters the trace in `RawConnection::drop` before `sqlite3_close`, so a close event could never reach the callback, and the only way to make it reachable (closing with the callback still live) is fragile. So `SqliteTraceFlags` covers `STMT`, `PROFILE`, and `ROW` only.
