### PR TITLE
Emit `#[doc(hidden)]` for undocumented `table!` and `view!` items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 * The minimal supported Rust version is now 1.88.0
 * Add support for no-std environments using the SQLite backend
 * Improved documentation and added examples for `filter_target` on `IncompleteOnConflict`
+* The `table!` and `view!` macros now mark the generated schema module and column structs `#[doc(hidden)]` when the caller supplied no doc comment, so the generated output compiles cleanly under `missing_docs`. Documented items keep the caller's docs and stay visible.
 
 ## [2.3.11] 2026-07-10
 

--- a/diesel_derives/Cargo.toml
+++ b/diesel_derives/Cargo.toml
@@ -34,6 +34,9 @@ proc-macro = true
 [[test]]
 name = "tests"
 
+[[test]]
+name = "missing_docs"
+
 [features]
 default = []
 nightly = ["proc-macro2/nightly", "diesel_attribute_parser/nightly"]

--- a/diesel_derives/src/table.rs
+++ b/diesel_derives/src/table.rs
@@ -15,6 +15,15 @@ fn has_cfg_attributes(column: &ColumnDef) -> bool {
     column.meta.iter().any(|attr| attr.path().is_ident("cfg"))
 }
 
+/// Emits `#[doc(hidden)]` unless the caller documented the item.
+fn doc_hidden_unless_documented(meta: &[syn::Attribute]) -> TokenStream {
+    if meta.iter().any(|attr| attr.path().is_ident("doc")) {
+        TokenStream::new()
+    } else {
+        quote::quote!(#[doc(hidden)])
+    }
+}
+
 struct CfgGroup<'a> {
     cfg_attrs: Vec<&'a syn::Attribute>,
     columns: Vec<&'a ColumnDef>,
@@ -550,8 +559,10 @@ fn expand(input: TableDecl, kind: QuerySourceMacroKind) -> TokenStream {
 
     let imports_for_column_module = imports.iter().map(fix_import_for_submodule);
 
+    let module_doc_hidden = doc_hidden_unless_documented(meta);
     quote::quote! {
         #(#meta)*
+        #module_doc_hidden
         #[allow(unused_imports, dead_code, unreachable_pub, unused_qualifications)]
         pub mod #table_name {
             const _: () = {
@@ -1091,8 +1102,10 @@ fn expand_column_def(
         }
     };
 
+    let column_doc_hidden = doc_hidden_unless_documented(meta);
     quote::quote_spanned! {span=>
         #(#meta)*
+        #column_doc_hidden
         #[allow(non_camel_case_types, dead_code)]
         #[derive(Debug, Clone, Copy, diesel::query_builder::QueryId, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
         pub struct #column_name;

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__table_1 (postgres).snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__table_1 (postgres).snap
@@ -4,6 +4,7 @@ expression: out
 info:
   input: "table! {\n    users { id -> Integer, name -> Text, }\n}\n"
 ---
+#[doc(hidden)]
 #[allow(unused_imports, dead_code, unreachable_pub, unused_qualifications)]
 pub mod users {
     const _: () = {
@@ -539,6 +540,7 @@ pub mod users {
         }
         impl diesel::SelectableExpression<table> for star {}
         impl diesel::AppearsOnTable<table> for star {}
+        #[doc(hidden)]
         #[allow(non_camel_case_types, dead_code)]
         #[derive(
             Debug,
@@ -793,6 +795,7 @@ pub mod users {
             type Table = super::table;
             const NAME: &'static str = "id";
         }
+        #[doc(hidden)]
         #[allow(non_camel_case_types, dead_code)]
         #[derive(
             Debug,

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__table_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__table_1.snap
@@ -4,6 +4,7 @@ expression: out
 info:
   input: "table! {\n    users { id -> Integer, name -> Text, }\n}\n"
 ---
+#[doc(hidden)]
 #[allow(unused_imports, dead_code, unreachable_pub, unused_qualifications)]
 pub mod users {
     const _: () = {
@@ -483,6 +484,7 @@ pub mod users {
         }
         impl diesel::SelectableExpression<table> for star {}
         impl diesel::AppearsOnTable<table> for star {}
+        #[doc(hidden)]
         #[allow(non_camel_case_types, dead_code)]
         #[derive(
             Debug,
@@ -716,6 +718,7 @@ pub mod users {
             type Table = super::table;
             const NAME: &'static str = "id";
         }
+        #[doc(hidden)]
         #[allow(non_camel_case_types, dead_code)]
         #[derive(
             Debug,

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__table_with_column_feature_gate (postgres).snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__table_with_column_feature_gate (postgres).snap
@@ -4,6 +4,7 @@ expression: out
 info:
   input: "table! {\n    users { id -> Integer, name -> Text, #[cfg(feature = \"chrono\")] created_at ->\n    Timestamp, }\n}\n"
 ---
+#[doc(hidden)]
 #[allow(unused_imports, dead_code, unreachable_pub, unused_qualifications)]
 pub mod users {
     const _: () = {
@@ -551,6 +552,7 @@ pub mod users {
         }
         impl diesel::SelectableExpression<table> for star {}
         impl diesel::AppearsOnTable<table> for star {}
+        #[doc(hidden)]
         #[allow(non_camel_case_types, dead_code)]
         #[derive(
             Debug,
@@ -805,6 +807,7 @@ pub mod users {
             type Table = super::table;
             const NAME: &'static str = "id";
         }
+        #[doc(hidden)]
         #[allow(non_camel_case_types, dead_code)]
         #[derive(
             Debug,
@@ -1004,6 +1007,7 @@ pub mod users {
             const NAME: &'static str = "name";
         }
         #[cfg(feature = "chrono")]
+        #[doc(hidden)]
         #[allow(non_camel_case_types, dead_code)]
         #[derive(
             Debug,

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__table_with_docs (postgres).snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__table_with_docs (postgres).snap
@@ -2,15 +2,15 @@
 source: diesel_derives/src/tests/mod.rs
 expression: out
 info:
-  input: "table! {\n    users { id -> Integer, name -> Text, #[cfg(feature = \"chrono\")] created_at ->\n    Timestamp, }\n}\n"
+  input: "table! {\n    #[doc = r\" The users of the application.\"] users { #[doc = r\" The primary key.\"] id\n    -> Integer, #[doc = r\" The user's display name.\"] name -> Text, }\n}\n"
 ---
-#[doc(hidden)]
+/// The users of the application.
 #[allow(unused_imports, dead_code, unreachable_pub, unused_qualifications)]
 pub mod users {
     const _: () = {
         assert!(
-            3u16 <= diesel::internal::table_macro::MAX_COLUMN_COUNT,
-            "`users` contains 3 columns, which is more than the supported maximum number of columns\nTry enabling a crate level feature to support more columns"
+            2u16 <= diesel::internal::table_macro::MAX_COLUMN_COUNT,
+            "`users` contains 2 columns, which is more than the supported maximum number of columns\nTry enabling a crate level feature to support more columns"
         );
     };
     use ::diesel;
@@ -26,18 +26,11 @@ pub mod users {
     pub mod dsl {
         pub use super::columns::id;
         pub use super::columns::name;
-        #[cfg(feature = "chrono")]
-        pub use super::columns::created_at;
         pub use super::table as users;
     }
     #[allow(non_upper_case_globals, dead_code)]
     #[doc = concat!("A tuple of all of the columns on this", "table")]
-    pub const all_columns: AllColumns = (
-        id,
-        name,
-        #[cfg(feature = "chrono")]
-        created_at,
-    );
+    pub const all_columns: AllColumns = (id, name);
     #[allow(non_camel_case_types)]
     #[derive(
         Debug,
@@ -67,14 +60,9 @@ pub mod users {
             star
         }
     }
-    #[cfg(all(not(feature = "chrono")))]
     #[allow(non_camel_case_types, dead_code)]
     #[doc = concat!("The tuple of all column structs on this ", "table")]
     pub type AllColumns = (id, name);
-    #[cfg(all(feature = "chrono"))]
-    #[allow(non_camel_case_types, dead_code)]
-    #[doc = concat!("The tuple of all column structs on this ", "table")]
-    pub type AllColumns = (id, name, created_at);
     #[doc = concat!("The SQL type of all of the columns on this ", "table")]
     pub type SqlType = <AllColumns as diesel::Expression>::SqlType;
     #[doc = concat!("Helper type for representing a boxed query from this ", "table")]
@@ -429,12 +417,68 @@ pub mod users {
             (__diesel_internal_rhs, __diesel_internal_on_clause)
         }
     }
-
-
-
-
-
-
+    impl<S> diesel::JoinTo<diesel::query_builder::Only<S>> for table
+    where
+        diesel::query_builder::Only<S>: diesel::JoinTo<table>,
+    {
+        type FromClause = diesel::query_builder::Only<S>;
+        type OnClause = <diesel::query_builder::Only<
+            S,
+        > as diesel::JoinTo<table>>::OnClause;
+        fn join_target(
+            __diesel_internal_rhs: diesel::query_builder::Only<S>,
+        ) -> (Self::FromClause, Self::OnClause) {
+            let (_, __diesel_internal_on_clause) = diesel::query_builder::Only::<
+                S,
+            >::join_target(table);
+            (__diesel_internal_rhs, __diesel_internal_on_clause)
+        }
+    }
+    impl diesel::query_source::AppearsInFromClause<diesel::query_builder::Only<table>>
+    for table {
+        type Count = diesel::query_source::Once;
+    }
+    impl diesel::query_source::AppearsInFromClause<table>
+    for diesel::query_builder::Only<table> {
+        type Count = diesel::query_source::Once;
+    }
+    impl<S, TSM> diesel::JoinTo<diesel::query_builder::Tablesample<S, TSM>> for table
+    where
+        diesel::query_builder::Tablesample<S, TSM>: diesel::JoinTo<table>,
+        TSM: diesel::internal::table_macro::TablesampleMethod,
+    {
+        type FromClause = diesel::query_builder::Tablesample<S, TSM>;
+        type OnClause = <diesel::query_builder::Tablesample<
+            S,
+            TSM,
+        > as diesel::JoinTo<table>>::OnClause;
+        fn join_target(
+            __diesel_internal_rhs: diesel::query_builder::Tablesample<S, TSM>,
+        ) -> (Self::FromClause, Self::OnClause) {
+            let (_, __diesel_internal_on_clause) = diesel::query_builder::Tablesample::<
+                S,
+                TSM,
+            >::join_target(table);
+            (__diesel_internal_rhs, __diesel_internal_on_clause)
+        }
+    }
+    impl<
+        TSM,
+    > diesel::query_source::AppearsInFromClause<
+        diesel::query_builder::Tablesample<table, TSM>,
+    > for table
+    where
+        TSM: diesel::internal::table_macro::TablesampleMethod,
+    {
+        type Count = diesel::query_source::Once;
+    }
+    impl<TSM> diesel::query_source::AppearsInFromClause<table>
+    for diesel::query_builder::Tablesample<table, TSM>
+    where
+        TSM: diesel::internal::table_macro::TablesampleMethod,
+    {
+        type Count = diesel::query_source::Once;
+    }
     #[doc = concat!("Contains all of the columns of this ", "table")]
     pub mod columns {
         use ::diesel;
@@ -496,7 +540,7 @@ pub mod users {
         }
         impl diesel::SelectableExpression<table> for star {}
         impl diesel::AppearsOnTable<table> for star {}
-        #[doc(hidden)]
+        /// The primary key.
         #[allow(non_camel_case_types, dead_code)]
         #[derive(
             Debug,
@@ -722,15 +766,36 @@ pub mod users {
                 )
             }
         }
-
-
-
-
+        impl diesel::query_source::AppearsInFromClause<
+            diesel::query_builder::Only<super::table>,
+        > for id {
+            type Count = diesel::query_source::Once;
+        }
+        impl diesel::SelectableExpression<diesel::query_builder::Only<super::table>>
+        for id {}
+        impl<
+            TSM,
+        > diesel::query_source::AppearsInFromClause<
+            diesel::query_builder::Tablesample<super::table, TSM>,
+        > for id
+        where
+            TSM: diesel::internal::table_macro::TablesampleMethod,
+        {
+            type Count = diesel::query_source::Once;
+        }
+        impl<
+            TSM,
+        > diesel::SelectableExpression<
+            diesel::query_builder::Tablesample<super::table, TSM>,
+        > for id
+        where
+            TSM: diesel::internal::table_macro::TablesampleMethod,
+        {}
         impl diesel::query_source::Column for id {
             type Table = super::table;
             const NAME: &'static str = "id";
         }
-        #[doc(hidden)]
+        /// The user's display name.
         #[allow(non_camel_case_types, dead_code)]
         #[derive(
             Debug,
@@ -900,258 +965,40 @@ pub mod users {
                 self.eq(__diesel_internal_rhs)
             }
         }
-
-
-
-
+        impl diesel::query_source::AppearsInFromClause<
+            diesel::query_builder::Only<super::table>,
+        > for name {
+            type Count = diesel::query_source::Once;
+        }
+        impl diesel::SelectableExpression<diesel::query_builder::Only<super::table>>
+        for name {}
+        impl<
+            TSM,
+        > diesel::query_source::AppearsInFromClause<
+            diesel::query_builder::Tablesample<super::table, TSM>,
+        > for name
+        where
+            TSM: diesel::internal::table_macro::TablesampleMethod,
+        {
+            type Count = diesel::query_source::Once;
+        }
+        impl<
+            TSM,
+        > diesel::SelectableExpression<
+            diesel::query_builder::Tablesample<super::table, TSM>,
+        > for name
+        where
+            TSM: diesel::internal::table_macro::TablesampleMethod,
+        {}
         impl diesel::query_source::Column for name {
             type Table = super::table;
             const NAME: &'static str = "name";
-        }
-        #[cfg(feature = "chrono")]
-        #[doc(hidden)]
-        #[allow(non_camel_case_types, dead_code)]
-        #[derive(
-            Debug,
-            Clone,
-            Copy,
-            diesel::query_builder::QueryId,
-            Default,
-            PartialEq,
-            Eq,
-            PartialOrd,
-            Ord,
-            Hash
-        )]
-        pub struct created_at;
-        #[cfg(feature = "chrono")]
-        impl diesel::expression::Expression for created_at {
-            type SqlType = Timestamp;
-        }
-        #[cfg(feature = "chrono")]
-        impl<DB> diesel::query_builder::QueryFragment<DB> for created_at
-        where
-            DB: diesel::backend::Backend,
-            diesel::internal::table_macro::StaticQueryFragmentInstance<
-                table,
-            >: diesel::query_builder::QueryFragment<DB>,
-        {
-            #[allow(non_snake_case)]
-            fn walk_ast<'b>(
-                &'b self,
-                mut __diesel_internal_out: diesel::query_builder::AstPass<'_, 'b, DB>,
-            ) -> diesel::result::QueryResult<()> {
-                if !__diesel_internal_out.should_skip_from() {
-                    const FROM_CLAUSE: diesel::internal::table_macro::StaticQueryFragmentInstance<
-                        table,
-                    > = diesel::internal::table_macro::StaticQueryFragmentInstance::new();
-                    FROM_CLAUSE.walk_ast(__diesel_internal_out.reborrow())?;
-                    __diesel_internal_out.push_sql(".");
-                }
-                __diesel_internal_out.push_identifier("created_at")
-            }
-        }
-        #[cfg(feature = "chrono")]
-        impl diesel::SelectableExpression<super::table> for created_at {}
-        #[cfg(feature = "chrono")]
-        impl<
-            __StmtKind,
-        > diesel::SelectableExpression<
-            diesel::internal::table_macro::returning::ReturningQuerySource<
-                __StmtKind,
-                super::table,
-            >,
-        > for created_at {}
-        #[cfg(feature = "chrono")]
-        impl<QS> diesel::AppearsOnTable<QS> for created_at
-        where
-            QS: diesel::query_source::AppearsInFromClause<
-                super::table,
-                Count = diesel::query_source::Once,
-            >,
-        {}
-        #[cfg(feature = "chrono")]
-        impl<
-            Left,
-            Right,
-        > diesel::SelectableExpression<
-            diesel::internal::table_macro::Join<
-                Left,
-                Right,
-                diesel::internal::table_macro::LeftOuter,
-            >,
-        > for created_at
-        where
-            created_at: diesel::AppearsOnTable<
-                diesel::internal::table_macro::Join<
-                    Left,
-                    Right,
-                    diesel::internal::table_macro::LeftOuter,
-                >,
-            >,
-            Self: diesel::SelectableExpression<Left>,
-            Right: diesel::query_source::AppearsInFromClause<
-                    super::table,
-                    Count = diesel::query_source::Never,
-                > + diesel::query_source::QuerySource,
-            Left: diesel::query_source::QuerySource,
-        {}
-        #[cfg(feature = "chrono")]
-        impl<
-            Left,
-            Right,
-        > diesel::SelectableExpression<
-            diesel::internal::table_macro::Join<
-                Left,
-                Right,
-                diesel::internal::table_macro::Inner,
-            >,
-        > for created_at
-        where
-            created_at: diesel::AppearsOnTable<
-                diesel::internal::table_macro::Join<
-                    Left,
-                    Right,
-                    diesel::internal::table_macro::Inner,
-                >,
-            >,
-            Left: diesel::query_source::AppearsInFromClause<super::table>
-                + diesel::query_source::QuerySource,
-            Right: diesel::query_source::AppearsInFromClause<super::table>
-                + diesel::query_source::QuerySource,
-            (
-                Left::Count,
-                Right::Count,
-            ): diesel::internal::table_macro::Pick<Left, Right>,
-            Self: diesel::SelectableExpression<
-                <(
-                    Left::Count,
-                    Right::Count,
-                ) as diesel::internal::table_macro::Pick<Left, Right>>::Selection,
-            >,
-        {}
-        #[cfg(feature = "chrono")]
-        impl<
-            Join,
-            On,
-        > diesel::SelectableExpression<diesel::internal::table_macro::JoinOn<Join, On>>
-        for created_at
-        where
-            created_at: diesel::SelectableExpression<Join>
-                + diesel::AppearsOnTable<
-                    diesel::internal::table_macro::JoinOn<Join, On>,
-                >,
-        {}
-        #[cfg(feature = "chrono")]
-        impl<
-            From,
-        > diesel::SelectableExpression<
-            diesel::internal::table_macro::SelectStatement<
-                diesel::internal::table_macro::FromClause<From>,
-            >,
-        > for created_at
-        where
-            From: diesel::query_source::QuerySource,
-            created_at: diesel::SelectableExpression<From>
-                + diesel::AppearsOnTable<
-                    diesel::internal::table_macro::SelectStatement<
-                        diesel::internal::table_macro::FromClause<From>,
-                    >,
-                >,
-        {}
-        #[cfg(feature = "chrono")]
-        impl<__GB> diesel::expression::ValidGrouping<__GB> for created_at
-        where
-            __GB: diesel::expression::IsContainedInGroupBy<
-                created_at,
-                Output = diesel::expression::is_contained_in_group_by::Yes,
-            >,
-        {
-            type IsAggregate = diesel::expression::is_aggregate::Yes;
-        }
-        #[cfg(feature = "chrono")]
-        impl diesel::expression::ValidGrouping<()> for created_at {
-            type IsAggregate = diesel::expression::is_aggregate::No;
-        }
-        #[cfg(feature = "chrono")]
-        impl diesel::expression::IsContainedInGroupBy<created_at> for created_at {
-            type Output = diesel::expression::is_contained_in_group_by::Yes;
-        }
-        #[cfg(feature = "chrono")]
-        impl<T> diesel::EqAll<T> for created_at
-        where
-            T: diesel::expression::AsExpression<Timestamp>,
-            diesel::dsl::Eq<
-                created_at,
-                T::Expression,
-            >: diesel::Expression<SqlType = diesel::sql_types::Bool>,
-        {
-            type Output = diesel::dsl::Eq<Self, T::Expression>;
-            fn eq_all(self, __diesel_internal_rhs: T) -> Self::Output {
-                use diesel::expression_methods::ExpressionMethods;
-                self.eq(__diesel_internal_rhs)
-            }
-        }
-        #[cfg(feature = "chrono")]
-        impl<Rhs> ::core::ops::Add<Rhs> for created_at
-        where
-            Rhs: diesel::expression::AsExpression<
-                <<created_at as diesel::Expression>::SqlType as diesel::sql_types::ops::Add>::Rhs,
-            >,
-        {
-            type Output = diesel::internal::table_macro::ops::Add<Self, Rhs::Expression>;
-            fn add(self, __diesel_internal_rhs: Rhs) -> Self::Output {
-                diesel::internal::table_macro::ops::Add::new(
-                    self,
-                    __diesel_internal_rhs.as_expression(),
-                )
-            }
-        }
-        #[cfg(feature = "chrono")]
-        impl<Rhs> ::core::ops::Sub<Rhs> for created_at
-        where
-            Rhs: diesel::expression::AsExpression<
-                <<created_at as diesel::Expression>::SqlType as diesel::sql_types::ops::Sub>::Rhs,
-            >,
-        {
-            type Output = diesel::internal::table_macro::ops::Sub<Self, Rhs::Expression>;
-            fn sub(self, __diesel_internal_rhs: Rhs) -> Self::Output {
-                diesel::internal::table_macro::ops::Sub::new(
-                    self,
-                    __diesel_internal_rhs.as_expression(),
-                )
-            }
-        }
-
-
-
-
-        #[cfg(feature = "chrono")]
-        impl diesel::query_source::Column for created_at {
-            type Table = super::table;
-            const NAME: &'static str = "created_at";
         }
         impl diesel::expression::IsContainedInGroupBy<id> for name {
             type Output = diesel::expression::is_contained_in_group_by::No;
         }
         impl diesel::expression::IsContainedInGroupBy<name> for id {
             type Output = diesel::expression::is_contained_in_group_by::Yes;
-        }
-        #[cfg(feature = "chrono")]
-        impl diesel::expression::IsContainedInGroupBy<id> for created_at {
-            type Output = diesel::expression::is_contained_in_group_by::No;
-        }
-        #[cfg(feature = "chrono")]
-        impl diesel::expression::IsContainedInGroupBy<created_at> for id {
-            type Output = diesel::expression::is_contained_in_group_by::Yes;
-        }
-        #[cfg(feature = "chrono")]
-        impl diesel::expression::IsContainedInGroupBy<name> for created_at {
-            type Output = diesel::expression::is_contained_in_group_by::No;
-        }
-        #[cfg(feature = "chrono")]
-        impl diesel::expression::IsContainedInGroupBy<created_at> for name {
-            type Output = diesel::expression::is_contained_in_group_by::No;
         }
     }
 }

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__table_with_docs.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__table_with_docs.snap
@@ -2,15 +2,15 @@
 source: diesel_derives/src/tests/mod.rs
 expression: out
 info:
-  input: "table! {\n    users { id -> Integer, name -> Text, #[cfg(feature = \"chrono\")] created_at ->\n    Timestamp, }\n}\n"
+  input: "table! {\n    #[doc = r\" The users of the application.\"] users { #[doc = r\" The primary key.\"] id\n    -> Integer, #[doc = r\" The user's display name.\"] name -> Text, }\n}\n"
 ---
-#[doc(hidden)]
+/// The users of the application.
 #[allow(unused_imports, dead_code, unreachable_pub, unused_qualifications)]
 pub mod users {
     const _: () = {
         assert!(
-            3u16 <= diesel::internal::table_macro::MAX_COLUMN_COUNT,
-            "`users` contains 3 columns, which is more than the supported maximum number of columns\nTry enabling a crate level feature to support more columns"
+            2u16 <= diesel::internal::table_macro::MAX_COLUMN_COUNT,
+            "`users` contains 2 columns, which is more than the supported maximum number of columns\nTry enabling a crate level feature to support more columns"
         );
     };
     use ::diesel;
@@ -26,18 +26,11 @@ pub mod users {
     pub mod dsl {
         pub use super::columns::id;
         pub use super::columns::name;
-        #[cfg(feature = "chrono")]
-        pub use super::columns::created_at;
         pub use super::table as users;
     }
     #[allow(non_upper_case_globals, dead_code)]
     #[doc = concat!("A tuple of all of the columns on this", "table")]
-    pub const all_columns: AllColumns = (
-        id,
-        name,
-        #[cfg(feature = "chrono")]
-        created_at,
-    );
+    pub const all_columns: AllColumns = (id, name);
     #[allow(non_camel_case_types)]
     #[derive(
         Debug,
@@ -67,14 +60,9 @@ pub mod users {
             star
         }
     }
-    #[cfg(all(not(feature = "chrono")))]
     #[allow(non_camel_case_types, dead_code)]
     #[doc = concat!("The tuple of all column structs on this ", "table")]
     pub type AllColumns = (id, name);
-    #[cfg(all(feature = "chrono"))]
-    #[allow(non_camel_case_types, dead_code)]
-    #[doc = concat!("The tuple of all column structs on this ", "table")]
-    pub type AllColumns = (id, name, created_at);
     #[doc = concat!("The SQL type of all of the columns on this ", "table")]
     pub type SqlType = <AllColumns as diesel::Expression>::SqlType;
     #[doc = concat!("Helper type for representing a boxed query from this ", "table")]
@@ -496,7 +484,7 @@ pub mod users {
         }
         impl diesel::SelectableExpression<table> for star {}
         impl diesel::AppearsOnTable<table> for star {}
-        #[doc(hidden)]
+        /// The primary key.
         #[allow(non_camel_case_types, dead_code)]
         #[derive(
             Debug,
@@ -730,7 +718,7 @@ pub mod users {
             type Table = super::table;
             const NAME: &'static str = "id";
         }
-        #[doc(hidden)]
+        /// The user's display name.
         #[allow(non_camel_case_types, dead_code)]
         #[derive(
             Debug,
@@ -908,250 +896,11 @@ pub mod users {
             type Table = super::table;
             const NAME: &'static str = "name";
         }
-        #[cfg(feature = "chrono")]
-        #[doc(hidden)]
-        #[allow(non_camel_case_types, dead_code)]
-        #[derive(
-            Debug,
-            Clone,
-            Copy,
-            diesel::query_builder::QueryId,
-            Default,
-            PartialEq,
-            Eq,
-            PartialOrd,
-            Ord,
-            Hash
-        )]
-        pub struct created_at;
-        #[cfg(feature = "chrono")]
-        impl diesel::expression::Expression for created_at {
-            type SqlType = Timestamp;
-        }
-        #[cfg(feature = "chrono")]
-        impl<DB> diesel::query_builder::QueryFragment<DB> for created_at
-        where
-            DB: diesel::backend::Backend,
-            diesel::internal::table_macro::StaticQueryFragmentInstance<
-                table,
-            >: diesel::query_builder::QueryFragment<DB>,
-        {
-            #[allow(non_snake_case)]
-            fn walk_ast<'b>(
-                &'b self,
-                mut __diesel_internal_out: diesel::query_builder::AstPass<'_, 'b, DB>,
-            ) -> diesel::result::QueryResult<()> {
-                if !__diesel_internal_out.should_skip_from() {
-                    const FROM_CLAUSE: diesel::internal::table_macro::StaticQueryFragmentInstance<
-                        table,
-                    > = diesel::internal::table_macro::StaticQueryFragmentInstance::new();
-                    FROM_CLAUSE.walk_ast(__diesel_internal_out.reborrow())?;
-                    __diesel_internal_out.push_sql(".");
-                }
-                __diesel_internal_out.push_identifier("created_at")
-            }
-        }
-        #[cfg(feature = "chrono")]
-        impl diesel::SelectableExpression<super::table> for created_at {}
-        #[cfg(feature = "chrono")]
-        impl<
-            __StmtKind,
-        > diesel::SelectableExpression<
-            diesel::internal::table_macro::returning::ReturningQuerySource<
-                __StmtKind,
-                super::table,
-            >,
-        > for created_at {}
-        #[cfg(feature = "chrono")]
-        impl<QS> diesel::AppearsOnTable<QS> for created_at
-        where
-            QS: diesel::query_source::AppearsInFromClause<
-                super::table,
-                Count = diesel::query_source::Once,
-            >,
-        {}
-        #[cfg(feature = "chrono")]
-        impl<
-            Left,
-            Right,
-        > diesel::SelectableExpression<
-            diesel::internal::table_macro::Join<
-                Left,
-                Right,
-                diesel::internal::table_macro::LeftOuter,
-            >,
-        > for created_at
-        where
-            created_at: diesel::AppearsOnTable<
-                diesel::internal::table_macro::Join<
-                    Left,
-                    Right,
-                    diesel::internal::table_macro::LeftOuter,
-                >,
-            >,
-            Self: diesel::SelectableExpression<Left>,
-            Right: diesel::query_source::AppearsInFromClause<
-                    super::table,
-                    Count = diesel::query_source::Never,
-                > + diesel::query_source::QuerySource,
-            Left: diesel::query_source::QuerySource,
-        {}
-        #[cfg(feature = "chrono")]
-        impl<
-            Left,
-            Right,
-        > diesel::SelectableExpression<
-            diesel::internal::table_macro::Join<
-                Left,
-                Right,
-                diesel::internal::table_macro::Inner,
-            >,
-        > for created_at
-        where
-            created_at: diesel::AppearsOnTable<
-                diesel::internal::table_macro::Join<
-                    Left,
-                    Right,
-                    diesel::internal::table_macro::Inner,
-                >,
-            >,
-            Left: diesel::query_source::AppearsInFromClause<super::table>
-                + diesel::query_source::QuerySource,
-            Right: diesel::query_source::AppearsInFromClause<super::table>
-                + diesel::query_source::QuerySource,
-            (
-                Left::Count,
-                Right::Count,
-            ): diesel::internal::table_macro::Pick<Left, Right>,
-            Self: diesel::SelectableExpression<
-                <(
-                    Left::Count,
-                    Right::Count,
-                ) as diesel::internal::table_macro::Pick<Left, Right>>::Selection,
-            >,
-        {}
-        #[cfg(feature = "chrono")]
-        impl<
-            Join,
-            On,
-        > diesel::SelectableExpression<diesel::internal::table_macro::JoinOn<Join, On>>
-        for created_at
-        where
-            created_at: diesel::SelectableExpression<Join>
-                + diesel::AppearsOnTable<
-                    diesel::internal::table_macro::JoinOn<Join, On>,
-                >,
-        {}
-        #[cfg(feature = "chrono")]
-        impl<
-            From,
-        > diesel::SelectableExpression<
-            diesel::internal::table_macro::SelectStatement<
-                diesel::internal::table_macro::FromClause<From>,
-            >,
-        > for created_at
-        where
-            From: diesel::query_source::QuerySource,
-            created_at: diesel::SelectableExpression<From>
-                + diesel::AppearsOnTable<
-                    diesel::internal::table_macro::SelectStatement<
-                        diesel::internal::table_macro::FromClause<From>,
-                    >,
-                >,
-        {}
-        #[cfg(feature = "chrono")]
-        impl<__GB> diesel::expression::ValidGrouping<__GB> for created_at
-        where
-            __GB: diesel::expression::IsContainedInGroupBy<
-                created_at,
-                Output = diesel::expression::is_contained_in_group_by::Yes,
-            >,
-        {
-            type IsAggregate = diesel::expression::is_aggregate::Yes;
-        }
-        #[cfg(feature = "chrono")]
-        impl diesel::expression::ValidGrouping<()> for created_at {
-            type IsAggregate = diesel::expression::is_aggregate::No;
-        }
-        #[cfg(feature = "chrono")]
-        impl diesel::expression::IsContainedInGroupBy<created_at> for created_at {
-            type Output = diesel::expression::is_contained_in_group_by::Yes;
-        }
-        #[cfg(feature = "chrono")]
-        impl<T> diesel::EqAll<T> for created_at
-        where
-            T: diesel::expression::AsExpression<Timestamp>,
-            diesel::dsl::Eq<
-                created_at,
-                T::Expression,
-            >: diesel::Expression<SqlType = diesel::sql_types::Bool>,
-        {
-            type Output = diesel::dsl::Eq<Self, T::Expression>;
-            fn eq_all(self, __diesel_internal_rhs: T) -> Self::Output {
-                use diesel::expression_methods::ExpressionMethods;
-                self.eq(__diesel_internal_rhs)
-            }
-        }
-        #[cfg(feature = "chrono")]
-        impl<Rhs> ::core::ops::Add<Rhs> for created_at
-        where
-            Rhs: diesel::expression::AsExpression<
-                <<created_at as diesel::Expression>::SqlType as diesel::sql_types::ops::Add>::Rhs,
-            >,
-        {
-            type Output = diesel::internal::table_macro::ops::Add<Self, Rhs::Expression>;
-            fn add(self, __diesel_internal_rhs: Rhs) -> Self::Output {
-                diesel::internal::table_macro::ops::Add::new(
-                    self,
-                    __diesel_internal_rhs.as_expression(),
-                )
-            }
-        }
-        #[cfg(feature = "chrono")]
-        impl<Rhs> ::core::ops::Sub<Rhs> for created_at
-        where
-            Rhs: diesel::expression::AsExpression<
-                <<created_at as diesel::Expression>::SqlType as diesel::sql_types::ops::Sub>::Rhs,
-            >,
-        {
-            type Output = diesel::internal::table_macro::ops::Sub<Self, Rhs::Expression>;
-            fn sub(self, __diesel_internal_rhs: Rhs) -> Self::Output {
-                diesel::internal::table_macro::ops::Sub::new(
-                    self,
-                    __diesel_internal_rhs.as_expression(),
-                )
-            }
-        }
-
-
-
-
-        #[cfg(feature = "chrono")]
-        impl diesel::query_source::Column for created_at {
-            type Table = super::table;
-            const NAME: &'static str = "created_at";
-        }
         impl diesel::expression::IsContainedInGroupBy<id> for name {
             type Output = diesel::expression::is_contained_in_group_by::No;
         }
         impl diesel::expression::IsContainedInGroupBy<name> for id {
             type Output = diesel::expression::is_contained_in_group_by::Yes;
-        }
-        #[cfg(feature = "chrono")]
-        impl diesel::expression::IsContainedInGroupBy<id> for created_at {
-            type Output = diesel::expression::is_contained_in_group_by::No;
-        }
-        #[cfg(feature = "chrono")]
-        impl diesel::expression::IsContainedInGroupBy<created_at> for id {
-            type Output = diesel::expression::is_contained_in_group_by::Yes;
-        }
-        #[cfg(feature = "chrono")]
-        impl diesel::expression::IsContainedInGroupBy<name> for created_at {
-            type Output = diesel::expression::is_contained_in_group_by::No;
-        }
-        #[cfg(feature = "chrono")]
-        impl diesel::expression::IsContainedInGroupBy<created_at> for name {
-            type Output = diesel::expression::is_contained_in_group_by::No;
         }
     }
 }

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__table_with_multiple_feature_gated_columns (postgres).snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__table_with_multiple_feature_gated_columns (postgres).snap
@@ -4,6 +4,7 @@ expression: out
 info:
   input: "table! {\n    users { id -> Integer, name -> Text, #[cfg(feature = \"chrono\")] created_at ->\n    Timestamp, #[cfg(feature = \"uuid\")] user_uuid -> Uuid, #[cfg(feature = \"chrono\")]\n    updated_at -> Timestamp, }\n}\n"
 ---
+#[doc(hidden)]
 #[allow(unused_imports, dead_code, unreachable_pub, unused_qualifications)]
 pub mod users {
     const _: () = {
@@ -567,6 +568,7 @@ pub mod users {
         }
         impl diesel::SelectableExpression<table> for star {}
         impl diesel::AppearsOnTable<table> for star {}
+        #[doc(hidden)]
         #[allow(non_camel_case_types, dead_code)]
         #[derive(
             Debug,
@@ -821,6 +823,7 @@ pub mod users {
             type Table = super::table;
             const NAME: &'static str = "id";
         }
+        #[doc(hidden)]
         #[allow(non_camel_case_types, dead_code)]
         #[derive(
             Debug,
@@ -1020,6 +1023,7 @@ pub mod users {
             const NAME: &'static str = "name";
         }
         #[cfg(feature = "chrono")]
+        #[doc(hidden)]
         #[allow(non_camel_case_types, dead_code)]
         #[derive(
             Debug,
@@ -1263,6 +1267,7 @@ pub mod users {
             const NAME: &'static str = "created_at";
         }
         #[cfg(feature = "uuid")]
+        #[doc(hidden)]
         #[allow(non_camel_case_types, dead_code)]
         #[derive(
             Debug,
@@ -1476,6 +1481,7 @@ pub mod users {
             const NAME: &'static str = "user_uuid";
         }
         #[cfg(feature = "chrono")]
+        #[doc(hidden)]
         #[allow(non_camel_case_types, dead_code)]
         #[derive(
             Debug,

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__table_with_multiple_feature_gated_columns.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__table_with_multiple_feature_gated_columns.snap
@@ -4,6 +4,7 @@ expression: out
 info:
   input: "table! {\n    users { id -> Integer, name -> Text, #[cfg(feature = \"chrono\")] created_at ->\n    Timestamp, #[cfg(feature = \"uuid\")] user_uuid -> Uuid, #[cfg(feature = \"chrono\")]\n    updated_at -> Timestamp, }\n}\n"
 ---
+#[doc(hidden)]
 #[allow(unused_imports, dead_code, unreachable_pub, unused_qualifications)]
 pub mod users {
     const _: () = {
@@ -511,6 +512,7 @@ pub mod users {
         }
         impl diesel::SelectableExpression<table> for star {}
         impl diesel::AppearsOnTable<table> for star {}
+        #[doc(hidden)]
         #[allow(non_camel_case_types, dead_code)]
         #[derive(
             Debug,
@@ -744,6 +746,7 @@ pub mod users {
             type Table = super::table;
             const NAME: &'static str = "id";
         }
+        #[doc(hidden)]
         #[allow(non_camel_case_types, dead_code)]
         #[derive(
             Debug,
@@ -922,6 +925,7 @@ pub mod users {
             const NAME: &'static str = "name";
         }
         #[cfg(feature = "chrono")]
+        #[doc(hidden)]
         #[allow(non_camel_case_types, dead_code)]
         #[derive(
             Debug,
@@ -1144,6 +1148,7 @@ pub mod users {
             const NAME: &'static str = "created_at";
         }
         #[cfg(feature = "uuid")]
+        #[doc(hidden)]
         #[allow(non_camel_case_types, dead_code)]
         #[derive(
             Debug,
@@ -1336,6 +1341,7 @@ pub mod users {
             const NAME: &'static str = "user_uuid";
         }
         #[cfg(feature = "chrono")]
+        #[doc(hidden)]
         #[allow(non_camel_case_types, dead_code)]
         #[derive(
             Debug,

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__view_1 (postgres).snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__view_1 (postgres).snap
@@ -4,6 +4,7 @@ expression: out
 info:
   input: "view! {\n    view { id -> Integer, name -> Text, }\n}\n"
 ---
+#[doc(hidden)]
 #[allow(unused_imports, dead_code, unreachable_pub, unused_qualifications)]
 pub mod view {
     const _: () = {
@@ -435,6 +436,7 @@ pub mod view {
         }
         impl diesel::SelectableExpression<view> for star {}
         impl diesel::AppearsOnTable<view> for star {}
+        #[doc(hidden)]
         #[allow(non_camel_case_types, dead_code)]
         #[derive(
             Debug,
@@ -664,6 +666,7 @@ pub mod view {
             type QueryRelation = super::view;
             const NAME: &'static str = "id";
         }
+        #[doc(hidden)]
         #[allow(non_camel_case_types, dead_code)]
         #[derive(
             Debug,

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__view_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__view_1.snap
@@ -4,6 +4,7 @@ expression: out
 info:
   input: "view! {\n    view { id -> Integer, name -> Text, }\n}\n"
 ---
+#[doc(hidden)]
 #[allow(unused_imports, dead_code, unreachable_pub, unused_qualifications)]
 pub mod view {
     const _: () = {
@@ -435,6 +436,7 @@ pub mod view {
         }
         impl diesel::SelectableExpression<view> for star {}
         impl diesel::AppearsOnTable<view> for star {}
+        #[doc(hidden)]
         #[allow(non_camel_case_types, dead_code)]
         #[derive(
             Debug,
@@ -664,6 +666,7 @@ pub mod view {
             type QueryRelation = super::view;
             const NAME: &'static str = "id";
         }
+        #[doc(hidden)]
         #[allow(non_camel_case_types, dead_code)]
         #[derive(
             Debug,

--- a/diesel_derives/src/tests/table.rs
+++ b/diesel_derives/src/tests/table.rs
@@ -24,6 +24,33 @@ pub(crate) fn table_1() {
 }
 
 #[test]
+pub(crate) fn table_with_docs() {
+    // A documented table with documented columns must keep the caller's docs
+    // and receive no injected `#[doc(hidden)]`.
+    let input = quote::quote! {
+        /// The users of the application.
+        users {
+            /// The primary key.
+            id -> Integer,
+            /// The user's display name.
+            name -> Text,
+        }
+    };
+    let name = if cfg!(feature = "postgres") {
+        "table_with_docs (postgres)"
+    } else {
+        "table_with_docs"
+    };
+
+    expand_with(
+        &crate::table_proc_inner as &dyn Fn(_) -> _,
+        input,
+        FunctionMacro(syn::parse_quote!(table)),
+        name,
+    );
+}
+
+#[test]
 pub(crate) fn table_with_column_feature_gate() {
     let input = quote::quote! {
         users {

--- a/diesel_derives/tests/missing_docs.rs
+++ b/diesel_derives/tests/missing_docs.rs
@@ -1,0 +1,76 @@
+//! Compile test asserting that `diesel::table!` and `diesel::view!` output is
+//! clean under `missing_docs` at the strictest lint level.
+#![forbid(missing_docs)]
+
+extern crate diesel;
+
+// table, no docs: module and both column structs are hidden.
+diesel::table! {
+    users {
+        id -> Integer,
+        name -> Text,
+    }
+}
+
+// table, fully documented: nothing is hidden, the caller's docs stay visible.
+diesel::table! {
+    /// The posts a user has written.
+    posts {
+        /// Primary key of the post.
+        id -> Integer,
+        /// Free-form title text.
+        title -> Text,
+    }
+}
+
+// table doc present, column docs absent: the module stays visible while the
+// undocumented column structs are hidden.
+diesel::table! {
+    /// Comments left on posts.
+    comments {
+        id -> Integer,
+        body -> Text,
+    }
+}
+
+// table doc absent, column docs present: the module is hidden, which propagates
+// to its columns, so documented columns compile under an undocumented table.
+diesel::table! {
+    tags {
+        /// The tag id.
+        id -> Integer,
+        /// The tag label.
+        label -> Text,
+    }
+}
+
+// view, no docs: the shared generator hides the module and column structs.
+diesel::view! {
+    active_users {
+        id -> Integer,
+        name -> Text,
+    }
+}
+
+// view, fully documented: the caller's docs stay visible.
+diesel::view! {
+    /// Users seen in the last 30 days.
+    recent_users {
+        /// The user id.
+        id -> Integer,
+        /// The user's display name.
+        name -> Text,
+    }
+}
+
+#[test]
+fn schema_macros_are_missing_docs_clean() {
+    // The contract under test is that the schema declarations above compile
+    // under `forbid(missing_docs)`.
+    let _ = users::table;
+    let _ = posts::table;
+    let _ = comments::table;
+    let _ = tags::table;
+    let _ = active_users::table;
+    let _ = recent_users::table;
+}


### PR DESCRIPTION
Under `#![forbid(missing_docs)]` a bare `diesel::table! { ... }` fails to compile as the generated schema module and each column struct carry only the caller's own doc comments, so an undocumented schema leaves them as undocumented public items.

The generator now marks the schema module and the column structs `#[doc(hidden)]`, but only when the caller wrote no doc comment for that item, reusing the `#[doc(hidden)]` approach the macro already applies to its own internals rather than fabricating filler text. Caller-written docs are left exactly as-is and still render.

Arguably, a user could just document the table macro call, but I thought this little ease of life thing may still be desirable to have.