### PR TITLE
feat: Optionally run migrations without generating schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 * Added support for generating matching Rust enums for database enums in Diesel-CLI
 * Added `#[diesel_async]` attribute to `#[derive(MultiConnection)]` to support async MultiConnections. 
 * Exposed the SQLite bind values collected for a query under the `i-implement-a-third-party-backend-and-opt-into-breaking-changes` feature, via public `SqliteBindCollector` and `SqliteBindCollectorData`, each with a `binds()` iterator over the live values and the owned snapshot respectively, plus the `SqliteBindValueRef` and `OwnedSqliteBindValue` enums.
+* Added `--no-schema` CLI flag to the `migration run` subcommand
 
 ### Fixed
 

--- a/diesel_cli/src/migrations/mod.rs
+++ b/diesel_cli/src/migrations/mod.rs
@@ -33,7 +33,11 @@ pub enum MigrationFormat {
 #[derive(Debug, Subcommand)]
 pub enum MigrationCommand {
     /// Runs all pending migrations.
-    Run,
+    Run {
+        /// Do not regenerate `schema.rs` during migration.
+        #[arg(long = "no-schema", action = ArgAction::SetTrue)]
+        no_schema: bool,
+    },
 
     /// Reverts the specified migrations.
     Revert {
@@ -200,12 +204,16 @@ pub(super) fn run_migration_command(
     migration_dir: Option<PathBuf>,
 ) -> Result<(), crate::errors::Error> {
     match args.command {
-        MigrationCommand::Run => {
+        MigrationCommand::Run { no_schema } => {
             let (mut conn, dir) =
                 conn_and_migration_dir(migration_dir, database_url.clone(), config_file.clone())?;
 
             run_migrations_with_output(&mut conn, dir)?;
-            regenerate_schema_if_file_specified(config_file, database_url, locked_schema)?;
+            if no_schema {
+                // No schema generated
+            } else {
+                regenerate_schema_if_file_specified(config_file, database_url, locked_schema)?;
+            }
         }
         MigrationCommand::Revert { all, number } => {
             let (mut conn, dir) =

--- a/diesel_cli/src/migrations/mod.rs
+++ b/diesel_cli/src/migrations/mod.rs
@@ -34,7 +34,7 @@ pub enum MigrationFormat {
 pub enum MigrationCommand {
     /// Runs all pending migrations.
     Run {
-        /// Do not regenerate `schema.rs` during migration.
+        /// Do not regenerate `schema.rs` while running the migrations.
         #[arg(long = "no-schema", action = ArgAction::SetTrue)]
         no_schema: bool,
     },

--- a/diesel_cli/src/migrations/mod.rs
+++ b/diesel_cli/src/migrations/mod.rs
@@ -209,9 +209,7 @@ pub(super) fn run_migration_command(
                 conn_and_migration_dir(migration_dir, database_url.clone(), config_file.clone())?;
 
             run_migrations_with_output(&mut conn, dir)?;
-            if no_schema {
-                // No schema generated
-            } else {
+            if !no_schema {
                 regenerate_schema_if_file_specified(config_file, database_url, locked_schema)?;
             }
         }

--- a/diesel_cli/tests/migration_run.rs
+++ b/diesel_cli/tests/migration_run.rs
@@ -423,6 +423,43 @@ fn migration_run_updates_schema_if_config_present() {
 }
 
 #[test]
+fn migration_run_ignores_schema_if_config_present_with_no_schema_cli_flag() {
+    let p = project("migration_run_ignores_schema_with_cli_flag")
+        .folder("migrations")
+        .file(
+            "diesel.toml",
+            r#"
+            [print_schema]
+            file = "src/my_schema.rs"
+            "#,
+        )
+        .build();
+
+    // Make sure the project is setup
+    p.command("setup").run();
+
+    p.create_migration(
+        "12345_create_users_table",
+        "CREATE TABLE users (id INTEGER PRIMARY KEY)",
+        Some("DROP TABLE users"),
+        None,
+    );
+
+    assert!(!p.has_file("src/my_schema.rs"));
+
+    let result = p.command("migration").arg("run").arg("--no-schema").run();
+
+    assert!(result.is_success(), "Result was unsuccessful {:?}", result);
+    assert!(
+        result.stdout().contains("Running migration 12345"),
+        "Unexpected stdout {}",
+        result.stdout()
+    );
+    // Schema still doesn't exist.
+    assert!(!p.has_file("src/my_schema.rs"));
+}
+
+#[test]
 fn migrations_can_be_run_with_no_config_file() {
     let p = project("migration_run_no_config_file")
         .folder("migrations")

--- a/diesel_cli/tests/snapshots/tests__help_snapshots__migration_run_help.snap
+++ b/diesel_cli/tests/snapshots/tests__help_snapshots__migration_run_help.snap
@@ -11,7 +11,7 @@ Options:
           Specifies the database URL to connect to. Falls back to the DATABASE_URL environment variable if unspecified
 
       --no-schema
-          Do not regenerate `schema.rs` during migration
+          Do not regenerate `schema.rs` while running the migrations
 
       --config-file <CONFIG_FILE>
           The location of the configuration file to use. Falls back to the `DIESEL_CONFIG_FILE` environment variable if unspecified. Defaults to `diesel.toml` in your project root. See diesel.rs/guides/configuring-diesel-cli for documentation on this file

--- a/diesel_cli/tests/snapshots/tests__help_snapshots__migration_run_help.snap
+++ b/diesel_cli/tests/snapshots/tests__help_snapshots__migration_run_help.snap
@@ -10,6 +10,9 @@ Options:
       --database-url <DATABASE_URL>
           Specifies the database URL to connect to. Falls back to the DATABASE_URL environment variable if unspecified
 
+      --no-schema
+          Do not regenerate `schema.rs` during migration
+
       --config-file <CONFIG_FILE>
           The location of the configuration file to use. Falls back to the `DIESEL_CONFIG_FILE` environment variable if unspecified. Defaults to `diesel.toml` in your project root. See diesel.rs/guides/configuring-diesel-cli for documentation on this file
 


### PR DESCRIPTION
for use in situations where both steps should run strictly separated. This allows, for example, to keep a schema file path configured in `diesel.toml` without actually overwriting it during database/schema generation in favor of writing the schema to a user-defined location. This simplifies diffing outputs and working with schemas in read-only environments.

<!-- 
Please provide a short brief summary description of your change here. 
Also make sure that your code passes all tests and style checks. 
Checkout the `CONTRIBUTING.md` file in the root of the repository for running these checks locally.
It's also fine to use the CI setup for running these tests, but in this case please indicate that your PR 
is not ready for review yet by marking it as DRAFT until it is ready.

If you submit a notable change please ensure to include it into the CHANGELOG.md file in
the root of the repository.

Also make sure to follow the projects guide lines about the usage of LLM's and AI agents as outlined
in the CONTRIBUTING.md file in the root of the repository.
-->

- [x] I checked for similar changes and make sure to reference them
- [x] I included a changelog entry for relevant new features or changes
