### PR TITLE
add diesel_async attribute to multiconnection macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 * Added a `RunQueryDslSupport` trait to indicate types that should implement `RunQueryDsl` in a sync/async agnostic way
 * Added a `#[derive(diesel::Enum)]` proc-macro to easily map Rust enums to database enums.
 * Added support for generating matching Rust enums for database enums in Diesel-CLI
+* Added `#[diesel_async]` attribute to `#[derive(MultiConnection)]` to support async MultiConnections. 
 
 ### Fixed
 

--- a/diesel_derives/build.rs
+++ b/diesel_derives/build.rs
@@ -274,6 +274,7 @@ fn main() {
             "multiconnection",
             vec![Example::new(
                 "diesel_derives__tests__multiconnection_1.snap",
+                "diesel_derives__tests__multiconnection_2.snap",
             )],
         ),
         (

--- a/diesel_derives/build.rs
+++ b/diesel_derives/build.rs
@@ -274,7 +274,6 @@ fn main() {
             "multiconnection",
             vec![Example::new(
                 "diesel_derives__tests__multiconnection_1.snap",
-                "diesel_derives__tests__multiconnection_2.snap",
             )],
         ),
         (

--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -1730,6 +1730,24 @@ fn view_proc_inner(input: proc_macro2::TokenStream) -> proc_macro2::TokenStream 
 /// corresponding enum manually by first establishing the connection via the inner type and then
 /// wrap the result into the enum.
 ///
+/// ## Required Container Attributes
+/// This macro supports generating code for [`diesel-async`](https://docs.rs/diesel-async/latest/diesel_async/).
+/// By adding the `#[diesel_async]` attribute, the macro instead derives
+/// implements `diesel_async::AsyncConnection` and related traits
+/// for an enum of connections to different databases.
+/// This way each tuple field type must implement `diesel_async::AsyncConnection`.
+/// It is possible to use `diesel-async`'s `SyncConnectionWrapper` as connection type.
+/// The implementation of `diesel_async::AsyncConnection::establish` works similar to the sync variant.
+///
+/// The usual stability guarantees of `diesel` do not apply here.
+/// When this attribute is used the generated code is only compatible to the `diesel-async` version supported,
+/// by this `diesel` version.
+///
+/// Note: The associated types `LoadFuture` and `ExecuteFuture` in the implementation
+/// of the trait [`AsyncConnectionCore`](https://docs.rs/diesel-async/latest/diesel_async/trait.AsyncConnectionCore.html)
+/// must be bound by `'conn`.
+///
+///
 /// # Example
 /// ```
 /// # extern crate diesel;
@@ -1890,7 +1908,7 @@ fn view_proc_inner(input: proc_macro2::TokenStream) -> proc_macro2::TokenStream 
 /// ```
 ///
 #[cfg_attr(diesel_docsrs, doc = include_str!(concat!(env!("OUT_DIR"), "/multiconnection.md")))]
-#[proc_macro_derive(MultiConnection)]
+#[proc_macro_derive(MultiConnection, attributes(diesel_async))]
 pub fn derive_multiconnection(input: TokenStream) -> TokenStream {
     derive_multiconnection_inner(input.into()).into()
 }

--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -1730,7 +1730,8 @@ fn view_proc_inner(input: proc_macro2::TokenStream) -> proc_macro2::TokenStream 
 /// corresponding enum manually by first establishing the connection via the inner type and then
 /// wrap the result into the enum.
 ///
-/// ## Required Container Attributes
+/// ## Optional Container Attributes
+///
 /// This macro supports generating code for [`diesel-async`](https://docs.rs/diesel-async/latest/diesel_async/).
 /// By adding the `#[diesel_async]` attribute, the macro instead derives
 /// implements `diesel_async::AsyncConnection` and related traits

--- a/diesel_derives/src/multiconnection.rs
+++ b/diesel_derives/src/multiconnection.rs
@@ -7,6 +7,7 @@ struct ConnectionVariant<'a> {
 }
 
 pub fn derive(item: DeriveInput) -> TokenStream {
+    let helper = MultiHelper::from_derive_input(&item);
     if let syn::Data::Enum(e) = item.data {
         let connection_types = e
             .variants
@@ -19,11 +20,11 @@ pub fn derive(item: DeriveInput) -> TokenStream {
                 _ => panic!("Only enums with one field per variant are supported"),
             })
             .collect::<Vec<_>>();
-        let backend = generate_backend(&connection_types);
-        let query_builder = generate_querybuilder(&connection_types);
-        let bind_collector = generate_bind_collector(&connection_types);
-        let row = generate_row(&connection_types);
-        let connection = generate_connection_impl(&connection_types, &item.ident);
+        let backend = generate_backend(&connection_types, &helper);
+        let query_builder = generate_querybuilder(&connection_types, &helper);
+        let bind_collector = generate_bind_collector(&connection_types, &helper);
+        let row = generate_row(&connection_types, &helper);
+        let connection = generate_connection_impl(&connection_types, &item.ident, &helper);
 
         quote::quote! {
             mod multi_connection_impl {
@@ -65,20 +66,139 @@ pub fn derive(item: DeriveInput) -> TokenStream {
     }
 }
 
+/// A helper struct containing common tokens used in the sync and async in similar.
+struct MultiHelper {
+    is_async: bool,
+    /// Type of Connection trait.
+    conn: TokenStream,
+    /// Trait with the Backend Type.
+    conn_backend: TokenStream,
+    /// Trait implementing the load function.
+    conn_load: TokenStream,
+    /// The multi connection helper trait, used to cast to Any.
+    multi_conn_helper: TokenStream,
+    /// Type of the SimpleConnection trait.
+    simple_connection: TokenStream,
+    /// Type of the TransactionManager trait.
+    transaction_manager: TokenStream,
+    /// `.await` or empty
+    await_token: Option<TokenStream>,
+    /// `async` or empty
+    async_token: Option<TokenStream>,
+}
+
+impl MultiHelper {
+    fn new(is_async: bool) -> Self {
+        let conn = if is_async {
+            quote::quote! { diesel_async::AsyncConnection }
+        } else {
+            quote::quote! { diesel::connection::Connection }
+        };
+
+        let conn_backend = if is_async {
+            quote::quote! { diesel_async::AsyncConnectionCore }
+        } else {
+            quote::quote! { diesel::connection::Connection }
+        };
+
+        let conn_load = if is_async {
+            quote::quote! { diesel_async::AsyncConnectionCore }
+        } else {
+            quote::quote! { diesel::connection::LoadConnection }
+        };
+
+        let multi_conn_helper = if is_async {
+            quote::quote! { diesel_async::AsyncMultiConnectionHelper }
+        } else {
+            quote::quote! { diesel::internal::derives::multiconnection::MultiConnectionHelper }
+        };
+
+        let await_token = if is_async {
+            Some(quote::quote! { .await })
+        } else {
+            None
+        };
+
+        let async_token = if is_async {
+            Some(quote::quote! { async })
+        } else {
+            None
+        };
+
+        let simple_connection = if is_async {
+            quote::quote! { diesel_async::SimpleAsyncConnection }
+        } else {
+            quote::quote! { diesel::connection::SimpleConnection }
+        };
+
+        let transaction_manager = if is_async {
+            quote::quote! { diesel_async::TransactionManager }
+        } else {
+            quote::quote! { diesel::connection::TransactionManager }
+        };
+
+        Self {
+            is_async,
+            conn,
+            conn_load,
+            conn_backend,
+            multi_conn_helper,
+            await_token,
+            async_token,
+            simple_connection,
+            transaction_manager,
+        }
+    }
+
+    fn from_derive_input(item: &DeriveInput) -> MultiHelper {
+        let is_async = item
+            .attrs
+            .iter()
+            .any(|a| matches!(&a.meta, syn::Meta::Path(ident) if ident.is_ident("diesel_async")));
+        Self::new(is_async)
+    }
+}
+
 fn generate_connection_impl(
     connection_types: &[ConnectionVariant],
     ident: &syn::Ident,
+    helper: &MultiHelper,
 ) -> TokenStream {
+    let MultiHelper {
+        is_async,
+        conn,
+        conn_backend,
+        multi_conn_helper,
+        await_token,
+        async_token,
+        conn_load,
+        simple_connection,
+        transaction_manager,
+        ..
+    } = helper;
+    let is_async = *is_async;
+
     let batch_execute_impl = connection_types.iter().map(|c| {
         let ident = c.name;
         quote::quote! {
-            Self::#ident(conn) => conn.batch_execute(query)
+            Self::#ident(conn) => conn.batch_execute(query)#await_token
         }
     });
 
-    let execute_returning_count_impl = connection_types.iter().map(|c| {
+    let conn_backend_impl = if is_async {
+        None
+    } else {
+        Some(quote::quote! { type Backend = super::MultiBackend; })
+    };
+
+    let execute_returning_count_var = connection_types.iter().map(|c| {
         let ident = c.name;
         let ty = c.ty;
+        let ref_token = if is_async {
+            quote::quote! { }
+        } else {
+            quote::quote! { & }
+        };
         quote::quote! {
             Self::#ident(conn) => {
                 let query = SerializedQuery {
@@ -87,33 +207,134 @@ fn generate_connection_impl(
                     query_builder: super::query_builder::MultiQueryBuilder::#ident(Default::default()),
                     p: std::marker::PhantomData::<#ty>,
                 };
-                conn.execute_returning_count(&query)
+                conn.execute_returning_count(#ref_token query)
             }
         }
-    });
+    }).collect::<Vec<_>>();
 
-    let load_impl = connection_types.iter().map(|c| {
-        let variant_ident = c.name;
-        let ty = &c.ty;
+    let impl_execute_returning_count_async = if is_async {
+        Some(quote::quote! {
+            fn execute_returning_count<'conn, 'query, T>(
+                &'conn mut self,
+                source: T,
+            ) -> Self::ExecuteFuture<'conn, 'query>
+            where
+                T: diesel::query_builder::QueryFragment<Self::Backend> + diesel::query_builder::QueryId + 'query,
+            {
+                match self {
+                    #(#execute_returning_count_var,)*
+                }
+            }
+        })
+    } else {
+        None
+    };
+
+    let impl_execute_returning_count = if is_async {
+        None
+    } else {
+        Some(quote::quote! {
+            fn execute_returning_count<T>(&mut self, source: &T) -> diesel::result::QueryResult<usize>
+            where
+                T: diesel::query_builder::QueryFragment<Self::Backend> + diesel::query_builder::QueryId,
+            {
+                match self {
+                    #(#execute_returning_count_var,)*
+                }
+            }
+        })
+    };
+
+    let load_impl = if is_async {
+        let load_var_impl = connection_types.iter().map(|c| {
+            let variant_ident = c.name;
+            let ty = &c.ty;
+            quote::quote! {
+                Self::#variant_ident(conn) => {
+                    let query = SerializedQuery {
+                        inner: source.as_query(),
+                        backend: MultiBackend::#variant_ident(Default::default()),
+                        query_builder: super::query_builder::MultiQueryBuilder::#variant_ident(Default::default()),
+                        p: std::marker::PhantomData::<#ty>,
+                    };
+                    let r = <#ty as #conn_load>::load(conn, query);
+                    Box::pin(async move {
+                        Ok(Box::pin(
+                            futures_util::StreamExt::map(r.await?, |result| result.map(super::row::MultiRow::#variant_ident))
+                        ) as Self::Stream<'conn, 'query>)
+                    })
+                }
+            }
+        });
         quote::quote! {
-            #ident::#variant_ident(conn) => {
-                let query = SerializedQuery {
-                    inner: source,
-                    backend: MultiBackend::#variant_ident(Default::default()),
-                    query_builder: super::query_builder::MultiQueryBuilder::#variant_ident(Default::default()),
-                    p: std::marker::PhantomData::<#ty>,
-                };
-                let r = <#ty as diesel::connection::LoadConnection>::load(conn, query)?;
-                Ok(super::row::MultiCursor::#variant_ident(r))
+            impl #conn_load for MultiConnection {
+                type LoadFuture<'conn, 'query> = futures_util::future::BoxFuture<'conn, diesel::QueryResult<Self::Stream<'conn, 'query>>>;
+                type ExecuteFuture<'conn, 'query> = futures_util::future::BoxFuture<'conn, diesel::QueryResult<usize>>;
+                type Stream<'conn, 'query> = futures_util::stream::BoxStream<'conn, diesel::QueryResult<Self::Row<'conn, 'query>>>;
+                type Row<'conn, 'query> = super::MultiRow<'conn, 'query>;
+
+                type Backend = super::MultiBackend;
+
+                fn load<'conn, 'query, T>(
+                    &'conn mut self,
+                    source: T,
+                ) -> Self::LoadFuture<'conn, 'query>
+                where
+                    T: diesel::query_builder::AsQuery + 'query,
+                    T::Query: diesel::query_builder::QueryFragment<Self::Backend> + diesel::query_builder::QueryId + 'query,
+                {
+                    match self {
+                        #(#load_var_impl,)*
+                    }
+                }
+
+                #impl_execute_returning_count_async
             }
         }
-    });
+    } else {
+        let load_var_impl = connection_types.iter().map(|c| {
+            let variant_ident = c.name;
+            let ty = &c.ty;
+            quote::quote! {
+                Self::#variant_ident(conn) => {
+                    let query = SerializedQuery {
+                        inner: source,
+                        backend: MultiBackend::#variant_ident(Default::default()),
+                        query_builder: super::query_builder::MultiQueryBuilder::#variant_ident(Default::default()),
+                        p: std::marker::PhantomData::<#ty>,
+                    };
+                    let r = <#ty as #conn_load>::load(conn, query)?;
+                    Ok(super::row::MultiCursor::#variant_ident(r))
+                }
+            }
+        });
+        quote::quote! {
+            impl #conn_load for MultiConnection
+            {
+                type Cursor<'conn, 'query> = super::row::MultiCursor<'conn, 'query>;
+                type Row<'conn, 'query> = super::MultiRow<'conn, 'query>;
+
+                fn load<'conn, 'query, T>(
+                    &'conn mut self,
+                    source: T,
+                ) -> diesel::result::QueryResult<Self::Cursor<'conn, 'query>>
+                where
+                    T: diesel::query_builder::Query + diesel::query_builder::QueryFragment<Self::Backend> + diesel::query_builder::QueryId + 'query,
+                    Self::Backend: diesel::expression::QueryMetadata<T::SqlType>,
+                {
+                    match self {
+                        #(#load_var_impl,)*
+                    }
+                }
+            }
+        }
+    };
 
     let instrumentation_impl = connection_types.iter().map(|c| {
         let variant_ident = c.name;
         quote::quote! {
-            #ident::#variant_ident(conn) => {
-                diesel::connection::Connection::set_instrumentation(conn, instrumentation);
+            Self::#variant_ident(conn) => {
+                #conn::set_instrumentation(conn, instrumentation);
             }
         }
     });
@@ -121,8 +342,8 @@ fn generate_connection_impl(
     let set_cache_impl = connection_types.iter().map(|c| {
         let variant_ident = c.name;
         quote::quote! {
-            #ident::#variant_ident(conn) => {
-                diesel::connection::Connection::set_prepared_statement_cache_size(conn, size);
+            Self::#variant_ident(conn) => {
+                #conn::set_prepared_statement_cache_size(conn, size);
             }
         }
     });
@@ -130,8 +351,8 @@ fn generate_connection_impl(
     let get_instrumentation_impl = connection_types.iter().map(|c| {
         let variant_ident = c.name;
         quote::quote! {
-            #ident::#variant_ident(conn) => {
-                diesel::connection::Connection::instrumentation(conn)
+            Self::#variant_ident(conn) => {
+                #conn::instrumentation(conn)
             }
         }
     });
@@ -140,7 +361,7 @@ fn generate_connection_impl(
         let ident = c.name;
         let ty = c.ty;
         quote::quote! {
-            if let Ok(conn) = #ty::establish(database_url) {
+            if let Ok(conn) = #ty::establish(database_url)#await_token {
                 return Ok(Self::#ident(conn));
             }
         }
@@ -150,7 +371,7 @@ fn generate_connection_impl(
         let ident = c.name;
         let ty = c.ty;
         quote::quote! {
-            Self::#ident(conn) => <#ty as Connection>::TransactionManager::begin_transaction(conn)
+            Self::#ident(conn) => <#ty as #conn>::TransactionManager::begin_transaction(conn)#await_token
         }
     });
 
@@ -158,7 +379,7 @@ fn generate_connection_impl(
         let ident = c.name;
         let ty = c.ty;
         quote::quote! {
-            Self::#ident(conn) => <#ty as Connection>::TransactionManager::commit_transaction(conn)
+            Self::#ident(conn) => <#ty as #conn>::TransactionManager::commit_transaction(conn)#await_token
         }
     });
 
@@ -166,7 +387,7 @@ fn generate_connection_impl(
         let ident = c.name;
         let ty = c.ty;
         quote::quote! {
-            Self::#ident(conn) => <#ty as Connection>::TransactionManager::rollback_transaction(conn)
+            Self::#ident(conn) => <#ty as #conn>::TransactionManager::rollback_transaction(conn)#await_token
         }
     });
 
@@ -174,7 +395,7 @@ fn generate_connection_impl(
         let ident = c.name;
         let ty = c.ty;
         quote::quote! {
-            Self::#ident(conn) => <#ty as Connection>::TransactionManager::is_broken_transaction_manager(conn)
+            Self::#ident(conn) => <#ty as #conn>::TransactionManager::is_broken_transaction_manager(conn)
         }
     });
 
@@ -182,7 +403,7 @@ fn generate_connection_impl(
         let ident = c.name;
         let ty = c.ty;
         quote::quote! {
-            Self::#ident(conn) => <#ty as Connection>::TransactionManager::transaction_manager_status_mut(conn)
+            Self::#ident(conn) => <#ty as #conn>::TransactionManager::transaction_manager_status_mut(conn)
         }
     });
 
@@ -197,7 +418,7 @@ fn generate_connection_impl(
                     backend: &'b MultiBackend,
                     q: &'b impl diesel::query_builder::QueryFragment<MultiBackend>,
                 ) -> diesel::QueryResult<()> {
-                    use diesel::internal::derives::multiconnection::MultiConnectionHelper;
+                    use #multi_conn_helper;
 
                     let mut collector = super::bind_collector::MultiBindCollector::#ident(Default::default());
                     let lookup = Self::to_any(lookup);
@@ -211,44 +432,69 @@ fn generate_connection_impl(
         }
     });
 
-    let impl_migration_connection_setup = connection_types.iter().map(|c| {
-        let ident = c.name;
-        quote::quote! {
-            Self::#ident(conn) => {
-                use diesel::migration::MigrationConnection;
-                conn.setup()
+    let migration_connection_impl = if is_async {
+        None
+    } else {
+        let impl_migration_connection_setup = connection_types.iter().map(|c| {
+            let ident = c.name;
+            quote::quote! {
+                Self::#ident(conn) => {
+                    use diesel::migration::MigrationConnection;
+                    conn.setup()
+                }
             }
-        }
-    });
+        });
+        let impl_migration_connection_read = connection_types.iter().map(|c| {
+            let ident = c.name;
+            quote::quote! {
+                Self::#ident(conn) => {
+                    use diesel::migration::MigrationConnection;
+                    conn.read_search_path()
+                }
+            }
+        });
 
-    let impl_migration_connection_read = connection_types.iter().map(|c| {
-        let ident = c.name;
-        quote::quote! {
-            Self::#ident(conn) => {
-                use diesel::migration::MigrationConnection;
-                conn.read_search_path()
+        let impl_migration_connection_set = connection_types.iter().map(|c| {
+            let ident = c.name;
+            quote::quote! {
+                Self::#ident(conn) => {
+                    use diesel::migration::MigrationConnection;
+                    conn.set_search_path(search_path)
+                }
             }
-        }
-    });
+        });
+        Some(quote::quote! {
+            impl diesel::migration::MigrationConnection for MultiConnection {
+                fn setup(&mut self) -> diesel::QueryResult<usize> {
+                    match self {
+                        #(#impl_migration_connection_setup,)*
+                    }
+                }
+                fn read_search_path(&mut self) -> diesel::QueryResult<Option<String>> {
+                    match self {
+                        #(#impl_migration_connection_read,)*
+                    }
+                }
 
-    let impl_migration_connection_set = connection_types.iter().map(|c| {
-        let ident = c.name;
-        quote::quote! {
-            Self::#ident(conn) => {
-                use diesel::migration::MigrationConnection;
-                conn.set_search_path(search_path)
+                fn set_search_path(&mut self, search_path: &str) -> diesel::QueryResult<()> {
+                    match self {
+                        #(#impl_migration_connection_set,)*
+                    }
+                }
             }
-        }
-    });
+        })
+    };
 
     let impl_begin_test_transaction = connection_types.iter().map(|c| {
         let ident = c.name;
         quote::quote! {
-            Self::#ident(conn) => conn.begin_test_transaction()
+            Self::#ident(conn) => conn.begin_test_transaction()#await_token
         }
     });
 
-    let r2d2_impl = {
+    let r2d2_impl = if is_async {
+        None
+    } else {
         let impl_ping_r2d2 = connection_types.iter().map(|c| {
             let ident = c.name;
             quote::quote! {
@@ -262,7 +508,7 @@ fn generate_connection_impl(
                 Self::#ident(conn) => conn.is_broken()
             }
         });
-        quote::quote! {
+        Some(quote::quote! {
             diesel::internal::derives::multiconnection::expand_r2d2! {
                 impl diesel::r2d2::R2D2Connection for MultiConnection {
                     fn ping(&mut self) -> diesel::QueryResult<()> {
@@ -280,22 +526,27 @@ fn generate_connection_impl(
                     }
                 }
             }
-        }
+        })
+    };
+
+    let simple_impls = if is_async {
+        quote::quote! { diesel_async::expand_pool! { impl diesel_async::pooled_connection::PoolableConnection for MultiConnection {} } }
+    } else {
+        quote::quote! { impl diesel::internal::derives::multiconnection::ConnectionSealed for MultiConnection {} }
     };
 
     quote::quote! {
-        use diesel::connection::*;
         pub(super) use super::#ident as MultiConnection;
 
-        impl SimpleConnection for MultiConnection {
-            fn batch_execute(&mut self, query: &str) -> diesel::result::QueryResult<()> {
+        impl #simple_connection for MultiConnection {
+            #async_token fn batch_execute(&mut self, query: &str) -> diesel::result::QueryResult<()> {
                 match self {
                     #(#batch_execute_impl,)*
                 }
             }
         }
 
-        impl diesel::internal::derives::multiconnection::ConnectionSealed for MultiConnection {}
+        #simple_impls
 
         struct SerializedQuery<T, C> {
             inner: T,
@@ -304,7 +555,7 @@ fn generate_connection_impl(
             p: std::marker::PhantomData<C>,
         }
 
-        trait BindParamHelper: Connection {
+        trait BindParamHelper: #conn {
             fn handle_inner_pass<'a, 'b: 'a>(
                 collector: &mut <Self::Backend as diesel::backend::Backend>::BindCollector<'a>,
                 lookup: &mut <Self::Backend as diesel::sql_types::TypeMetadata>::MetadataLookup,
@@ -319,7 +570,7 @@ fn generate_connection_impl(
         where
             DB: diesel::backend::Backend + 'static,
             T: diesel::query_builder::QueryFragment<MultiBackend>,
-            C: diesel::connection::Connection<Backend = DB> + BindParamHelper + diesel::internal::derives::multiconnection::MultiConnectionHelper,
+            C: #conn_backend<Backend = DB> + BindParamHelper + #multi_conn_helper,
         {
             fn walk_ast<'b>(
                 &'b self,
@@ -363,28 +614,20 @@ fn generate_connection_impl(
             type SqlType = diesel::sql_types::Untyped;
         }
 
-        impl Connection for MultiConnection {
-            type Backend = super::MultiBackend;
+        impl #conn for MultiConnection {
+            #conn_backend_impl
 
             type TransactionManager = Self;
 
-            fn establish(database_url: &str) -> diesel::ConnectionResult<Self> {
+            #async_token fn establish(database_url: &str) -> diesel::ConnectionResult<Self> {
                 #(#establish_impls)*
                 Err(diesel::ConnectionError::BadConnection("Invalid connection url for multiconnection".into()))
             }
-
-            fn execute_returning_count<T>(&mut self, source: &T) -> diesel::result::QueryResult<usize>
-            where
-                T: diesel::query_builder::QueryFragment<Self::Backend> + diesel::query_builder::QueryId,
-            {
-                match self {
-                    #(#execute_returning_count_impl,)*
-                }
-            }
+            #impl_execute_returning_count
 
             fn transaction_state(
                 &mut self,
-            ) -> &mut <Self::TransactionManager as TransactionManager<Self>>::TransactionStateData {
+            ) -> &mut <Self::TransactionManager as #transaction_manager<Self>>::TransactionStateData {
                 self
             }
 
@@ -406,48 +649,31 @@ fn generate_connection_impl(
                 }
             }
 
-            fn begin_test_transaction(&mut self) -> diesel::QueryResult<()> {
+            #async_token fn begin_test_transaction(&mut self) -> diesel::QueryResult<()> {
                 match self {
                     #(#impl_begin_test_transaction,)*
                 }
             }
         }
 
-        impl LoadConnection for MultiConnection
-        {
-            type Cursor<'conn, 'query> = super::row::MultiCursor<'conn, 'query>;
-            type Row<'conn, 'query> = super::MultiRow<'conn, 'query>;
+        #load_impl
 
-            fn load<'conn, 'query, T>(
-                &'conn mut self,
-                source: T,
-            ) -> diesel::result::QueryResult<Self::Cursor<'conn, 'query>>
-            where
-                T: diesel::query_builder::Query + diesel::query_builder::QueryFragment<Self::Backend> + diesel::query_builder::QueryId + 'query,
-                Self::Backend: diesel::expression::QueryMetadata<T::SqlType>,
-            {
-                match self {
-                    #(#load_impl,)*
-                }
-            }
-        }
-
-        impl TransactionManager<MultiConnection> for MultiConnection {
+        impl #transaction_manager<MultiConnection> for MultiConnection {
             type TransactionStateData = Self;
 
-            fn begin_transaction(conn: &mut MultiConnection) -> diesel::QueryResult<()> {
+            #async_token fn begin_transaction(conn: &mut MultiConnection) -> diesel::QueryResult<()> {
                 match conn {
                     #(#begin_transaction_impl,)*
                 }
             }
 
-            fn rollback_transaction(conn: &mut MultiConnection) -> diesel::QueryResult<()> {
+            #async_token fn rollback_transaction(conn: &mut MultiConnection) -> diesel::QueryResult<()> {
                 match conn {
                     #(#rollback_transaction_impl,)*
                 }
             }
 
-            fn commit_transaction(conn: &mut MultiConnection) -> diesel::QueryResult<()> {
+            #async_token fn commit_transaction(conn: &mut MultiConnection) -> diesel::QueryResult<()> {
                 match conn {
                     #(#commit_transaction_impl,)*
                 }
@@ -466,36 +692,25 @@ fn generate_connection_impl(
             }
         }
 
-        impl diesel::migration::MigrationConnection for MultiConnection {
-            fn setup(&mut self) -> diesel::QueryResult<usize> {
-                match self {
-                    #(#impl_migration_connection_setup,)*
-                }
-            }
-
-            fn read_search_path(&mut self) -> diesel::QueryResult<Option<String>> {
-                match self {
-                    #(#impl_migration_connection_read,)*
-                }
-            }
-
-            fn set_search_path(&mut self, search_path: &str) -> diesel::QueryResult<()> {
-                match self {
-                    #(#impl_migration_connection_set,)*
-                }
-            }
-        }
+        #migration_connection_impl
 
         #r2d2_impl
     }
 }
 
-fn generate_row(connection_types: &[ConnectionVariant]) -> TokenStream {
+fn generate_row(connection_types: &[ConnectionVariant], helper: &MultiHelper) -> TokenStream {
+    let MultiHelper {
+        is_async,
+        conn_load,
+        conn_backend,
+        ..
+    } = helper;
+    let is_async = *is_async;
     let row_variants = connection_types.iter().map(|c| {
         let ident = c.name;
         let ty = c.ty;
         quote::quote! {
-            #ident(<#ty as diesel::connection::LoadConnection>::Row<'conn, 'query>)
+            #ident(<#ty as #conn_load>::Row<'conn, 'query>)
         }
     });
 
@@ -503,7 +718,7 @@ fn generate_row(connection_types: &[ConnectionVariant]) -> TokenStream {
         let ident = c.name;
         let ty = c.ty;
         quote::quote! {
-            #ident(<<#ty as diesel::connection::LoadConnection>::Row<'conn, 'query> as diesel::row::Row<'conn, <#ty as diesel::connection::Connection>::Backend>>::Field<'query>)
+            #ident(<<#ty as #conn_load>::Row<'conn, 'query> as diesel::row::Row<'conn, <#ty as #conn_backend>::Backend>>::Field<'query>)
         }
     });
 
@@ -532,20 +747,39 @@ fn generate_row(connection_types: &[ConnectionVariant]) -> TokenStream {
         .collect::<Vec<_>>();
     let row_index_impl = &row_index_impl;
 
-    let cursor_variants = connection_types.iter().map(|c| {
-        let ident = c.name;
-        let ty = c.ty;
-        quote::quote! {
-            #ident(<#ty as diesel::connection::LoadConnection>::Cursor<'conn, 'query>)
-        }
-    });
+    let cursor_impl = if is_async {
+        None
+    } else {
+        let cursor_variants = connection_types.iter().map(|c| {
+            let ident = c.name;
+            let ty = c.ty;
+            quote::quote! {
+                #ident(<#ty as #conn_load>::Cursor<'conn, 'query>)
+            }
+        });
+        let iterator_impl = connection_types.iter().map(|c| {
+            let ident = c.name;
+            quote::quote! {
+                Self::#ident(r) => Some(r.next()?.map(MultiRow::#ident))
+            }
+        });
 
-    let iterator_impl = connection_types.iter().map(|c| {
-        let ident = c.name;
-        quote::quote! {
-            Self::#ident(r) => Some(r.next()?.map(MultiRow::#ident))
-        }
-    });
+        Some(quote::quote! {
+            pub enum MultiCursor<'conn, 'query> {
+                #(#cursor_variants,)*
+            }
+
+            impl<'conn, 'query> Iterator for MultiCursor<'conn, 'query> {
+                type Item = diesel::QueryResult<MultiRow<'conn, 'query>>;
+
+                fn next(&mut self) -> Option<Self::Item> {
+                    match self {
+                        #(#iterator_impl,)*
+                    }
+                }
+            }
+        })
+    };
 
     let field_count_impl = connection_types.iter().map(|c| {
         let ident = c.name;
@@ -643,25 +877,21 @@ fn generate_row(connection_types: &[ConnectionVariant]) -> TokenStream {
                 diesel::internal::derives::multiconnection::PartialRow::new(self, range)
             }
         }
-
-        pub enum MultiCursor<'conn, 'query> {
-            #(#cursor_variants,)*
-        }
-
-        impl<'conn, 'query> Iterator for MultiCursor<'conn, 'query> {
-            type Item = diesel::QueryResult<MultiRow<'conn, 'query>>;
-
-            fn next(&mut self) -> Option<Self::Item> {
-                match self {
-                    #(#iterator_impl,)*
-                }
-            }
-        }
+        #cursor_impl
 
     }
 }
 
-fn generate_bind_collector(connection_types: &[ConnectionVariant]) -> TokenStream {
+fn generate_bind_collector(
+    connection_types: &[ConnectionVariant],
+    helper: &MultiHelper,
+) -> TokenStream {
+    let MultiHelper {
+        multi_conn_helper,
+        conn_backend,
+        ..
+    } = helper;
+
     let mut to_sql_impls = [
         (
             quote::quote!(diesel::sql_types::SmallInt),
@@ -816,14 +1046,14 @@ fn generate_bind_collector(connection_types: &[ConnectionVariant]) -> TokenStrea
     let into_bind_value_bounds = connection_types.iter().map(|c| {
         let ty = c.ty;
         quote::quote! {
-            diesel::serialize::ToSql<ST, <#ty as diesel::connection::Connection>::Backend>
+            diesel::serialize::ToSql<ST, <#ty as #conn_backend>::Backend>
         }
     });
 
     let has_sql_type_bounds = connection_types.iter().map(|c| {
         let ty = c.ty;
         quote::quote! {
-            <#ty as diesel::connection::Connection>::Backend: diesel::sql_types::HasSqlType<ST>
+            <#ty as #conn_backend>::Backend: diesel::sql_types::HasSqlType<ST>
         }
     });
 
@@ -831,7 +1061,7 @@ fn generate_bind_collector(connection_types: &[ConnectionVariant]) -> TokenStrea
         let ident = c.name;
         let ty = c.ty;
         quote::quote! {
-            #ident(<<#ty as diesel::connection::Connection>::Backend as diesel::backend::Backend>::BindCollector<'a>)
+            #ident(<<#ty as #conn_backend>::Backend as diesel::backend::Backend>::BindCollector<'a>)
         }
     });
 
@@ -842,7 +1072,7 @@ fn generate_bind_collector(connection_types: &[ConnectionVariant]) -> TokenStrea
         quote::quote! {
             pub(super) fn #lower_ident(
                 &mut self,
-            ) -> &mut <<#ty as diesel::connection::Connection>::Backend as diesel::backend::Backend>::BindCollector<'a> {
+            ) -> &mut <<#ty as #conn_backend>::Backend as diesel::backend::Backend>::BindCollector<'a> {
                 match self {
                     Self::#ident(bc) => bc,
                     _ => unreachable!(),
@@ -861,11 +1091,11 @@ fn generate_bind_collector(connection_types: &[ConnectionVariant]) -> TokenStrea
                 let out = out.inner.expect("This inner value is set via our custom `ToSql` impls");
                 let callback = out.push_bound_value_to_collector;
                 let value = out.value;
-                <_ as PushBoundValueToCollectorDB<<#ty as diesel::Connection>::Backend>>::push_bound_value(
+                <_ as PushBoundValueToCollectorDB<<#ty as #conn_backend>::Backend>>::push_bound_value(
                      callback,
                      value,
                      bc,
-                     <#ty as diesel::internal::derives::multiconnection::MultiConnectionHelper>::from_any(metadata_lookup)
+                     <#ty as #multi_conn_helper>::from_any(metadata_lookup)
                         .expect("We can downcast the metadata lookup to the right type")
                  )?
             }
@@ -889,7 +1119,7 @@ fn generate_bind_collector(connection_types: &[ConnectionVariant]) -> TokenStrea
         .map(|c| {
             let ty = c.ty;
             quote::quote! {
-                PushBoundValueToCollectorDB<<#ty as diesel::Connection>::Backend>
+                PushBoundValueToCollectorDB<<#ty as #conn_backend>::Backend>
             }
         })
         .collect::<Vec<_>>();
@@ -1215,12 +1445,20 @@ fn generate_queryfragment_impls(
     }
 }
 
-fn generate_querybuilder(connection_types: &[ConnectionVariant]) -> TokenStream {
+fn generate_querybuilder(
+    connection_types: &[ConnectionVariant],
+    helper: &MultiHelper,
+) -> TokenStream {
+    let MultiHelper {
+        multi_conn_helper,
+        conn_backend,
+        ..
+    } = helper;
     let variants = connection_types.iter().map(|c| {
         let ident = c.name;
         let ty = c.ty;
         quote::quote! {
-            #ident(<<#ty as diesel::Connection>::Backend as diesel::backend::Backend>::QueryBuilder)
+            #ident(<<#ty as #conn_backend>::Backend as diesel::backend::Backend>::QueryBuilder)
         }
     });
 
@@ -1257,7 +1495,7 @@ fn generate_querybuilder(connection_types: &[ConnectionVariant]) -> TokenStream 
         let ident = c.name;
         let lower_ident = syn::Ident::new(&ident.to_string().to_lowercase(), ident.span());
         quote::quote! {
-            pub(super) fn #lower_ident(&mut self) -> &mut <<#ty as diesel::Connection>::Backend as diesel::backend::Backend>::QueryBuilder {
+            pub(super) fn #lower_ident(&mut self) -> &mut <<#ty as #conn_backend>::Backend as diesel::backend::Backend>::QueryBuilder {
                 match self {
                     Self::#ident(qb) => qb,
                     _ => unreachable!(),
@@ -1266,12 +1504,15 @@ fn generate_querybuilder(connection_types: &[ConnectionVariant]) -> TokenStream 
         }
     });
 
-    let query_fragment_bounds = connection_types.iter().map(|c| {
-        let ty = c.ty;
-        quote::quote! {
-            diesel::query_builder::QueryFragment<<#ty as diesel::connection::Connection>::Backend>
-        }
-    }).collect::<Vec<_>>();
+    let query_fragment_bounds = connection_types
+        .iter()
+        .map(|c| {
+            let ty = c.ty;
+            quote::quote! {
+                diesel::query_builder::QueryFragment<<#ty as #conn_backend>::Backend>
+            }
+        })
+        .collect::<Vec<_>>();
 
     let duplicate_query_builder = connection_types.iter().map(|c| {
         let ident = c.name;
@@ -1341,14 +1582,14 @@ fn generate_querybuilder(connection_types: &[ConnectionVariant]) -> TokenStream 
         let ty = c.ty;
         quote::quote! {
             super::backend::MultiBackend::#ident(_) => {
-                <Self as diesel::insertable::InsertValues<<#ty as diesel::connection::Connection>::Backend, Col::Table>>::column_names(
+                <Self as diesel::insertable::InsertValues<<#ty as #conn_backend>::Backend, Col::Table>>::column_names(
                     &self,
                     out.cast_database(
                         super::bind_collector::MultiBindCollector::#lower_ident,
                         super::query_builder::MultiQueryBuilder::#lower_ident,
                         super::backend::MultiBackend::#lower_ident,
                         |l| {
-                            <#ty as diesel::internal::derives::multiconnection::MultiConnectionHelper>::from_any(l)
+                            <#ty as #multi_conn_helper>::from_any(l)
                                 .expect("It's possible to downcast the metadata lookup type to the correct type")
                         },
                     ),
@@ -1360,7 +1601,7 @@ fn generate_querybuilder(connection_types: &[ConnectionVariant]) -> TokenStream 
     let insert_values_backend_bounds = connection_types.iter().map(|c| {
         let ty = c.ty;
         quote::quote! {
-            diesel::insertable::DefaultableColumnInsertValue<diesel::insertable::ColumnInsertValue<Col, Expr>>: diesel::insertable::InsertValues<<#ty as diesel::connection::Connection>::Backend, Col::Table>
+            diesel::insertable::DefaultableColumnInsertValue<diesel::insertable::ColumnInsertValue<Col, Expr>>: diesel::insertable::InsertValues<<#ty as #conn_backend>::Backend, Col::Table>
         }
     });
 
@@ -1574,12 +1815,17 @@ fn generate_querybuilder(connection_types: &[ConnectionVariant]) -> TokenStream 
     }
 }
 
-fn generate_backend(connection_types: &[ConnectionVariant]) -> TokenStream {
+fn generate_backend(connection_types: &[ConnectionVariant], helper: &MultiHelper) -> TokenStream {
+    let MultiHelper {
+        multi_conn_helper,
+        conn_backend,
+        ..
+    } = helper;
     let backend_variants = connection_types.iter().map(|c| {
         let ident = c.name;
         let ty = c.ty;
         quote::quote! {
-            #ident(<#ty as diesel::Connection>::Backend)
+            #ident(<#ty as #conn_backend>::Backend)
         }
     });
 
@@ -1587,7 +1833,7 @@ fn generate_backend(connection_types: &[ConnectionVariant]) -> TokenStream {
         let ident = c.name;
         let ty = c.ty;
         quote::quote! {
-            #ident(<<#ty as diesel::Connection>::Backend as diesel::backend::Backend>::RawValue<'a>)
+            #ident(<<#ty as #conn_backend>::Backend as diesel::backend::Backend>::RawValue<'a>)
         }
     });
 
@@ -1595,7 +1841,7 @@ fn generate_backend(connection_types: &[ConnectionVariant]) -> TokenStream {
         let ident = c.name;
         let ty = c.ty;
         quote::quote! {
-            pub(super) #ident: Option<<<#ty as diesel::Connection>::Backend as diesel::sql_types::TypeMetadata>::TypeMetadata>
+            pub(super) #ident: Option<<<#ty as #conn_backend>::Backend as diesel::sql_types::TypeMetadata>::TypeMetadata>
         }
     });
 
@@ -1621,7 +1867,7 @@ fn generate_backend(connection_types: &[ConnectionVariant]) -> TokenStream {
         let ident = c.name;
         let lower_ident = syn::Ident::new(&ident.to_string().to_lowercase(), ident.span());
         quote::quote! {
-            pub(super) fn #lower_ident(&self) -> &<#ty as diesel::Connection>::Backend {
+            pub(super) fn #lower_ident(&self) -> &<#ty as #conn_backend>::Backend {
                 match self {
                     Self::#ident(b) => b,
                     _ => unreachable!(),
@@ -1635,7 +1881,7 @@ fn generate_backend(connection_types: &[ConnectionVariant]) -> TokenStream {
         let ty = v.ty;
         quote::quote!{
             Self::#ident(b) => {
-                <T as diesel::deserialize::FromSql<ST, <#ty as diesel::Connection>::Backend>>::from_sql(b)
+                <T as diesel::deserialize::FromSql<ST, <#ty as #conn_backend>::Backend>>::from_sql(b)
             }
         }
     });
@@ -1643,7 +1889,7 @@ fn generate_backend(connection_types: &[ConnectionVariant]) -> TokenStream {
     let backend_from_sql_bounds = connection_types.iter().map(|v| {
         let ty = v.ty;
         quote::quote! {
-            T: diesel::deserialize::FromSql<ST, <#ty as diesel::Connection>::Backend>
+            T: diesel::deserialize::FromSql<ST, <#ty as #conn_backend>::Backend>
         }
     });
 
@@ -1653,14 +1899,14 @@ fn generate_backend(connection_types: &[ConnectionVariant]) -> TokenStream {
         let ty = c.ty;
         quote::quote! {
             super::backend::MultiBackend::#ident(_) => {
-                <T as diesel::query_builder::QueryFragment<<#ty as diesel::connection::Connection>::Backend>>::walk_ast(
+                <T as diesel::query_builder::QueryFragment<<#ty as #conn_backend>::Backend>>::walk_ast(
                     ast_node,
                     pass.cast_database(
                         super::bind_collector::MultiBindCollector::#lower_ident,
                         super::query_builder::MultiQueryBuilder::#lower_ident,
                         super::backend::MultiBackend::#lower_ident,
                         |l| {
-                            <#ty as diesel::internal::derives::multiconnection::MultiConnectionHelper>::from_any(l)
+                            <#ty as #multi_conn_helper>::from_any(l)
                                 .expect("It's possible to downcast the metadata lookup type to the correct type")
                         },
                     ),
@@ -1673,7 +1919,7 @@ fn generate_backend(connection_types: &[ConnectionVariant]) -> TokenStream {
         let ty = c.ty;
 
         quote::quote! {
-            T: diesel::query_builder::QueryFragment<<#ty as diesel::Connection>::Backend>
+            T: diesel::query_builder::QueryFragment<<#ty as #conn_backend>::Backend>
         }
     });
 
@@ -1682,8 +1928,8 @@ fn generate_backend(connection_types: &[ConnectionVariant]) -> TokenStream {
         let ty = v.ty;
 
         quote::quote!{
-            if let Some(lookup) = <#ty as diesel::internal::derives::multiconnection::MultiConnectionHelper>::from_any(lookup) {
-                ret.#name = Some(<<#ty as diesel::Connection>::Backend as diesel::sql_types::HasSqlType<ST>>::metadata(lookup));
+            if let Some(lookup) = <#ty as #multi_conn_helper>::from_any(lookup) {
+                ret.#name = Some(<<#ty as #conn_backend>::Backend as diesel::sql_types::HasSqlType<ST>>::metadata(lookup));
             }
         }
 
@@ -1692,7 +1938,7 @@ fn generate_backend(connection_types: &[ConnectionVariant]) -> TokenStream {
     let lookup_sql_type_bounds = connection_types.iter().map(|c| {
         let ty = c.ty;
         quote::quote! {
-            <#ty as diesel::Connection>::Backend: diesel::sql_types::HasSqlType<ST>
+            <#ty as #conn_backend>::Backend: diesel::sql_types::HasSqlType<ST>
         }
     });
 

--- a/diesel_derives/src/multiconnection.rs
+++ b/diesel_derives/src/multiconnection.rs
@@ -194,11 +194,7 @@ fn generate_connection_impl(
     let execute_returning_count_var = connection_types.iter().map(|c| {
         let ident = c.name;
         let ty = c.ty;
-        let ref_token = if is_async {
-            quote::quote! { }
-        } else {
-            quote::quote! { & }
-        };
+        let ref_token = (!is_async).then_some(quote::quote! { & });
         quote::quote! {
             Self::#ident(conn) => {
                 let query = SerializedQuery {
@@ -229,6 +225,23 @@ fn generate_connection_impl(
     } else {
         None
     };
+    let inner_query = if is_async {
+        quote::quote!(source.as_query())
+    } else {
+        quote::quote!(source)
+    };
+
+    let load_query = |ty, variant_ident| {
+        quote::quote! {
+            let query = SerializedQuery {
+                inner: #inner_query,
+                backend: MultiBackend::#variant_ident(Default::default()),
+                query_builder: super::query_builder::MultiQueryBuilder::#variant_ident(Default::default()),
+                p: std::marker::PhantomData::<#ty>,
+            };
+            let r = <#ty as #conn_load>::load(conn, query)#await_token?;
+        }
+    };
 
     let impl_execute_returning_count = if is_async {
         None
@@ -249,18 +262,13 @@ fn generate_connection_impl(
         let load_var_impl = connection_types.iter().map(|c| {
             let variant_ident = c.name;
             let ty = &c.ty;
+            let load_query = load_query(ty, variant_ident);
             quote::quote! {
                 Self::#variant_ident(conn) => {
-                    let query = SerializedQuery {
-                        inner: source.as_query(),
-                        backend: MultiBackend::#variant_ident(Default::default()),
-                        query_builder: super::query_builder::MultiQueryBuilder::#variant_ident(Default::default()),
-                        p: std::marker::PhantomData::<#ty>,
-                    };
-                    let r = <#ty as #conn_load>::load(conn, query);
+                    #load_query
                     Box::pin(async move {
                         Ok(Box::pin(
-                            futures_util::StreamExt::map(r.await?, |result| result.map(super::row::MultiRow::#variant_ident))
+                            futures_util::StreamExt::map(r, |result| result.map(super::row::MultiRow::#variant_ident))
                         ) as Self::Stream<'conn, 'query>)
                     })
                 }
@@ -295,15 +303,10 @@ fn generate_connection_impl(
         let load_var_impl = connection_types.iter().map(|c| {
             let variant_ident = c.name;
             let ty = &c.ty;
+            let load_query = load_query(ty, variant_ident);
             quote::quote! {
                 Self::#variant_ident(conn) => {
-                    let query = SerializedQuery {
-                        inner: source,
-                        backend: MultiBackend::#variant_ident(Default::default()),
-                        query_builder: super::query_builder::MultiQueryBuilder::#variant_ident(Default::default()),
-                        p: std::marker::PhantomData::<#ty>,
-                    };
-                    let r = <#ty as #conn_load>::load(conn, query)?;
+                    #load_query
                     Ok(super::row::MultiCursor::#variant_ident(r))
                 }
             }

--- a/diesel_derives/src/tests/multiconnection.rs
+++ b/diesel_derives/src/tests/multiconnection.rs
@@ -15,3 +15,22 @@ pub(crate) fn multiconnection_1() {
         "multiconnection_1",
     );
 }
+
+#[cfg(all(feature = "r2d2", feature = "chrono", feature = "time"))]
+#[test]
+pub(crate) fn multiconnection_2() {
+    let input = quote::quote! {
+        #[diesel_async]
+        enum DbConnection {
+            Pg(diesel_async::AsyncPgConnection),
+            Sqlite(diesel_async::AsyncMysqlConnection),
+        }
+    };
+
+    super::expand_with(
+        &crate::derive_multiconnection_inner as &dyn Fn(_) -> _,
+        input,
+        super::derive(syn::parse_quote!(#[derive(MultiConnection)])),
+        "multiconnection_2",
+    );
+}

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__multiconnection_2.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__multiconnection_2.snap
@@ -1944,14 +1944,15 @@ mod multi_connection_impl {
                             >,
                         };
                         let r = <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::load(
-                            conn,
-                            query,
-                        );
+                                conn,
+                                query,
+                            )
+                            .await?;
                         Box::pin(async move {
                             Ok(
                                 Box::pin(
                                     futures_util::StreamExt::map(
-                                        r.await?,
+                                        r,
                                         |result| result.map(super::row::MultiRow::Pg),
                                     ),
                                 ) as Self::Stream<'conn, 'query>,
@@ -1970,14 +1971,15 @@ mod multi_connection_impl {
                             >,
                         };
                         let r = <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::load(
-                            conn,
-                            query,
-                        );
+                                conn,
+                                query,
+                            )
+                            .await?;
                         Box::pin(async move {
                             Ok(
                                 Box::pin(
                                     futures_util::StreamExt::map(
-                                        r.await?,
+                                        r,
                                         |result| result.map(super::row::MultiRow::Sqlite),
                                     ),
                                 ) as Self::Stream<'conn, 'query>,

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__multiconnection_2.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__multiconnection_2.snap
@@ -2,22 +2,24 @@
 source: diesel_derives/src/tests/mod.rs
 expression: out
 info:
-  input: "#[derive(MultiConnection)]\nenum DbConnection {\n    Pg(PgConnection),\n    Sqlite(diesel::SqliteConnection),\n}\n"
+  input: "#[derive(MultiConnection)]\n#[diesel_async]\nenum DbConnection {\n    Pg(diesel_async::AsyncPgConnection),\n    Sqlite(diesel_async::AsyncMysqlConnection),\n}\n"
 ---
 mod multi_connection_impl {
     use super::*;
     mod backend {
         use super::*;
         pub enum MultiBackend {
-            Pg(<PgConnection as diesel::connection::Connection>::Backend),
+            Pg(
+                <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend,
+            ),
             Sqlite(
-                <diesel::SqliteConnection as diesel::connection::Connection>::Backend,
+                <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend,
             ),
         }
         impl MultiBackend {
             pub(super) fn pg(
                 &self,
-            ) -> &<PgConnection as diesel::connection::Connection>::Backend {
+            ) -> &<diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend {
                 match self {
                     Self::Pg(b) => b,
                     _ => unreachable!(),
@@ -25,7 +27,7 @@ mod multi_connection_impl {
             }
             pub(super) fn sqlite(
                 &self,
-            ) -> &<diesel::SqliteConnection as diesel::connection::Connection>::Backend {
+            ) -> &<diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend {
                 match self {
                     Self::Sqlite(b) => b,
                     _ => unreachable!(),
@@ -35,28 +37,28 @@ mod multi_connection_impl {
                 lookup: &mut dyn std::any::Any,
             ) -> MultiTypeMetadata
             where
-                <PgConnection as diesel::connection::Connection>::Backend: diesel::sql_types::HasSqlType<
+                <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend: diesel::sql_types::HasSqlType<
                     ST,
                 >,
-                <diesel::SqliteConnection as diesel::connection::Connection>::Backend: diesel::sql_types::HasSqlType<
+                <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend: diesel::sql_types::HasSqlType<
                     ST,
                 >,
             {
                 let mut ret = MultiTypeMetadata::default();
-                if let Some(lookup) = <PgConnection as diesel::internal::derives::multiconnection::MultiConnectionHelper>::from_any(
+                if let Some(lookup) = <diesel_async::AsyncPgConnection as diesel_async::AsyncMultiConnectionHelper>::from_any(
                     lookup,
                 ) {
                     ret.Pg = Some(
-                        <<PgConnection as diesel::connection::Connection>::Backend as diesel::sql_types::HasSqlType<
+                        <<diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend as diesel::sql_types::HasSqlType<
                             ST,
                         >>::metadata(lookup),
                     );
                 }
-                if let Some(lookup) = <diesel::SqliteConnection as diesel::internal::derives::multiconnection::MultiConnectionHelper>::from_any(
+                if let Some(lookup) = <diesel_async::AsyncMysqlConnection as diesel_async::AsyncMultiConnectionHelper>::from_any(
                     lookup,
                 ) {
                     ret.Sqlite = Some(
-                        <<diesel::SqliteConnection as diesel::connection::Connection>::Backend as diesel::sql_types::HasSqlType<
+                        <<diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend as diesel::sql_types::HasSqlType<
                             ST,
                         >>::metadata(lookup),
                     );
@@ -71,17 +73,17 @@ mod multi_connection_impl {
             ) -> diesel::QueryResult<()>
             where
                 T: diesel::query_builder::QueryFragment<
-                    <PgConnection as diesel::connection::Connection>::Backend,
+                    <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >,
                 T: diesel::query_builder::QueryFragment<
-                    <diesel::SqliteConnection as diesel::connection::Connection>::Backend,
+                    <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >,
             {
                 use diesel::internal::derives::multiconnection::AstPassHelper;
                 match pass.backend() {
                     super::backend::MultiBackend::Pg(_) => {
                         <T as diesel::query_builder::QueryFragment<
-                            <PgConnection as diesel::connection::Connection>::Backend,
+                            <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend,
                         >>::walk_ast(
                             ast_node,
                             pass
@@ -90,7 +92,7 @@ mod multi_connection_impl {
                                     super::query_builder::MultiQueryBuilder::pg,
                                     super::backend::MultiBackend::pg,
                                     |l| {
-                                        <PgConnection as diesel::internal::derives::multiconnection::MultiConnectionHelper>::from_any(
+                                        <diesel_async::AsyncPgConnection as diesel_async::AsyncMultiConnectionHelper>::from_any(
                                                 l,
                                             )
                                             .expect(
@@ -102,7 +104,7 @@ mod multi_connection_impl {
                     }
                     super::backend::MultiBackend::Sqlite(_) => {
                         <T as diesel::query_builder::QueryFragment<
-                            <diesel::SqliteConnection as diesel::connection::Connection>::Backend,
+                            <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend,
                         >>::walk_ast(
                             ast_node,
                             pass
@@ -111,7 +113,7 @@ mod multi_connection_impl {
                                     super::query_builder::MultiQueryBuilder::sqlite,
                                     super::backend::MultiBackend::sqlite,
                                     |l| {
-                                        <diesel::SqliteConnection as diesel::internal::derives::multiconnection::MultiConnectionHelper>::from_any(
+                                        <diesel_async::AsyncMysqlConnection as diesel_async::AsyncMultiConnectionHelper>::from_any(
                                                 l,
                                             )
                                             .expect(
@@ -126,12 +128,12 @@ mod multi_connection_impl {
         }
         pub enum MultiRawValue<'a> {
             Pg(
-                <<PgConnection as diesel::connection::Connection>::Backend as diesel::backend::Backend>::RawValue<
+                <<diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend as diesel::backend::Backend>::RawValue<
                     'a,
                 >,
             ),
             Sqlite(
-                <<diesel::SqliteConnection as diesel::connection::Connection>::Backend as diesel::backend::Backend>::RawValue<
+                <<diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend as diesel::backend::Backend>::RawValue<
                     'a,
                 >,
             ),
@@ -141,24 +143,24 @@ mod multi_connection_impl {
             where
                 T: diesel::deserialize::FromSql<
                     ST,
-                    <PgConnection as diesel::connection::Connection>::Backend,
+                    <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >,
                 T: diesel::deserialize::FromSql<
                     ST,
-                    <diesel::SqliteConnection as diesel::connection::Connection>::Backend,
+                    <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >,
             {
                 match self {
                     Self::Pg(b) => {
                         <T as diesel::deserialize::FromSql<
                             ST,
-                            <PgConnection as diesel::connection::Connection>::Backend,
+                            <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend,
                         >>::from_sql(b)
                     }
                     Self::Sqlite(b) => {
                         <T as diesel::deserialize::FromSql<
                             ST,
-                            <diesel::SqliteConnection as diesel::connection::Connection>::Backend,
+                            <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend,
                         >>::from_sql(b)
                     }
                 }
@@ -173,10 +175,10 @@ mod multi_connection_impl {
         #[allow(non_snake_case)]
         pub struct MultiTypeMetadata {
             pub(super) Pg: Option<
-                <<PgConnection as diesel::connection::Connection>::Backend as diesel::sql_types::TypeMetadata>::TypeMetadata,
+                <<diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend as diesel::sql_types::TypeMetadata>::TypeMetadata,
             >,
             pub(super) Sqlite: Option<
-                <<diesel::SqliteConnection as diesel::connection::Connection>::Backend as diesel::sql_types::TypeMetadata>::TypeMetadata,
+                <<diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend as diesel::sql_types::TypeMetadata>::TypeMetadata,
             >,
         }
         impl diesel::sql_types::TypeMetadata for MultiBackend {
@@ -295,10 +297,10 @@ mod multi_connection_impl {
         use super::*;
         pub enum MultiQueryBuilder {
             Pg(
-                <<PgConnection as diesel::connection::Connection>::Backend as diesel::backend::Backend>::QueryBuilder,
+                <<diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend as diesel::backend::Backend>::QueryBuilder,
             ),
             Sqlite(
-                <<diesel::SqliteConnection as diesel::connection::Connection>::Backend as diesel::backend::Backend>::QueryBuilder,
+                <<diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend as diesel::backend::Backend>::QueryBuilder,
             ),
         }
         impl MultiQueryBuilder {
@@ -312,7 +314,7 @@ mod multi_connection_impl {
         impl MultiQueryBuilder {
             pub(super) fn pg(
                 &mut self,
-            ) -> &mut <<PgConnection as diesel::connection::Connection>::Backend as diesel::backend::Backend>::QueryBuilder {
+            ) -> &mut <<diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend as diesel::backend::Backend>::QueryBuilder {
                 match self {
                     Self::Pg(qb) => qb,
                     _ => unreachable!(),
@@ -320,7 +322,7 @@ mod multi_connection_impl {
             }
             pub(super) fn sqlite(
                 &mut self,
-            ) -> &mut <<diesel::SqliteConnection as diesel::connection::Connection>::Backend as diesel::backend::Backend>::QueryBuilder {
+            ) -> &mut <<diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend as diesel::backend::Backend>::QueryBuilder {
                 match self {
                     Self::Sqlite(qb) => qb,
                     _ => unreachable!(),
@@ -358,10 +360,10 @@ mod multi_connection_impl {
         for diesel::internal::derives::multiconnection::LimitOffsetClause<L, O>
         where
             Self: diesel::query_builder::QueryFragment<
-                    <PgConnection as diesel::connection::Connection>::Backend,
+                    <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >
                 + diesel::query_builder::QueryFragment<
-                    <diesel::SqliteConnection as diesel::connection::Connection>::Backend,
+                    <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >,
         {
             fn walk_ast<'b>(
@@ -380,10 +382,10 @@ mod multi_connection_impl {
         > for diesel::internal::derives::multiconnection::Concat<L, R>
         where
             Self: diesel::query_builder::QueryFragment<
-                    <PgConnection as diesel::connection::Connection>::Backend,
+                    <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >
                 + diesel::query_builder::QueryFragment<
-                    <diesel::SqliteConnection as diesel::connection::Connection>::Backend,
+                    <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >,
         {
             fn walk_ast<'b>(
@@ -402,10 +404,10 @@ mod multi_connection_impl {
         > for diesel::internal::derives::multiconnection::array_comparison::In<T, U>
         where
             Self: diesel::query_builder::QueryFragment<
-                    <PgConnection as diesel::connection::Connection>::Backend,
+                    <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >
                 + diesel::query_builder::QueryFragment<
-                    <diesel::SqliteConnection as diesel::connection::Connection>::Backend,
+                    <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >,
         {
             fn walk_ast<'b>(
@@ -424,10 +426,10 @@ mod multi_connection_impl {
         > for diesel::internal::derives::multiconnection::array_comparison::NotIn<T, U>
         where
             Self: diesel::query_builder::QueryFragment<
-                    <PgConnection as diesel::connection::Connection>::Backend,
+                    <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >
                 + diesel::query_builder::QueryFragment<
-                    <diesel::SqliteConnection as diesel::connection::Connection>::Backend,
+                    <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >,
         {
             fn walk_ast<'b>(
@@ -446,10 +448,10 @@ mod multi_connection_impl {
         > for diesel::internal::derives::multiconnection::array_comparison::Many<ST, I>
         where
             Self: diesel::query_builder::QueryFragment<
-                    <PgConnection as diesel::connection::Connection>::Backend,
+                    <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >
                 + diesel::query_builder::QueryFragment<
-                    <diesel::SqliteConnection as diesel::connection::Connection>::Backend,
+                    <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >,
         {
             fn walk_ast<'b>(
@@ -467,10 +469,10 @@ mod multi_connection_impl {
         > for diesel::internal::derives::multiconnection::Exists<T>
         where
             Self: diesel::query_builder::QueryFragment<
-                    <PgConnection as diesel::connection::Connection>::Backend,
+                    <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >
                 + diesel::query_builder::QueryFragment<
-                    <diesel::SqliteConnection as diesel::connection::Connection>::Backend,
+                    <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >,
         {
             fn walk_ast<'b>(
@@ -486,10 +488,10 @@ mod multi_connection_impl {
         > for diesel::internal::derives::multiconnection::NoFromClause
         where
             Self: diesel::query_builder::QueryFragment<
-                    <PgConnection as diesel::connection::Connection>::Backend,
+                    <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >
                 + diesel::query_builder::QueryFragment<
-                    <diesel::SqliteConnection as diesel::connection::Connection>::Backend,
+                    <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >,
         {
             fn walk_ast<'b>(
@@ -505,10 +507,10 @@ mod multi_connection_impl {
         > for diesel::internal::derives::multiconnection::DefaultValues
         where
             Self: diesel::query_builder::QueryFragment<
-                    <PgConnection as diesel::connection::Connection>::Backend,
+                    <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >
                 + diesel::query_builder::QueryFragment<
-                    <diesel::SqliteConnection as diesel::connection::Connection>::Backend,
+                    <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >,
         {
             fn walk_ast<'b>(
@@ -526,10 +528,10 @@ mod multi_connection_impl {
         > for diesel::internal::derives::multiconnection::ReturningClause<Expr>
         where
             Self: diesel::query_builder::QueryFragment<
-                    <PgConnection as diesel::connection::Connection>::Backend,
+                    <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >
                 + diesel::query_builder::QueryFragment<
-                    <diesel::SqliteConnection as diesel::connection::Connection>::Backend,
+                    <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >,
         {
             fn walk_ast<'b>(
@@ -547,10 +549,10 @@ mod multi_connection_impl {
         > for diesel::insertable::DefaultableColumnInsertValue<Expr>
         where
             Self: diesel::query_builder::QueryFragment<
-                    <PgConnection as diesel::connection::Connection>::Backend,
+                    <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >
                 + diesel::query_builder::QueryFragment<
-                    <diesel::SqliteConnection as diesel::connection::Connection>::Backend,
+                    <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >,
         {
             fn walk_ast<'b>(
@@ -577,10 +579,10 @@ mod multi_connection_impl {
         >
         where
             Self: diesel::query_builder::QueryFragment<
-                    <PgConnection as diesel::connection::Connection>::Backend,
+                    <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >
                 + diesel::query_builder::QueryFragment<
-                    <diesel::SqliteConnection as diesel::connection::Connection>::Backend,
+                    <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >,
         {
             fn walk_ast<'b>(
@@ -598,10 +600,10 @@ mod multi_connection_impl {
         > for diesel::query_source::Alias<S>
         where
             Self: diesel::query_builder::QueryFragment<
-                    <PgConnection as diesel::connection::Connection>::Backend,
+                    <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >
                 + diesel::query_builder::QueryFragment<
-                    <diesel::SqliteConnection as diesel::connection::Connection>::Backend,
+                    <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >,
         {
             fn walk_ast<'b>(
@@ -842,13 +844,13 @@ mod multi_connection_impl {
             diesel::insertable::DefaultableColumnInsertValue<
                 diesel::insertable::ColumnInsertValue<Col, Expr>,
             >: diesel::insertable::InsertValues<
-                <PgConnection as diesel::connection::Connection>::Backend,
+                <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend,
                 Col::Table,
             >,
             diesel::insertable::DefaultableColumnInsertValue<
                 diesel::insertable::ColumnInsertValue<Col, Expr>,
             >: diesel::insertable::InsertValues<
-                <diesel::SqliteConnection as diesel::connection::Connection>::Backend,
+                <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend,
                 Col::Table,
             >,
         {
@@ -864,7 +866,7 @@ mod multi_connection_impl {
                 match out.backend() {
                     super::backend::MultiBackend::Pg(_) => {
                         <Self as diesel::insertable::InsertValues<
-                            <PgConnection as diesel::connection::Connection>::Backend,
+                            <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend,
                             Col::Table,
                         >>::column_names(
                             &self,
@@ -874,7 +876,7 @@ mod multi_connection_impl {
                                     super::query_builder::MultiQueryBuilder::pg,
                                     super::backend::MultiBackend::pg,
                                     |l| {
-                                        <PgConnection as diesel::internal::derives::multiconnection::MultiConnectionHelper>::from_any(
+                                        <diesel_async::AsyncPgConnection as diesel_async::AsyncMultiConnectionHelper>::from_any(
                                                 l,
                                             )
                                             .expect(
@@ -886,7 +888,7 @@ mod multi_connection_impl {
                     }
                     super::backend::MultiBackend::Sqlite(_) => {
                         <Self as diesel::insertable::InsertValues<
-                            <diesel::SqliteConnection as diesel::connection::Connection>::Backend,
+                            <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend,
                             Col::Table,
                         >>::column_names(
                             &self,
@@ -896,7 +898,7 @@ mod multi_connection_impl {
                                     super::query_builder::MultiQueryBuilder::sqlite,
                                     super::backend::MultiBackend::sqlite,
                                     |l| {
-                                        <diesel::SqliteConnection as diesel::internal::derives::multiconnection::MultiConnectionHelper>::from_any(
+                                        <diesel_async::AsyncMysqlConnection as diesel_async::AsyncMultiConnectionHelper>::from_any(
                                                 l,
                                             )
                                             .expect(
@@ -914,12 +916,12 @@ mod multi_connection_impl {
         use super::*;
         pub enum MultiBindCollector<'a> {
             Pg(
-                <<PgConnection as diesel::connection::Connection>::Backend as diesel::backend::Backend>::BindCollector<
+                <<diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend as diesel::backend::Backend>::BindCollector<
                     'a,
                 >,
             ),
             Sqlite(
-                <<diesel::SqliteConnection as diesel::connection::Connection>::Backend as diesel::backend::Backend>::BindCollector<
+                <<diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend as diesel::backend::Backend>::BindCollector<
                     'a,
                 >,
             ),
@@ -927,7 +929,7 @@ mod multi_connection_impl {
         impl<'a> MultiBindCollector<'a> {
             pub(super) fn pg(
                 &mut self,
-            ) -> &mut <<PgConnection as diesel::connection::Connection>::Backend as diesel::backend::Backend>::BindCollector<
+            ) -> &mut <<diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend as diesel::backend::Backend>::BindCollector<
                 'a,
             > {
                 match self {
@@ -937,7 +939,7 @@ mod multi_connection_impl {
             }
             pub(super) fn sqlite(
                 &mut self,
-            ) -> &mut <<diesel::SqliteConnection as diesel::connection::Connection>::Backend as diesel::backend::Backend>::BindCollector<
+            ) -> &mut <<diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend as diesel::backend::Backend>::BindCollector<
                 'a,
             > {
                 match self {
@@ -1040,17 +1042,17 @@ mod multi_connection_impl {
             }
         }
         trait PushBoundValueToCollector: PushBoundValueToCollectorDB<
-                <PgConnection as diesel::connection::Connection>::Backend,
+                <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend,
             > + PushBoundValueToCollectorDB<
-                <diesel::SqliteConnection as diesel::connection::Connection>::Backend,
+                <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend,
             > {}
         impl<T> PushBoundValueToCollector for T
         where
             T: PushBoundValueToCollectorDB<
-                    <PgConnection as diesel::connection::Connection>::Backend,
+                    <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >
                 + PushBoundValueToCollectorDB<
-                    <diesel::SqliteConnection as diesel::connection::Connection>::Backend,
+                    <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >,
         {}
         #[derive(Default)]
@@ -1098,20 +1100,20 @@ mod multi_connection_impl {
             T: std::any::Any
                 + diesel::serialize::ToSql<
                     ST,
-                    <PgConnection as diesel::connection::Connection>::Backend,
+                    <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >
                 + diesel::serialize::ToSql<
                     ST,
-                    <diesel::SqliteConnection as diesel::connection::Connection>::Backend,
+                    <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend,
                 > + Send + Sync + 'static,
             ST: Send
                 + diesel::sql_types::SqlType<
                     IsNull = diesel::sql_types::is_nullable::NotNull,
                 > + 'static,
-            <PgConnection as diesel::connection::Connection>::Backend: diesel::sql_types::HasSqlType<
+            <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend: diesel::sql_types::HasSqlType<
                 ST,
             >,
-            <diesel::SqliteConnection as diesel::connection::Connection>::Backend: diesel::sql_types::HasSqlType<
+            <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend: diesel::sql_types::HasSqlType<
                 ST,
             >,
         {
@@ -1183,12 +1185,12 @@ mod multi_connection_impl {
                         let callback = out.push_bound_value_to_collector;
                         let value = out.value;
                         <_ as PushBoundValueToCollectorDB<
-                            <PgConnection as diesel::connection::Connection>::Backend,
+                            <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend,
                         >>::push_bound_value(
                             callback,
                             value,
                             bc,
-                            <PgConnection as diesel::internal::derives::multiconnection::MultiConnectionHelper>::from_any(
+                            <diesel_async::AsyncPgConnection as diesel_async::AsyncMultiConnectionHelper>::from_any(
                                     metadata_lookup,
                                 )
                                 .expect(
@@ -1205,12 +1207,12 @@ mod multi_connection_impl {
                         let callback = out.push_bound_value_to_collector;
                         let value = out.value;
                         <_ as PushBoundValueToCollectorDB<
-                            <diesel::SqliteConnection as diesel::connection::Connection>::Backend,
+                            <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend,
                         >>::push_bound_value(
                             callback,
                             value,
                             bc,
-                            <diesel::SqliteConnection as diesel::internal::derives::multiconnection::MultiConnectionHelper>::from_any(
+                            <diesel_async::AsyncMysqlConnection as diesel_async::AsyncMultiConnectionHelper>::from_any(
                                     metadata_lookup,
                                 )
                                 .expect(
@@ -1584,9 +1586,14 @@ mod multi_connection_impl {
     mod row {
         use super::*;
         pub enum MultiRow<'conn, 'query> {
-            Pg(<PgConnection as diesel::connection::LoadConnection>::Row<'conn, 'query>),
+            Pg(
+                <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Row<
+                    'conn,
+                    'query,
+                >,
+            ),
             Sqlite(
-                <diesel::SqliteConnection as diesel::connection::LoadConnection>::Row<
+                <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Row<
                     'conn,
                     'query,
                 >,
@@ -1596,21 +1603,21 @@ mod multi_connection_impl {
         for MultiRow<'conn, 'query> {}
         pub enum MultiField<'conn: 'query, 'query> {
             Pg(
-                <<PgConnection as diesel::connection::LoadConnection>::Row<
+                <<diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Row<
                     'conn,
                     'query,
                 > as diesel::row::Row<
                     'conn,
-                    <PgConnection as diesel::connection::Connection>::Backend,
+                    <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >>::Field<'query>,
             ),
             Sqlite(
-                <<diesel::SqliteConnection as diesel::connection::LoadConnection>::Row<
+                <<diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Row<
                     'conn,
                     'query,
                 > as diesel::row::Row<
                     'conn,
-                    <diesel::SqliteConnection as diesel::connection::Connection>::Backend,
+                    <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >>::Field<'query>,
             ),
         }
@@ -1687,50 +1694,32 @@ mod multi_connection_impl {
                 diesel::internal::derives::multiconnection::PartialRow::new(self, range)
             }
         }
-        pub enum MultiCursor<'conn, 'query> {
-            Pg(
-                <PgConnection as diesel::connection::LoadConnection>::Cursor<
-                    'conn,
-                    'query,
-                >,
-            ),
-            Sqlite(
-                <diesel::SqliteConnection as diesel::connection::LoadConnection>::Cursor<
-                    'conn,
-                    'query,
-                >,
-            ),
-        }
-        impl<'conn, 'query> Iterator for MultiCursor<'conn, 'query> {
-            type Item = diesel::QueryResult<MultiRow<'conn, 'query>>;
-            fn next(&mut self) -> Option<Self::Item> {
-                match self {
-                    Self::Pg(r) => Some(r.next()?.map(MultiRow::Pg)),
-                    Self::Sqlite(r) => Some(r.next()?.map(MultiRow::Sqlite)),
-                }
-            }
-        }
     }
     mod connection {
         use super::*;
         pub(super) use super::DbConnection as MultiConnection;
-        impl diesel::connection::SimpleConnection for MultiConnection {
-            fn batch_execute(&mut self, query: &str) -> diesel::result::QueryResult<()> {
+        impl diesel_async::SimpleAsyncConnection for MultiConnection {
+            async fn batch_execute(
+                &mut self,
+                query: &str,
+            ) -> diesel::result::QueryResult<()> {
                 match self {
-                    Self::Pg(conn) => conn.batch_execute(query),
-                    Self::Sqlite(conn) => conn.batch_execute(query),
+                    Self::Pg(conn) => conn.batch_execute(query).await,
+                    Self::Sqlite(conn) => conn.batch_execute(query).await,
                 }
             }
         }
-        impl diesel::internal::derives::multiconnection::ConnectionSealed
-        for MultiConnection {}
+        diesel_async::expand_pool! {
+            impl diesel_async::pooled_connection::PoolableConnection for MultiConnection
+            {}
+        }
         struct SerializedQuery<T, C> {
             inner: T,
             backend: MultiBackend,
             query_builder: super::query_builder::MultiQueryBuilder,
             p: std::marker::PhantomData<C>,
         }
-        trait BindParamHelper: diesel::connection::Connection {
+        trait BindParamHelper: diesel_async::AsyncConnection {
             fn handle_inner_pass<'a, 'b: 'a>(
                 collector: &mut <Self::Backend as diesel::backend::Backend>::BindCollector<
                     'a,
@@ -1740,7 +1729,7 @@ mod multi_connection_impl {
                 q: &'b impl diesel::query_builder::QueryFragment<MultiBackend>,
             ) -> diesel::QueryResult<()>;
         }
-        impl BindParamHelper for PgConnection {
+        impl BindParamHelper for diesel_async::AsyncPgConnection {
             fn handle_inner_pass<'a, 'b: 'a>(
                 outer_collector: &mut <Self::Backend as diesel::backend::Backend>::BindCollector<
                     'a,
@@ -1749,7 +1738,7 @@ mod multi_connection_impl {
                 backend: &'b MultiBackend,
                 q: &'b impl diesel::query_builder::QueryFragment<MultiBackend>,
             ) -> diesel::QueryResult<()> {
-                use diesel::internal::derives::multiconnection::MultiConnectionHelper;
+                use diesel_async::AsyncMultiConnectionHelper;
                 let mut collector = super::bind_collector::MultiBindCollector::Pg(
                     Default::default(),
                 );
@@ -1761,7 +1750,7 @@ mod multi_connection_impl {
                 Ok(())
             }
         }
-        impl BindParamHelper for diesel::SqliteConnection {
+        impl BindParamHelper for diesel_async::AsyncMysqlConnection {
             fn handle_inner_pass<'a, 'b: 'a>(
                 outer_collector: &mut <Self::Backend as diesel::backend::Backend>::BindCollector<
                     'a,
@@ -1770,7 +1759,7 @@ mod multi_connection_impl {
                 backend: &'b MultiBackend,
                 q: &'b impl diesel::query_builder::QueryFragment<MultiBackend>,
             ) -> diesel::QueryResult<()> {
-                use diesel::internal::derives::multiconnection::MultiConnectionHelper;
+                use diesel_async::AsyncMultiConnectionHelper;
                 let mut collector = super::bind_collector::MultiBindCollector::Sqlite(
                     Default::default(),
                 );
@@ -1786,8 +1775,8 @@ mod multi_connection_impl {
         where
             DB: diesel::backend::Backend + 'static,
             T: diesel::query_builder::QueryFragment<MultiBackend>,
-            C: diesel::connection::Connection<Backend = DB> + BindParamHelper
-                + diesel::internal::derives::multiconnection::MultiConnectionHelper,
+            C: diesel_async::AsyncConnectionCore<Backend = DB> + BindParamHelper
+                + diesel_async::AsyncMultiConnectionHelper,
         {
             fn walk_ast<'b>(
                 &'b self,
@@ -1831,14 +1820,21 @@ mod multi_connection_impl {
         {
             type SqlType = diesel::sql_types::Untyped;
         }
-        impl diesel::connection::Connection for MultiConnection {
-            type Backend = super::MultiBackend;
+        impl diesel_async::AsyncConnection for MultiConnection {
             type TransactionManager = Self;
-            fn establish(database_url: &str) -> diesel::ConnectionResult<Self> {
-                if let Ok(conn) = PgConnection::establish(database_url) {
+            async fn establish(database_url: &str) -> diesel::ConnectionResult<Self> {
+                if let Ok(conn) = diesel_async::AsyncPgConnection::establish(
+                        database_url,
+                    )
+                    .await
+                {
                     return Ok(Self::Pg(conn));
                 }
-                if let Ok(conn) = diesel::SqliteConnection::establish(database_url) {
+                if let Ok(conn) = diesel_async::AsyncMysqlConnection::establish(
+                        database_url,
+                    )
+                    .await
+                {
                     return Ok(Self::Sqlite(conn));
                 }
                 Err(
@@ -1847,42 +1843,9 @@ mod multi_connection_impl {
                     ),
                 )
             }
-            fn execute_returning_count<T>(
-                &mut self,
-                source: &T,
-            ) -> diesel::result::QueryResult<usize>
-            where
-                T: diesel::query_builder::QueryFragment<Self::Backend>
-                    + diesel::query_builder::QueryId,
-            {
-                match self {
-                    Self::Pg(conn) => {
-                        let query = SerializedQuery {
-                            inner: source,
-                            backend: MultiBackend::Pg(Default::default()),
-                            query_builder: super::query_builder::MultiQueryBuilder::Pg(
-                                Default::default(),
-                            ),
-                            p: std::marker::PhantomData::<PgConnection>,
-                        };
-                        conn.execute_returning_count(&query)
-                    }
-                    Self::Sqlite(conn) => {
-                        let query = SerializedQuery {
-                            inner: source,
-                            backend: MultiBackend::Sqlite(Default::default()),
-                            query_builder: super::query_builder::MultiQueryBuilder::Sqlite(
-                                Default::default(),
-                            ),
-                            p: std::marker::PhantomData::<diesel::SqliteConnection>,
-                        };
-                        conn.execute_returning_count(&query)
-                    }
-                }
-            }
             fn transaction_state(
                 &mut self,
-            ) -> &mut <Self::TransactionManager as diesel::connection::TransactionManager<
+            ) -> &mut <Self::TransactionManager as diesel_async::TransactionManager<
                 Self,
             >>::TransactionStateData {
                 self
@@ -1892,10 +1855,10 @@ mod multi_connection_impl {
             ) -> &mut dyn diesel::connection::Instrumentation {
                 match self {
                     Self::Pg(conn) => {
-                        diesel::connection::Connection::instrumentation(conn)
+                        diesel_async::AsyncConnection::instrumentation(conn)
                     }
                     Self::Sqlite(conn) => {
-                        diesel::connection::Connection::instrumentation(conn)
+                        diesel_async::AsyncConnection::instrumentation(conn)
                     }
                 }
             }
@@ -1905,13 +1868,13 @@ mod multi_connection_impl {
             ) {
                 match self {
                     Self::Pg(conn) => {
-                        diesel::connection::Connection::set_instrumentation(
+                        diesel_async::AsyncConnection::set_instrumentation(
                             conn,
                             instrumentation,
                         );
                     }
                     Self::Sqlite(conn) => {
-                        diesel::connection::Connection::set_instrumentation(
+                        diesel_async::AsyncConnection::set_instrumentation(
                             conn,
                             instrumentation,
                         );
@@ -1924,38 +1887,112 @@ mod multi_connection_impl {
             ) {
                 match self {
                     Self::Pg(conn) => {
-                        diesel::connection::Connection::set_prepared_statement_cache_size(
+                        diesel_async::AsyncConnection::set_prepared_statement_cache_size(
                             conn,
                             size,
                         );
                     }
                     Self::Sqlite(conn) => {
-                        diesel::connection::Connection::set_prepared_statement_cache_size(
+                        diesel_async::AsyncConnection::set_prepared_statement_cache_size(
                             conn,
                             size,
                         );
                     }
                 }
             }
-            fn begin_test_transaction(&mut self) -> diesel::QueryResult<()> {
+            async fn begin_test_transaction(&mut self) -> diesel::QueryResult<()> {
                 match self {
-                    Self::Pg(conn) => conn.begin_test_transaction(),
-                    Self::Sqlite(conn) => conn.begin_test_transaction(),
+                    Self::Pg(conn) => conn.begin_test_transaction().await,
+                    Self::Sqlite(conn) => conn.begin_test_transaction().await,
                 }
             }
         }
-        impl diesel::connection::LoadConnection for MultiConnection {
-            type Cursor<'conn, 'query> = super::row::MultiCursor<'conn, 'query>;
+        impl diesel_async::AsyncConnectionCore for MultiConnection {
+            type LoadFuture<'conn, 'query> = futures_util::future::BoxFuture<
+                'conn,
+                diesel::QueryResult<Self::Stream<'conn, 'query>>,
+            >;
+            type ExecuteFuture<'conn, 'query> = futures_util::future::BoxFuture<
+                'conn,
+                diesel::QueryResult<usize>,
+            >;
+            type Stream<'conn, 'query> = futures_util::stream::BoxStream<
+                'conn,
+                diesel::QueryResult<Self::Row<'conn, 'query>>,
+            >;
             type Row<'conn, 'query> = super::MultiRow<'conn, 'query>;
+            type Backend = super::MultiBackend;
             fn load<'conn, 'query, T>(
                 &'conn mut self,
                 source: T,
-            ) -> diesel::result::QueryResult<Self::Cursor<'conn, 'query>>
+            ) -> Self::LoadFuture<'conn, 'query>
             where
-                T: diesel::query_builder::Query
-                    + diesel::query_builder::QueryFragment<Self::Backend>
+                T: diesel::query_builder::AsQuery + 'query,
+                T::Query: diesel::query_builder::QueryFragment<Self::Backend>
                     + diesel::query_builder::QueryId + 'query,
-                Self::Backend: diesel::expression::QueryMetadata<T::SqlType>,
+            {
+                match self {
+                    Self::Pg(conn) => {
+                        let query = SerializedQuery {
+                            inner: source.as_query(),
+                            backend: MultiBackend::Pg(Default::default()),
+                            query_builder: super::query_builder::MultiQueryBuilder::Pg(
+                                Default::default(),
+                            ),
+                            p: std::marker::PhantomData::<
+                                diesel_async::AsyncPgConnection,
+                            >,
+                        };
+                        let r = <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::load(
+                            conn,
+                            query,
+                        );
+                        Box::pin(async move {
+                            Ok(
+                                Box::pin(
+                                    futures_util::StreamExt::map(
+                                        r.await?,
+                                        |result| result.map(super::row::MultiRow::Pg),
+                                    ),
+                                ) as Self::Stream<'conn, 'query>,
+                            )
+                        })
+                    }
+                    Self::Sqlite(conn) => {
+                        let query = SerializedQuery {
+                            inner: source.as_query(),
+                            backend: MultiBackend::Sqlite(Default::default()),
+                            query_builder: super::query_builder::MultiQueryBuilder::Sqlite(
+                                Default::default(),
+                            ),
+                            p: std::marker::PhantomData::<
+                                diesel_async::AsyncMysqlConnection,
+                            >,
+                        };
+                        let r = <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::load(
+                            conn,
+                            query,
+                        );
+                        Box::pin(async move {
+                            Ok(
+                                Box::pin(
+                                    futures_util::StreamExt::map(
+                                        r.await?,
+                                        |result| result.map(super::row::MultiRow::Sqlite),
+                                    ),
+                                ) as Self::Stream<'conn, 'query>,
+                            )
+                        })
+                    }
+                }
+            }
+            fn execute_returning_count<'conn, 'query, T>(
+                &'conn mut self,
+                source: T,
+            ) -> Self::ExecuteFuture<'conn, 'query>
+            where
+                T: diesel::query_builder::QueryFragment<Self::Backend>
+                    + diesel::query_builder::QueryId + 'query,
             {
                 match self {
                     Self::Pg(conn) => {
@@ -1965,13 +2002,11 @@ mod multi_connection_impl {
                             query_builder: super::query_builder::MultiQueryBuilder::Pg(
                                 Default::default(),
                             ),
-                            p: std::marker::PhantomData::<PgConnection>,
+                            p: std::marker::PhantomData::<
+                                diesel_async::AsyncPgConnection,
+                            >,
                         };
-                        let r = <PgConnection as diesel::connection::LoadConnection>::load(
-                            conn,
-                            query,
-                        )?;
-                        Ok(super::row::MultiCursor::Pg(r))
+                        conn.execute_returning_count(query)
                     }
                     Self::Sqlite(conn) => {
                         let query = SerializedQuery {
@@ -1980,63 +2015,68 @@ mod multi_connection_impl {
                             query_builder: super::query_builder::MultiQueryBuilder::Sqlite(
                                 Default::default(),
                             ),
-                            p: std::marker::PhantomData::<diesel::SqliteConnection>,
+                            p: std::marker::PhantomData::<
+                                diesel_async::AsyncMysqlConnection,
+                            >,
                         };
-                        let r = <diesel::SqliteConnection as diesel::connection::LoadConnection>::load(
-                            conn,
-                            query,
-                        )?;
-                        Ok(super::row::MultiCursor::Sqlite(r))
+                        conn.execute_returning_count(query)
                     }
                 }
             }
         }
-        impl diesel::connection::TransactionManager<MultiConnection>
-        for MultiConnection {
+        impl diesel_async::TransactionManager<MultiConnection> for MultiConnection {
             type TransactionStateData = Self;
-            fn begin_transaction(conn: &mut MultiConnection) -> diesel::QueryResult<()> {
-                match conn {
-                    Self::Pg(conn) => {
-                        <PgConnection as diesel::connection::Connection>::TransactionManager::begin_transaction(
-                            conn,
-                        )
-                    }
-                    Self::Sqlite(conn) => {
-                        <diesel::SqliteConnection as diesel::connection::Connection>::TransactionManager::begin_transaction(
-                            conn,
-                        )
-                    }
-                }
-            }
-            fn rollback_transaction(
+            async fn begin_transaction(
                 conn: &mut MultiConnection,
             ) -> diesel::QueryResult<()> {
                 match conn {
                     Self::Pg(conn) => {
-                        <PgConnection as diesel::connection::Connection>::TransactionManager::rollback_transaction(
-                            conn,
-                        )
+                        <diesel_async::AsyncPgConnection as diesel_async::AsyncConnection>::TransactionManager::begin_transaction(
+                                conn,
+                            )
+                            .await
                     }
                     Self::Sqlite(conn) => {
-                        <diesel::SqliteConnection as diesel::connection::Connection>::TransactionManager::rollback_transaction(
-                            conn,
-                        )
+                        <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnection>::TransactionManager::begin_transaction(
+                                conn,
+                            )
+                            .await
                     }
                 }
             }
-            fn commit_transaction(
+            async fn rollback_transaction(
                 conn: &mut MultiConnection,
             ) -> diesel::QueryResult<()> {
                 match conn {
                     Self::Pg(conn) => {
-                        <PgConnection as diesel::connection::Connection>::TransactionManager::commit_transaction(
-                            conn,
-                        )
+                        <diesel_async::AsyncPgConnection as diesel_async::AsyncConnection>::TransactionManager::rollback_transaction(
+                                conn,
+                            )
+                            .await
                     }
                     Self::Sqlite(conn) => {
-                        <diesel::SqliteConnection as diesel::connection::Connection>::TransactionManager::commit_transaction(
-                            conn,
-                        )
+                        <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnection>::TransactionManager::rollback_transaction(
+                                conn,
+                            )
+                            .await
+                    }
+                }
+            }
+            async fn commit_transaction(
+                conn: &mut MultiConnection,
+            ) -> diesel::QueryResult<()> {
+                match conn {
+                    Self::Pg(conn) => {
+                        <diesel_async::AsyncPgConnection as diesel_async::AsyncConnection>::TransactionManager::commit_transaction(
+                                conn,
+                            )
+                            .await
+                    }
+                    Self::Sqlite(conn) => {
+                        <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnection>::TransactionManager::commit_transaction(
+                                conn,
+                            )
+                            .await
                     }
                 }
             }
@@ -2045,12 +2085,12 @@ mod multi_connection_impl {
             ) -> &mut diesel::connection::TransactionManagerStatus {
                 match conn {
                     Self::Pg(conn) => {
-                        <PgConnection as diesel::connection::Connection>::TransactionManager::transaction_manager_status_mut(
+                        <diesel_async::AsyncPgConnection as diesel_async::AsyncConnection>::TransactionManager::transaction_manager_status_mut(
                             conn,
                         )
                     }
                     Self::Sqlite(conn) => {
-                        <diesel::SqliteConnection as diesel::connection::Connection>::TransactionManager::transaction_manager_status_mut(
+                        <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnection>::TransactionManager::transaction_manager_status_mut(
                             conn,
                         )
                     }
@@ -2059,69 +2099,15 @@ mod multi_connection_impl {
             fn is_broken_transaction_manager(conn: &mut MultiConnection) -> bool {
                 match conn {
                     Self::Pg(conn) => {
-                        <PgConnection as diesel::connection::Connection>::TransactionManager::is_broken_transaction_manager(
+                        <diesel_async::AsyncPgConnection as diesel_async::AsyncConnection>::TransactionManager::is_broken_transaction_manager(
                             conn,
                         )
                     }
                     Self::Sqlite(conn) => {
-                        <diesel::SqliteConnection as diesel::connection::Connection>::TransactionManager::is_broken_transaction_manager(
+                        <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnection>::TransactionManager::is_broken_transaction_manager(
                             conn,
                         )
                     }
-                }
-            }
-        }
-        impl diesel::migration::MigrationConnection for MultiConnection {
-            fn setup(&mut self) -> diesel::QueryResult<usize> {
-                match self {
-                    Self::Pg(conn) => {
-                        use diesel::migration::MigrationConnection;
-                        conn.setup()
-                    }
-                    Self::Sqlite(conn) => {
-                        use diesel::migration::MigrationConnection;
-                        conn.setup()
-                    }
-                }
-            }
-            fn read_search_path(&mut self) -> diesel::QueryResult<Option<String>> {
-                match self {
-                    Self::Pg(conn) => {
-                        use diesel::migration::MigrationConnection;
-                        conn.read_search_path()
-                    }
-                    Self::Sqlite(conn) => {
-                        use diesel::migration::MigrationConnection;
-                        conn.read_search_path()
-                    }
-                }
-            }
-            fn set_search_path(&mut self, search_path: &str) -> diesel::QueryResult<()> {
-                match self {
-                    Self::Pg(conn) => {
-                        use diesel::migration::MigrationConnection;
-                        conn.set_search_path(search_path)
-                    }
-                    Self::Sqlite(conn) => {
-                        use diesel::migration::MigrationConnection;
-                        conn.set_search_path(search_path)
-                    }
-                }
-            }
-        }
-        impl diesel::r2d2::R2D2Connection for MultiConnection {
-            fn ping(&mut self) -> diesel::QueryResult<()> {
-                use diesel::r2d2::R2D2Connection;
-                match self {
-                    Self::Pg(conn) => conn.ping(),
-                    Self::Sqlite(conn) => conn.ping(),
-                }
-            }
-            fn is_broken(&mut self) -> bool {
-                use diesel::r2d2::R2D2Connection;
-                match self {
-                    Self::Pg(conn) => conn.is_broken(),
-                    Self::Sqlite(conn) => conn.is_broken(),
                 }
             }
         }


### PR DESCRIPTION
Adds and implements a diesel_async attribute to multiconnection macro.
This change depends on: https://github.com/diesel-rs/diesel_async/pull/295

Prior Discussion: https://github.com/diesel-rs/diesel_async/discussions/108

I ported the test pointed out in the discussion in https://github.com/jusax23/diesel_async/tree/dev-async_multi_connection-test
This test in diesel_async is depended on this macro change. 
Should I add this test to the existing pr in diesel_async, or open a new one after it is merged?

I added a feature `async_pool`, so diesel_async can control the implementation of `PoolableConnection`.

---

- [x] I checked for similar changes and make sure to reference them
- [x] I included a changelog entry for relevant new features or changes
