### PR TITLE
fix await position in load_query builder

### DIFF
--- a/diesel_derives/src/multiconnection.rs
+++ b/diesel_derives/src/multiconnection.rs
@@ -239,7 +239,7 @@ fn generate_connection_impl(
                 query_builder: super::query_builder::MultiQueryBuilder::#variant_ident(Default::default()),
                 p: std::marker::PhantomData::<#ty>,
             };
-            let r = <#ty as #conn_load>::load(conn, query)#await_token?;
+            let r = <#ty as #conn_load>::load(conn, query);
         }
     };
 
@@ -268,7 +268,7 @@ fn generate_connection_impl(
                     #load_query
                     Box::pin(async move {
                         Ok(Box::pin(
-                            futures_util::StreamExt::map(r, |result| result.map(super::row::MultiRow::#variant_ident))
+                            futures_util::StreamExt::map(r.await?, |result| result.map(super::row::MultiRow::#variant_ident))
                         ) as Self::Stream<'conn, 'query>)
                     })
                 }
@@ -307,7 +307,7 @@ fn generate_connection_impl(
             quote::quote! {
                 Self::#variant_ident(conn) => {
                     #load_query
-                    Ok(super::row::MultiCursor::#variant_ident(r))
+                    Ok(super::row::MultiCursor::#variant_ident(r?))
                 }
             }
         });

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__multiconnection_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__multiconnection_1.snap
@@ -1970,8 +1970,8 @@ mod multi_connection_impl {
                         let r = <PgConnection as diesel::connection::LoadConnection>::load(
                             conn,
                             query,
-                        )?;
-                        Ok(super::row::MultiCursor::Pg(r))
+                        );
+                        Ok(super::row::MultiCursor::Pg(r?))
                     }
                     Self::Sqlite(conn) => {
                         let query = SerializedQuery {
@@ -1985,8 +1985,8 @@ mod multi_connection_impl {
                         let r = <diesel::SqliteConnection as diesel::connection::LoadConnection>::load(
                             conn,
                             query,
-                        )?;
-                        Ok(super::row::MultiCursor::Sqlite(r))
+                        );
+                        Ok(super::row::MultiCursor::Sqlite(r?))
                     }
                 }
             }

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__multiconnection_2.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__multiconnection_2.snap
@@ -1944,15 +1944,14 @@ mod multi_connection_impl {
                             >,
                         };
                         let r = <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::load(
-                                conn,
-                                query,
-                            )
-                            .await?;
+                            conn,
+                            query,
+                        );
                         Box::pin(async move {
                             Ok(
                                 Box::pin(
                                     futures_util::StreamExt::map(
-                                        r,
+                                        r.await?,
                                         |result| result.map(super::row::MultiRow::Pg),
                                     ),
                                 ) as Self::Stream<'conn, 'query>,
@@ -1971,15 +1970,14 @@ mod multi_connection_impl {
                             >,
                         };
                         let r = <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::load(
-                                conn,
-                                query,
-                            )
-                            .await?;
+                            conn,
+                            query,
+                        );
                         Box::pin(async move {
                             Ok(
                                 Box::pin(
                                     futures_util::StreamExt::map(
-                                        r,
+                                        r.await?,
                                         |result| result.map(super::row::MultiRow::Sqlite),
                                     ),
                                 ) as Self::Stream<'conn, 'query>,


### PR DESCRIPTION
I noticed that the await in the load_query builder was outside an async block, causing the diesel_async version to not compile. 