### PR TITLE
Raise minimum libsqlite3-sys to 0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 ### Changed
 
 * The minimal supported Rust version is now 1.88.0
+* The minimum supported version of `libsqlite3-sys` is now `0.24.0`, up from `0.17.2`. `0.24.0` is the first release whose bundled SQLite amalgamation (3.38.0) exposes `sqlite3_autovacuum_pages`, which future hook wrappers rely on. Users who pinned to an older `libsqlite3-sys` will need to update.
 * Add support for no-std environments using the SQLite backend
 * Improved documentation and added examples for `filter_target` on `IncompleteOnConflict`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 ### Changed
 
 * The minimal supported Rust version is now 1.88.0
+* The minimum supported version of `libsqlite3-sys` is now `0.24.0`, up from `0.17.2`. `0.24.0` is the first release whose bundled SQLite amalgamation (3.38.0) exposes `sqlite3_autovacuum_pages`, which future hook wrappers rely on. Users who pinned to an older `libsqlite3-sys` will need to update.
 * Add support for no-std environments using the SQLite backend
 * Improved documentation and added examples for `filter_target` on `IncompleteOnConflict`
 * A MySQL or MariaDB read whose requested signedness disagrees with the column's now errors instead of reinterpreting the bits, which affects a signed value read through `Unsigned<T>` and an `UNSIGNED BIGINT` above `i64::MAX` read as `BigInt`

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -51,7 +51,7 @@ version = "~2.3.0"
 path = "../diesel_derives"
 
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
-libsqlite3-sys = { version = ">=0.17.2, <0.38.0", optional = true, features = ["bundled_bindings"] }
+libsqlite3-sys = { version = ">=0.24.0, <0.38.0", optional = true, features = ["bundled_bindings"] }
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
 sqlite-wasm-rs = { version = ">=0.4.0, <0.6.0", optional = true, default-features = false }

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -51,7 +51,7 @@ version = "~2.3.0"
 path = "../diesel_derives"
 
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
-libsqlite3-sys = { version = ">=0.17.2, <0.39.0", optional = true, features = ["bundled_bindings"] }
+libsqlite3-sys = { version = ">=0.24.0, <0.39.0", optional = true, features = ["bundled_bindings"] }
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
 sqlite-wasm-rs = { version = ">=0.4.0, <0.6.0", optional = true, default-features = false }

--- a/diesel/src/sqlite/connection/raw.rs
+++ b/diesel/src/sqlite/connection/raw.rs
@@ -35,7 +35,7 @@ use core::{mem, ptr, slice, str};
 // `sqlite3_db_config()` option codes controlling whether ATTACH may create new
 // database files (ATTACH_CREATE) or open them in write mode (ATTACH_WRITE).
 // Introduced in SQLite 3.49.0 / `libsqlite3-sys` 0.35.0, but Diesel supports
-// `libsqlite3-sys` >= 0.17.2, so we define them here to build against any
+// `libsqlite3-sys` >= 0.24.0, so we define them here to build against any
 // supported version. On an older linked SQLite the `sqlite3_db_config()` call
 // fails at runtime, which callers already handle.
 pub(super) const SQLITE_DBCONFIG_ENABLE_ATTACH_CREATE: i32 = 1020;

--- a/diesel/src/sqlite/connection/raw.rs
+++ b/diesel/src/sqlite/connection/raw.rs
@@ -33,7 +33,7 @@ use core::{mem, ptr, slice, str};
 // `sqlite3_db_config()` option codes controlling whether ATTACH may create new
 // database files (ATTACH_CREATE) or open them in write mode (ATTACH_WRITE).
 // Introduced in SQLite 3.49.0 / `libsqlite3-sys` 0.35.0, but Diesel supports
-// `libsqlite3-sys` >= 0.17.2, so we define them here to build against any
+// `libsqlite3-sys` >= 0.24.0, so we define them here to build against any
 // supported version. On an older linked SQLite the `sqlite3_db_config()` call
 // fails at runtime, which callers already handle.
 pub(super) const SQLITE_DBCONFIG_ENABLE_ATTACH_CREATE: i32 = 1020;

--- a/diesel_compile_tests/tests/Cargo.toml
+++ b/diesel_compile_tests/tests/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2024"
 [dependencies]
 diesel = { version = "2.0.0", default-features = false, features = ["extras", "sqlite", "postgres", "mysql" , "mariadb", "with-deprecated"], path = "../../diesel" }
 # Pin Diesel's declared minimum so the compile tests cover it.
-libsqlite3-sys = "=0.17.2"
+libsqlite3-sys = "=0.24.0"
 
 [workspace]


### PR DESCRIPTION
Prerequisite for wrapping `sqlite3_autovacuum_pages`, mentioned by @weiznich in a [comment in PR #5098](https://github.com/diesel-rs/diesel/pull/5098#pullrequestreview-4647852559). That function was added in SQLite `3.37.0` (2021-11) and is absent from the bundled amalgamation of every `libsqlite3-sys` older than `0.24.0` (the first release to ship SQLite `3.38.0`). Bumping the floor here lets the follow-up `on_autovacuum` PR use the `ffi::` alias like every other hook wrapper in the crate.