### PR TITLE
Expose collected SQLite bind values under the third-party backend feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 * Added a `#[derive(diesel::Enum)]` proc-macro to easily map Rust enums to database enums.
 * Added support for generating matching Rust enums for database enums in Diesel-CLI
 * Added `#[diesel_async]` attribute to `#[derive(MultiConnection)]` to support async MultiConnections. 
+* Exposed the SQLite bind values collected for a query under the `i-implement-a-third-party-backend-and-opt-into-breaking-changes` feature, via public `SqliteBindCollector` and `SqliteBindCollectorData`, each with a `binds()` iterator over the live values and the owned snapshot respectively, plus the `SqliteBindValueRef` and `OwnedSqliteBindValue` enums.
 
 ### Fixed
 

--- a/diesel/src/sqlite/connection/bind_collector.rs
+++ b/diesel/src/sqlite/connection/bind_collector.rs
@@ -11,14 +11,73 @@ use libsqlite3_sys as ffi;
 #[cfg(all(target_family = "wasm", target_os = "unknown"))]
 use sqlite_wasm_rs as ffi;
 
+/// The [`BindCollector`] used by the SQLite backend.
+///
+/// You only interact with this when adding a third-party SQLite backend.
 #[derive(Debug, Default)]
 pub struct SqliteBindCollector<'a> {
-    pub(in crate::sqlite) binds: Vec<(InternalSqliteBindValue<'a>, SqliteType)>,
+    pub(in crate::sqlite) binds: Vec<(SqliteBindValueRef<'a>, SqliteType)>,
 }
 
-impl SqliteBindCollector<'_> {
+impl<'a> SqliteBindCollector<'a> {
+    /// Construct an empty `SqliteBindCollector`
+    #[diesel_derives::__diesel_public_if(
+        feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
+    )]
     pub(in crate::sqlite) fn new() -> Self {
         Self { binds: Vec::new() }
+    }
+
+    /// Iterate over the collected bind values and their SQLite storage classes,
+    /// in positional order.
+    ///
+    /// Each yielded tuple carries a reference to the [`SqliteBindValueRef`] as
+    /// it lives inside the collector, so borrowed string and blob variants are
+    /// exposed without an intervening copy. If the caller needs a
+    /// [`Send`] snapshot instead, use [`MoveableBindCollector::moveable`]
+    /// and inspect [`SqliteBindCollectorData`].
+    ///
+    /// # Example
+    ///
+    /// A third-party backend can render a typed Diesel query into
+    /// placeholder SQL and recover the ordered bind values:
+    ///
+    /// ```rust
+    /// use diesel::expression::IntoSql;
+    /// use diesel::query_builder::{QueryBuilder, QueryFragment};
+    /// use diesel::sql_types::{BigInt, Integer, Text};
+    /// use diesel::sqlite::{
+    ///     Sqlite, SqliteBindCollector, SqliteBindValueRef, SqliteQueryBuilder, SqliteType,
+    /// };
+    ///
+    /// fn render<Q: QueryFragment<Sqlite>>(query: &Q) -> (String, Vec<SqliteType>) {
+    ///     let mut qb = SqliteQueryBuilder::new();
+    ///     query.to_sql(&mut qb, &Sqlite).unwrap();
+    ///
+    ///     let mut collector = SqliteBindCollector::new();
+    ///     query.collect_binds(&mut collector, &mut (), &Sqlite).unwrap();
+    ///
+    ///     let binds: Vec<(&SqliteBindValueRef<'_>, SqliteType)> = collector.binds().collect();
+    ///     assert!(matches!(binds[0].0, SqliteBindValueRef::I32(1)));
+    ///     assert!(matches!(binds[1].0, SqliteBindValueRef::I64(2)));
+    ///     assert!(matches!(binds[2].0, SqliteBindValueRef::BorrowedString("hi")));
+    ///
+    ///     (qb.finish(), binds.iter().map(|(_, t)| *t).collect())
+    /// }
+    ///
+    /// let query = diesel::select((
+    ///     1_i32.into_sql::<Integer>(),
+    ///     2_i64.into_sql::<BigInt>(),
+    ///     "hi".into_sql::<Text>(),
+    /// ));
+    ///
+    /// let (sql, types) = render(&query);
+    /// assert!(sql.contains('?'));
+    /// assert_eq!(types, [SqliteType::Integer, SqliteType::Long, SqliteType::Text]);
+    /// ```
+    #[cfg(feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes")]
+    pub fn binds(&self) -> impl ExactSizeIterator<Item = (&SqliteBindValueRef<'a>, SqliteType)> {
+        self.binds.iter().map(|(v, t)| (v, *t))
     }
 }
 
@@ -28,13 +87,13 @@ impl SqliteBindCollector<'_> {
 /// It can be constructed via the various `From<T>` implementations
 #[derive(Debug)]
 pub struct SqliteBindValue<'a> {
-    pub(in crate::sqlite) inner: InternalSqliteBindValue<'a>,
+    pub(in crate::sqlite) inner: SqliteBindValueRef<'a>,
 }
 
 impl From<i32> for SqliteBindValue<'_> {
     fn from(i: i32) -> Self {
         Self {
-            inner: InternalSqliteBindValue::I32(i),
+            inner: SqliteBindValueRef::I32(i),
         }
     }
 }
@@ -42,7 +101,7 @@ impl From<i32> for SqliteBindValue<'_> {
 impl From<i64> for SqliteBindValue<'_> {
     fn from(i: i64) -> Self {
         Self {
-            inner: InternalSqliteBindValue::I64(i),
+            inner: SqliteBindValueRef::I64(i),
         }
     }
 }
@@ -50,7 +109,7 @@ impl From<i64> for SqliteBindValue<'_> {
 impl From<f64> for SqliteBindValue<'_> {
     fn from(f: f64) -> Self {
         Self {
-            inner: InternalSqliteBindValue::F64(f),
+            inner: SqliteBindValueRef::F64(f),
         }
     }
 }
@@ -63,7 +122,7 @@ where
         match o {
             Some(v) => v.into(),
             None => Self {
-                inner: InternalSqliteBindValue::Null,
+                inner: SqliteBindValueRef::Null,
             },
         }
     }
@@ -72,7 +131,7 @@ where
 impl<'a> From<&'a str> for SqliteBindValue<'a> {
     fn from(s: &'a str) -> Self {
         Self {
-            inner: InternalSqliteBindValue::BorrowedString(s),
+            inner: SqliteBindValueRef::BorrowedString(s),
         }
     }
 }
@@ -80,7 +139,7 @@ impl<'a> From<&'a str> for SqliteBindValue<'a> {
 impl From<String> for SqliteBindValue<'_> {
     fn from(s: String) -> Self {
         Self {
-            inner: InternalSqliteBindValue::String(s.into_boxed_str()),
+            inner: SqliteBindValueRef::String(s.into_boxed_str()),
         }
     }
 }
@@ -88,7 +147,7 @@ impl From<String> for SqliteBindValue<'_> {
 impl From<Vec<u8>> for SqliteBindValue<'_> {
     fn from(b: Vec<u8>) -> Self {
         Self {
-            inner: InternalSqliteBindValue::Binary(b.into_boxed_slice()),
+            inner: SqliteBindValueRef::Binary(b.into_boxed_slice()),
         }
     }
 }
@@ -96,41 +155,54 @@ impl From<Vec<u8>> for SqliteBindValue<'_> {
 impl<'a> From<&'a [u8]> for SqliteBindValue<'a> {
     fn from(b: &'a [u8]) -> Self {
         Self {
-            inner: InternalSqliteBindValue::BorrowedBinary(b),
+            inner: SqliteBindValueRef::BorrowedBinary(b),
         }
     }
 }
 
+/// The concrete bind value carried by a live [`SqliteBindCollector`].
+///
+/// Distinct from [`OwnedSqliteBindValue`] (the moved snapshot stored in
+/// [`SqliteBindCollectorData`]) in that borrowed and owned string or blob
+/// variants are kept separate, which lets third-party backends read the
+/// collector without cloning transient buffers.
 #[derive(Debug)]
-pub(crate) enum InternalSqliteBindValue<'a> {
+#[diesel_derives::__diesel_public_if(
+    feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
+)]
+pub(crate) enum SqliteBindValueRef<'a> {
+    /// A `TEXT` value that borrows from the query.
     BorrowedString(&'a str),
+    /// A `TEXT` value the collector owns.
     String(Box<str>),
+    /// A `BLOB` value that borrows from the query.
     BorrowedBinary(&'a [u8]),
+    /// A `BLOB` value the collector owns.
     Binary(Box<[u8]>),
+    /// An `INTEGER` value that fits in an `i32`.
     I32(i32),
+    /// An `INTEGER` value that requires an `i64`.
     I64(i64),
+    /// A `REAL` value.
     F64(f64),
+    /// A `NULL` value.
     Null,
 }
 
-impl core::fmt::Display for InternalSqliteBindValue<'_> {
+impl core::fmt::Display for SqliteBindValueRef<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let n = match self {
-            InternalSqliteBindValue::BorrowedString(_) | InternalSqliteBindValue::String(_) => {
-                "Text"
-            }
-            InternalSqliteBindValue::BorrowedBinary(_) | InternalSqliteBindValue::Binary(_) => {
-                "Binary"
-            }
-            InternalSqliteBindValue::I32(_) | InternalSqliteBindValue::I64(_) => "Integer",
-            InternalSqliteBindValue::F64(_) => "Float",
-            InternalSqliteBindValue::Null => "Null",
+            SqliteBindValueRef::BorrowedString(_) | SqliteBindValueRef::String(_) => "Text",
+            SqliteBindValueRef::BorrowedBinary(_) | SqliteBindValueRef::Binary(_) => "Binary",
+            SqliteBindValueRef::I32(_) | SqliteBindValueRef::I64(_) => "Integer",
+            SqliteBindValueRef::F64(_) => "Float",
+            SqliteBindValueRef::Null => "Null",
         };
         f.write_str(n)
     }
 }
 
-impl InternalSqliteBindValue<'_> {
+impl SqliteBindValueRef<'_> {
     #[allow(unsafe_code)] // ffi function calls
     pub(in crate::sqlite) fn result_of(
         self,
@@ -142,36 +214,34 @@ impl InternalSqliteBindValue<'_> {
         // - `ctx` points to valid memory
         unsafe {
             match self {
-                InternalSqliteBindValue::BorrowedString(s) => ffi::sqlite3_result_text(
+                SqliteBindValueRef::BorrowedString(s) => ffi::sqlite3_result_text(
                     ctx,
                     s.as_ptr() as *const libc::c_char,
                     s.len().try_into()?,
                     ffi::SQLITE_TRANSIENT(),
                 ),
-                InternalSqliteBindValue::String(s) => ffi::sqlite3_result_text(
+                SqliteBindValueRef::String(s) => ffi::sqlite3_result_text(
                     ctx,
                     s.as_ptr() as *const libc::c_char,
                     s.len().try_into()?,
                     ffi::SQLITE_TRANSIENT(),
                 ),
-                InternalSqliteBindValue::Binary(b) => ffi::sqlite3_result_blob(
+                SqliteBindValueRef::Binary(b) => ffi::sqlite3_result_blob(
                     ctx,
                     b.as_ptr() as *const libc::c_void,
                     b.len().try_into()?,
                     ffi::SQLITE_TRANSIENT(),
                 ),
-                InternalSqliteBindValue::BorrowedBinary(b) => ffi::sqlite3_result_blob(
+                SqliteBindValueRef::BorrowedBinary(b) => ffi::sqlite3_result_blob(
                     ctx,
                     b.as_ptr() as *const libc::c_void,
                     b.len().try_into()?,
                     ffi::SQLITE_TRANSIENT(),
                 ),
-                InternalSqliteBindValue::I32(i) => ffi::sqlite3_result_int(ctx, i as libc::c_int),
-                InternalSqliteBindValue::I64(l) => ffi::sqlite3_result_int64(ctx, l),
-                InternalSqliteBindValue::F64(d) => {
-                    ffi::sqlite3_result_double(ctx, d as libc::c_double)
-                }
-                InternalSqliteBindValue::Null => ffi::sqlite3_result_null(ctx),
+                SqliteBindValueRef::I32(i) => ffi::sqlite3_result_int(ctx, i as libc::c_int),
+                SqliteBindValueRef::I64(l) => ffi::sqlite3_result_int64(ctx, l),
+                SqliteBindValueRef::F64(d) => ffi::sqlite3_result_double(ctx, d as libc::c_double),
+                SqliteBindValueRef::Null => ffi::sqlite3_result_null(ctx),
             }
         }
         Ok(())
@@ -187,7 +257,7 @@ impl<'a> BindCollector<'a, Sqlite> for SqliteBindCollector<'a> {
         U: crate::serialize::ToSql<T, Sqlite> + ?Sized,
     {
         let value = SqliteBindValue {
-            inner: InternalSqliteBindValue::Null,
+            inner: SqliteBindValueRef::Null,
         };
         let mut to_sql_output = Output::new(value, metadata_lookup);
         let is_null = bind
@@ -198,7 +268,7 @@ impl<'a> BindCollector<'a, Sqlite> for SqliteBindCollector<'a> {
         self.binds.push((
             match is_null {
                 IsNull::No => bind.inner,
-                IsNull::Yes => InternalSqliteBindValue::Null,
+                IsNull::Yes => SqliteBindValueRef::Null,
             },
             metadata,
         ));
@@ -206,41 +276,51 @@ impl<'a> BindCollector<'a, Sqlite> for SqliteBindCollector<'a> {
     }
 
     fn push_null_value(&mut self, metadata: SqliteType) -> QueryResult<()> {
-        self.binds.push((InternalSqliteBindValue::Null, metadata));
+        self.binds.push((SqliteBindValueRef::Null, metadata));
         Ok(())
     }
 }
 
+/// An owned value bound to a SQLite prepared statement.
+///
+/// The readable counterpart to the values a [`SqliteBindCollector`] holds.
 #[derive(Debug, Clone)]
+#[diesel_derives::__diesel_public_if(
+    feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
+)]
 enum OwnedSqliteBindValue {
+    /// A `TEXT` value.
     String(Box<str>),
+    /// A `BLOB` value.
     Binary(Box<[u8]>),
+    /// An `INTEGER` value that fits in an `i32`.
     I32(i32),
+    /// An `INTEGER` value that requires an `i64`.
     I64(i64),
+    /// A `REAL` value.
     F64(f64),
+    /// A `NULL` value.
     Null,
 }
 
-impl<'a> core::convert::From<&InternalSqliteBindValue<'a>> for OwnedSqliteBindValue {
-    fn from(value: &InternalSqliteBindValue<'a>) -> Self {
+impl<'a> core::convert::From<&SqliteBindValueRef<'a>> for OwnedSqliteBindValue {
+    fn from(value: &SqliteBindValueRef<'a>) -> Self {
         match value {
-            InternalSqliteBindValue::String(s) => Self::String(s.clone()),
-            InternalSqliteBindValue::BorrowedString(s) => {
+            SqliteBindValueRef::String(s) => Self::String(s.clone()),
+            SqliteBindValueRef::BorrowedString(s) => {
                 Self::String(String::from(*s).into_boxed_str())
             }
-            InternalSqliteBindValue::Binary(b) => Self::Binary(b.clone()),
-            InternalSqliteBindValue::BorrowedBinary(s) => {
-                Self::Binary(Vec::from(*s).into_boxed_slice())
-            }
-            InternalSqliteBindValue::I32(val) => Self::I32(*val),
-            InternalSqliteBindValue::I64(val) => Self::I64(*val),
-            InternalSqliteBindValue::F64(val) => Self::F64(*val),
-            InternalSqliteBindValue::Null => Self::Null,
+            SqliteBindValueRef::Binary(b) => Self::Binary(b.clone()),
+            SqliteBindValueRef::BorrowedBinary(s) => Self::Binary(Vec::from(*s).into_boxed_slice()),
+            SqliteBindValueRef::I32(val) => Self::I32(*val),
+            SqliteBindValueRef::I64(val) => Self::I64(*val),
+            SqliteBindValueRef::F64(val) => Self::F64(*val),
+            SqliteBindValueRef::Null => Self::Null,
         }
     }
 }
 
-impl core::convert::From<&OwnedSqliteBindValue> for InternalSqliteBindValue<'_> {
+impl core::convert::From<&OwnedSqliteBindValue> for SqliteBindValueRef<'_> {
     fn from(value: &OwnedSqliteBindValue) -> Self {
         match value {
             OwnedSqliteBindValue::String(s) => Self::String(s.clone()),
@@ -253,10 +333,77 @@ impl core::convert::From<&OwnedSqliteBindValue> for InternalSqliteBindValue<'_> 
     }
 }
 
+/// SQLite bind collector data that is movable across threads.
+///
+/// This is the [`Send`] snapshot produced by [`MoveableBindCollector::moveable`]
+/// on a [`SqliteBindCollector`]. Both borrowed and owned string or blob variants
+/// of [`SqliteBindValueRef`] collapse into their [`OwnedSqliteBindValue`]
+/// counterparts, so a caller crossing a thread boundary carries no borrows from
+/// the original query. For a zero-copy view of the live collector see
+/// [`SqliteBindCollector::binds`].
 #[derive(Debug)]
-/// Sqlite bind collector data that is movable across threads
+#[diesel_derives::__diesel_public_if(
+    feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
+)]
 pub struct SqliteBindCollectorData {
+    /// The collected bind values, in the order they appear in the query.
     binds: Vec<(OwnedSqliteBindValue, SqliteType)>,
+}
+
+impl SqliteBindCollectorData {
+    /// Iterate over the collected bind values and their SQLite storage classes,
+    /// in positional order.
+    ///
+    /// The values yielded are the moved [`OwnedSqliteBindValue`] snapshot, so
+    /// this method is safe to call from any thread. For a zero-copy view of the
+    /// live collector see [`SqliteBindCollector::binds`].
+    ///
+    /// # Example
+    ///
+    /// A third-party backend can snapshot the ordered bind values of a typed
+    /// Diesel query and inspect the owned variants:
+    ///
+    /// ```rust
+    /// use diesel::expression::IntoSql;
+    /// use diesel::query_builder::{MoveableBindCollector, QueryFragment};
+    /// use diesel::sql_types::{Binary, Integer, Nullable, Text};
+    /// use diesel::sqlite::{
+    ///     OwnedSqliteBindValue, Sqlite, SqliteBindCollector, SqliteBindCollectorData, SqliteType,
+    /// };
+    ///
+    /// fn snapshot<Q: QueryFragment<Sqlite>>(query: &Q) -> SqliteBindCollectorData {
+    ///     let mut collector = SqliteBindCollector::new();
+    ///     query.collect_binds(&mut collector, &mut (), &Sqlite).unwrap();
+    ///     collector.moveable()
+    /// }
+    ///
+    /// let query = diesel::select((
+    ///     42_i32.into_sql::<Integer>(),
+    ///     "hi".into_sql::<Text>(),
+    ///     vec![1_u8, 2, 3].into_sql::<Binary>(),
+    ///     None::<i32>.into_sql::<Nullable<Integer>>(),
+    /// ));
+    ///
+    /// let data = snapshot(&query);
+    ///
+    /// // Types survive the move.
+    /// let types: Vec<_> = data.binds().map(|(_, t)| t).collect();
+    /// assert_eq!(
+    ///     types,
+    ///     [SqliteType::Integer, SqliteType::Text, SqliteType::Binary, SqliteType::Integer],
+    /// );
+    ///
+    /// // Borrowed variants normalize into their owned counterparts.
+    /// let binds: Vec<_> = data.binds().collect();
+    /// assert!(matches!(binds[0].0, OwnedSqliteBindValue::I32(42)));
+    /// assert!(matches!(binds[1].0, OwnedSqliteBindValue::String(s) if &**s == "hi"));
+    /// assert!(matches!(binds[2].0, OwnedSqliteBindValue::Binary(b) if **b == [1, 2, 3]));
+    /// assert!(matches!(binds[3].0, OwnedSqliteBindValue::Null));
+    /// ```
+    #[cfg(feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes")]
+    pub fn binds(&self) -> impl ExactSizeIterator<Item = (&OwnedSqliteBindValue, SqliteType)> {
+        self.binds.iter().map(|(v, t)| (v, *t))
+    }
 }
 
 impl MoveableBindCollector<Sqlite> for SqliteBindCollector<'_> {
@@ -279,7 +426,7 @@ impl MoveableBindCollector<Sqlite> for SqliteBindCollector<'_> {
         self.binds.extend(
             from.binds
                 .iter()
-                .map(|(bind, tpe)| (InternalSqliteBindValue::from(bind), *tpe)),
+                .map(|(bind, tpe)| (SqliteBindValueRef::from(bind), *tpe)),
         );
     }
 
@@ -293,5 +440,152 @@ impl MoveableBindCollector<Sqlite> for SqliteBindCollector<'_> {
                 .iter()
                 .map(|(b, _)| Box::new(b.clone()) as Box<dyn core::fmt::Debug>),
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        OwnedSqliteBindValue, SqliteBindCollector, SqliteBindCollectorData, SqliteBindValueRef,
+    };
+    use crate::expression::IntoSql;
+    use crate::query_builder::{MoveableBindCollector, QueryFragment};
+    use crate::sql_types::{BigInt, Binary, Double, Integer, Nullable, Text};
+    use crate::sqlite::{Sqlite, SqliteType};
+
+    // Collecting binds needs no connection, the property downstream callers rely on.
+    fn collect<Q: QueryFragment<Sqlite>>(query: Q) -> SqliteBindCollectorData {
+        let mut collector = SqliteBindCollector::new();
+        query
+            .collect_binds(&mut collector, &mut (), &Sqlite)
+            .unwrap();
+        collector.moveable()
+    }
+
+    #[diesel_test_helper::test]
+    fn collected_binds_are_readable_in_positional_order_with_their_type() {
+        let data = collect(crate::select((
+            1_i32.into_sql::<Integer>(),
+            2_i64.into_sql::<BigInt>(),
+            3.5_f64.into_sql::<Double>(),
+            "hello".into_sql::<Text>(),
+            vec![1_u8, 2, 3].into_sql::<Binary>(),
+            None::<i32>.into_sql::<Nullable<Integer>>(),
+        )));
+
+        let types: Vec<_> = data.binds.iter().map(|(_, t)| *t).collect();
+        assert_eq!(
+            types,
+            [
+                SqliteType::Integer,
+                SqliteType::Long,
+                SqliteType::Double,
+                SqliteType::Text,
+                SqliteType::Binary,
+                SqliteType::Integer,
+            ]
+        );
+
+        assert!(matches!(data.binds[0].0, OwnedSqliteBindValue::I32(1)));
+        assert!(matches!(data.binds[1].0, OwnedSqliteBindValue::I64(2)));
+        assert!(matches!(data.binds[2].0, OwnedSqliteBindValue::F64(f) if f == 3.5));
+        assert!(matches!(&data.binds[3].0, OwnedSqliteBindValue::String(s) if &**s == "hello"));
+        assert!(matches!(&data.binds[4].0, OwnedSqliteBindValue::Binary(b) if **b == [1, 2, 3]));
+        assert!(matches!(data.binds[5].0, OwnedSqliteBindValue::Null));
+    }
+
+    // `moveable` must own every internal variant, borrowed and owned alike.
+    #[diesel_test_helper::test]
+    fn moveable_owns_every_internal_variant() {
+        let collector = SqliteBindCollector {
+            binds: vec![
+                (
+                    SqliteBindValueRef::BorrowedString("borrowed"),
+                    SqliteType::Text,
+                ),
+                (SqliteBindValueRef::String("owned".into()), SqliteType::Text),
+                (
+                    SqliteBindValueRef::BorrowedBinary(&[1, 2]),
+                    SqliteType::Binary,
+                ),
+                (
+                    SqliteBindValueRef::Binary(vec![3, 4].into()),
+                    SqliteType::Binary,
+                ),
+                (SqliteBindValueRef::I32(7), SqliteType::Integer),
+                (SqliteBindValueRef::I64(8), SqliteType::Long),
+                (SqliteBindValueRef::F64(9.0), SqliteType::Double),
+                (SqliteBindValueRef::Null, SqliteType::Text),
+            ],
+        };
+
+        let data = collector.moveable();
+        assert!(matches!(&data.binds[0].0, OwnedSqliteBindValue::String(s) if &**s == "borrowed"));
+        assert!(matches!(&data.binds[1].0, OwnedSqliteBindValue::String(s) if &**s == "owned"));
+        assert!(matches!(&data.binds[2].0, OwnedSqliteBindValue::Binary(b) if **b == [1, 2]));
+        assert!(matches!(&data.binds[3].0, OwnedSqliteBindValue::Binary(b) if **b == [3, 4]));
+        assert!(matches!(data.binds[4].0, OwnedSqliteBindValue::I32(7)));
+        assert!(matches!(data.binds[5].0, OwnedSqliteBindValue::I64(8)));
+        assert!(matches!(data.binds[6].0, OwnedSqliteBindValue::F64(f) if f == 9.0));
+        assert!(matches!(data.binds[7].0, OwnedSqliteBindValue::Null));
+    }
+
+    // `SqliteBindCollector::binds` exposes the live enum without cloning
+    // borrowed variants, which is the reason it exists next to `moveable()`.
+    #[cfg(feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes")]
+    #[diesel_test_helper::test]
+    fn binds_iterator_yields_live_ref_without_cloning() {
+        let collector = SqliteBindCollector {
+            binds: vec![
+                (
+                    SqliteBindValueRef::BorrowedString("borrowed"),
+                    SqliteType::Text,
+                ),
+                (
+                    SqliteBindValueRef::BorrowedBinary(&[9, 9]),
+                    SqliteType::Binary,
+                ),
+                (SqliteBindValueRef::I32(1), SqliteType::Integer),
+                (SqliteBindValueRef::Null, SqliteType::Text),
+            ],
+        };
+
+        let seen: Vec<_> = collector.binds().collect();
+        assert_eq!(seen.len(), 4);
+        assert_eq!(seen[0].1, SqliteType::Text);
+        assert_eq!(seen[1].1, SqliteType::Binary);
+        assert!(matches!(
+            seen[0].0,
+            SqliteBindValueRef::BorrowedString("borrowed")
+        ));
+        assert!(matches!(seen[1].0, SqliteBindValueRef::BorrowedBinary(b) if *b == [9, 9]));
+        assert!(matches!(seen[2].0, SqliteBindValueRef::I32(1)));
+        assert!(matches!(seen[3].0, SqliteBindValueRef::Null));
+    }
+
+    // Appending an owned snapshot back into a collector, the reverse conversion.
+    #[diesel_test_helper::test]
+    fn append_bind_data_round_trips_the_owned_snapshot() {
+        let data = collect(crate::select((
+            42_i32.into_sql::<Integer>(),
+            "text".into_sql::<Text>(),
+            None::<i32>.into_sql::<Nullable<Integer>>(),
+        )));
+
+        let mut collector = SqliteBindCollector::new();
+        collector.append_bind_data(&data);
+        let round_tripped = collector.moveable();
+
+        assert!(matches!(
+            round_tripped.binds[0].0,
+            OwnedSqliteBindValue::I32(42)
+        ));
+        assert!(
+            matches!(&round_tripped.binds[1].0, OwnedSqliteBindValue::String(s) if &**s == "text")
+        );
+        assert!(matches!(
+            round_tripped.binds[2].0,
+            OwnedSqliteBindValue::Null
+        ));
     }
 }

--- a/diesel/src/sqlite/connection/functions.rs
+++ b/diesel/src/sqlite/connection/functions.rs
@@ -14,7 +14,7 @@ use crate::serialize::{IsNull, Output, ToSql};
 use crate::sql_types::HasSqlType;
 use crate::sqlite::SqliteFunctionBehavior;
 use crate::sqlite::SqliteValue;
-use crate::sqlite::connection::bind_collector::InternalSqliteBindValue;
+use crate::sqlite::connection::bind_collector::SqliteBindValueRef;
 use crate::sqlite::connection::sqlite_value::OwnedSqliteValue;
 use alloc::boxed::Box;
 use alloc::string::ToString;
@@ -105,20 +105,20 @@ where
 #[allow(clippy::let_unit_value)]
 pub(super) fn process_sql_function_result<RetSqlType, Ret>(
     result: &'_ Ret,
-) -> QueryResult<InternalSqliteBindValue<'_>>
+) -> QueryResult<SqliteBindValueRef<'_>>
 where
     Ret: ToSql<RetSqlType, Sqlite>,
     Sqlite: HasSqlType<RetSqlType>,
 {
     let mut metadata_lookup = ();
     let value = SqliteBindValue {
-        inner: InternalSqliteBindValue::Null,
+        inner: SqliteBindValueRef::Null,
     };
     let mut buf = Output::new(value, &mut metadata_lookup);
     let is_null = result.to_sql(&mut buf).map_err(Error::SerializationError)?;
 
     if let IsNull::Yes = is_null {
-        Ok(InternalSqliteBindValue::Null)
+        Ok(SqliteBindValueRef::Null)
     } else {
         Ok(buf.into_inner().inner)
     }

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -22,8 +22,13 @@ mod trace;
 mod update_hook;
 
 pub use self::authorizer::{AuthorizerContext, AuthorizerDecision};
+#[diesel_derives::__diesel_public_if(
+    feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
+)]
 pub(in crate::sqlite) use self::bind_collector::SqliteBindCollector;
 pub use self::bind_collector::SqliteBindValue;
+#[cfg(feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes")]
+pub use self::bind_collector::{OwnedSqliteBindValue, SqliteBindCollectorData, SqliteBindValueRef};
 pub use self::collation_needed::{CollationNeededContext, SqliteTextRep};
 pub use self::limits::SqliteLimit;
 use self::raw::RawConnection;

--- a/diesel/src/sqlite/connection/stmt.rs
+++ b/diesel/src/sqlite/connection/stmt.rs
@@ -1,5 +1,5 @@
 #![allow(unsafe_code)] // fii code
-use super::bind_collector::{InternalSqliteBindValue, SqliteBindCollector};
+use super::bind_collector::{SqliteBindCollector, SqliteBindValueRef};
 use super::raw::RawConnection;
 use super::sqlite_value::OwnedSqliteValue;
 use crate::connection::Instrumentation;
@@ -79,15 +79,15 @@ impl Statement {
     unsafe fn bind(
         &mut self,
         tpe: SqliteType,
-        value: InternalSqliteBindValue<'_>,
+        value: SqliteBindValueRef<'_>,
         bind_index: i32,
     ) -> QueryResult<Option<NonNull<[u8]>>> {
         let mut ret_ptr = None;
         let result = match (tpe, value) {
-            (_, InternalSqliteBindValue::Null) => unsafe {
+            (_, SqliteBindValueRef::Null) => unsafe {
                 ffi::sqlite3_bind_null(self.inner_statement.as_ptr(), bind_index)
             },
-            (SqliteType::Binary, InternalSqliteBindValue::BorrowedBinary(bytes)) => {
+            (SqliteType::Binary, SqliteBindValueRef::BorrowedBinary(bytes)) => {
                 let n = bytes
                     .len()
                     .try_into()
@@ -102,7 +102,7 @@ impl Statement {
                     )
                 }
             }
-            (SqliteType::Binary, InternalSqliteBindValue::Binary(mut bytes)) => {
+            (SqliteType::Binary, SqliteBindValueRef::Binary(mut bytes)) => {
                 let len = bytes
                     .len()
                     .try_into()
@@ -122,7 +122,7 @@ impl Statement {
                     )
                 }
             }
-            (SqliteType::Text, InternalSqliteBindValue::BorrowedString(bytes)) => {
+            (SqliteType::Text, SqliteBindValueRef::BorrowedString(bytes)) => {
                 let len = bytes
                     .len()
                     .try_into()
@@ -137,7 +137,7 @@ impl Statement {
                     )
                 }
             }
-            (SqliteType::Text, InternalSqliteBindValue::String(bytes)) => {
+            (SqliteType::Text, SqliteBindValueRef::String(bytes)) => {
                 let mut bytes = Box::<[u8]>::from(bytes);
                 let len = bytes
                     .len()
@@ -158,19 +158,19 @@ impl Statement {
                     )
                 }
             }
-            (SqliteType::Float, InternalSqliteBindValue::F64(value))
-            | (SqliteType::Double, InternalSqliteBindValue::F64(value)) => unsafe {
+            (SqliteType::Float, SqliteBindValueRef::F64(value))
+            | (SqliteType::Double, SqliteBindValueRef::F64(value)) => unsafe {
                 ffi::sqlite3_bind_double(
                     self.inner_statement.as_ptr(),
                     bind_index,
                     value as libc::c_double,
                 )
             },
-            (SqliteType::SmallInt, InternalSqliteBindValue::I32(value))
-            | (SqliteType::Integer, InternalSqliteBindValue::I32(value)) => unsafe {
+            (SqliteType::SmallInt, SqliteBindValueRef::I32(value))
+            | (SqliteType::Integer, SqliteBindValueRef::I32(value)) => unsafe {
                 ffi::sqlite3_bind_int(self.inner_statement.as_ptr(), bind_index, value)
             },
-            (SqliteType::Long, InternalSqliteBindValue::I64(value)) => unsafe {
+            (SqliteType::Long, SqliteBindValueRef::I64(value)) => unsafe {
                 ffi::sqlite3_bind_int64(self.inner_statement.as_ptr(), bind_index, value)
             },
             (t, b) => {
@@ -328,7 +328,7 @@ impl<'stmt, 'query> BoundStatement<'stmt, 'query> {
     // This hopefully prevents binary bloat.
     fn bind_buffers(
         &mut self,
-        binds: Vec<(InternalSqliteBindValue<'_>, SqliteType)>,
+        binds: Vec<(SqliteBindValueRef<'_>, SqliteType)>,
     ) -> QueryResult<()> {
         // It is useful to preallocate `binds_to_free` because it
         // - Guarantees that pushing inside it cannot panic, which guarantees the `Drop`
@@ -340,10 +340,10 @@ impl<'stmt, 'query> BoundStatement<'stmt, 'query> {
                 .filter(|&(b, _)| {
                     matches!(
                         b,
-                        InternalSqliteBindValue::BorrowedBinary(_)
-                            | InternalSqliteBindValue::BorrowedString(_)
-                            | InternalSqliteBindValue::String(_)
-                            | InternalSqliteBindValue::Binary(_)
+                        SqliteBindValueRef::BorrowedBinary(_)
+                            | SqliteBindValueRef::BorrowedString(_)
+                            | SqliteBindValueRef::String(_)
+                            | SqliteBindValueRef::Binary(_)
                     )
                 })
                 .count(),
@@ -351,8 +351,7 @@ impl<'stmt, 'query> BoundStatement<'stmt, 'query> {
         for (bind_idx, (bind, tpe)) in (1..).zip(binds) {
             let is_borrowed_bind = matches!(
                 bind,
-                InternalSqliteBindValue::BorrowedString(_)
-                    | InternalSqliteBindValue::BorrowedBinary(_)
+                SqliteBindValueRef::BorrowedString(_) | SqliteBindValueRef::BorrowedBinary(_)
             );
 
             // It's safe to call bind here as:
@@ -402,7 +401,7 @@ impl Drop for BoundStatement<'_, '_> {
             unsafe {
                 // It's always safe to bind null values, as there is no buffer that needs to outlife something
                 self.statement
-                    .bind(SqliteType::Text, InternalSqliteBindValue::Null, idx)
+                    .bind(SqliteType::Text, SqliteBindValueRef::Null, idx)
                     .expect(
                         "Binding a null value should never fail. \
                              If you ever see this error message please open \

--- a/diesel/src/sqlite/mod.rs
+++ b/diesel/src/sqlite/mod.rs
@@ -32,6 +32,10 @@ pub use self::connection::authorizer;
 pub use self::connection::sqlite_blob::SqliteReadOnlyBlob;
 pub use self::connection::{AuthorizerContext, AuthorizerDecision};
 pub use self::connection::{CollationNeededContext, SqliteTextRep};
+#[cfg(feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes")]
+pub use self::connection::{
+    OwnedSqliteBindValue, SqliteBindCollector, SqliteBindCollectorData, SqliteBindValueRef,
+};
 pub use self::connection::{
     SqliteChangeEvent, SqliteChangeOp, SqliteChangeOps, SqliteUpdateRouter,
 };


### PR DESCRIPTION
The SQLite bind collector could be populated but not read back, because `SqliteBindCollectorData.binds` and the `OwnedSqliteBindValue` enum were private. Postgres already allows this through `RawBytesBindCollector<Pg>` under `i-implement-a-third-party-backend-and-opt-into-breaking-changes`, so a third-party backend can render a typed query to placeholder SQL and recover the ordered bind values that go with it. SQLite had no equivalent.

This makes `SqliteBindCollector` (and its `new`), `SqliteBindCollectorData` with a public `binds` field, and `OwnedSqliteBindValue` public under that same feature, via `__diesel_public_if` and feature-gated re-exports. The enum stays exhaustive since its variants cover SQLite's storage classes.

One more note: initially, I had also added tests in the external testing crate actually using this, but I saw that there was no test for the equivalent Pg object, so I decided against it as it would require to run tests with the `i-implement-a-third-party-backend-and-opt-into-breaking-changes` feature. I could go for the other direction, and add add tests for both SQLite and Pg, as you prefer.