### PR TITLE
diesel_dynamic_schema: support adding heterogeneous SQL-typed fields to DynamicSelectClause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 
 * Diesel-Migrations now contains a migration source that easily allows you to register Rust based migrations
 * Diesel-Migrations now contains a migration source that allows you to combine migrations from several different sources
+* Added `DynamicSelectClause::add_boxed_fields`, `DynamicSelectClause::box_field`, and the `IntoBoxedField` trait to `diesel_dynamic_schema`, allowing columns of different SQL types to be collected into a single `Vec` and added to a dynamic select clause in one call
 * Added `SqliteConnection::with_raw_connection` to provide safe, callback-based access to the raw `*mut sqlite3` handle for advanced SQLite C APIs (session extension, hooks, etc.)
 * Added `SqliteConnection::on_commit` and `SqliteConnection::remove_commit_hook` to register a callback invoked when a transaction is about to be committed, wrapping `sqlite3_commit_hook`
 * Added `SqliteConnection::on_authorize` and `SqliteConnection::remove_authorizer` to register an authorizer callback that allows, denies, or ignores SQL actions during statement compilation, wrapping `sqlite3_set_authorizer`, along with the `AuthorizerContext` and `AuthorizerDecision` types

--- a/diesel_dynamic_schema/src/dynamic_select.rs
+++ b/diesel_dynamic_schema/src/dynamic_select.rs
@@ -42,6 +42,75 @@ impl<'a, DB, QS> DynamicSelectClause<'a, DB, QS> {
         self.selects.push(Box::new(field))
     }
 
+    /// Boxes a field as a type-erased `QueryFragment`, using this select clause's
+    /// own `DB`/`QS` type parameters to resolve them for the conversion.
+    ///
+    /// This is a thin wrapper around [`IntoBoxedField::into_boxed`] that exists
+    /// purely for type inference: `QS` does not appear anywhere in the boxed
+    /// return type, so calling `field.into_boxed()` directly on a loose
+    /// expression usually leaves the compiler unable to infer it. Going through
+    /// an existing `&DynamicSelectClause<'a, DB, QS>` pins both `DB` and `QS`
+    /// from `self`'s own type, so no annotation or turbofish is needed.
+    pub fn box_field<F>(&self, field: F) -> Box<dyn QueryFragment<DB> + Send + 'a>
+    where
+        F: QueryFragment<DB> + SelectableExpression<QS> + NonAggregate + Send + 'a,
+        DB: Backend,
+    {
+        Box::new(field)
+    }
+
+    /// Add multiple already boxed fields to the dynamically sized select clause
+    /// in a single call.
+    ///
+    /// Unlike [`add_fields`](Self::add_fields), the fields do not all need to share
+    /// the same Rust type, since each one has already been type-erased via
+    /// [`box_field`](Self::box_field) (or [`IntoBoxedField::into_boxed`] directly).
+    /// This is useful when the set of columns (and their SQL types) is only
+    /// known at runtime, e.g. when it was discovered by introspecting the
+    /// database schema.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # include!("../tests/connection_setup.rs");
+    /// # use diesel::prelude::*;
+    /// # use diesel::sql_types::{Integer, Text};
+    /// # use diesel_dynamic_schema::{table, DynamicSelectClause, Table};
+    /// #
+    /// # #[cfg(feature = "sqlite")]
+    /// # fn main() {
+    /// # let conn = &mut establish_connection();
+    /// # create_user_table(conn);
+    /// let users = table("users");
+    /// let id = users.column::<Integer, _>("id");
+    /// let name = users.column::<Text, _>("name");
+    ///
+    /// // The select clause's own `DB`/`QS` need to be known before boxing
+    /// // anything into it; here that's the same pair you'd normally get for
+    /// // free from a later `.select(select)` call. Annotate it up front if you
+    /// // want to build the boxed `Vec` before wiring up the rest of the query.
+    /// let mut select: DynamicSelectClause<diesel::sqlite::Sqlite, Table<&str>> =
+    ///     DynamicSelectClause::new();
+    ///
+    /// // `id` and `name` have different Rust types (`Column<_, _, Integer>` vs.
+    /// // `Column<_, _, Text>`), so they can't be collected into a single `Vec`
+    /// // without boxing them first. `box_field` uses `select`'s own type to
+    /// // resolve the boxing, so no turbofish is required.
+    /// let boxed_fields = vec![select.box_field(id), select.box_field(name)];
+    ///
+    /// select.add_boxed_fields(boxed_fields);
+    /// assert_eq!(select.len(), 2);
+    /// # }
+    /// # #[cfg(not(feature = "sqlite"))]
+    /// # fn main() {}
+    /// ```
+    pub fn add_boxed_fields<I>(&mut self, fields: I)
+    where
+        I: IntoIterator<Item = Box<dyn QueryFragment<DB> + Send + 'a>>,
+    {
+        self.selects.extend(fields);
+    }
+
     /// Add multiple fields to the dynamically sized select clause
     pub fn add_fields<I, F>(&mut self, fields: I)
     where
@@ -117,5 +186,25 @@ where
 {
     fn extend<I: IntoIterator<Item = F>>(&mut self, iter: I) {
         self.add_fields(iter)
+    }
+}
+
+/// Type-erases a column/expression so it can be stored alongside other
+/// fields of different SQL types, e.g. via [`DynamicSelectClause::add_boxed_fields`].
+pub trait IntoBoxedField<'a, DB, QS> {
+    /// Boxes `self` as a type-erased `QueryFragment`.
+    ///
+    /// This drops the field's concrete Rust type (including its SQL type),
+    /// while preserving its ability to be walked into a SQL query.
+    fn into_boxed(self) -> Box<dyn QueryFragment<DB> + Send + 'a>;
+}
+
+impl<'a, DB, QS, F> IntoBoxedField<'a, DB, QS> for F
+where
+    F: QueryFragment<DB> + SelectableExpression<QS> + NonAggregate + Send + 'a,
+    DB: Backend,
+{
+    fn into_boxed(self) -> Box<dyn QueryFragment<DB> + Send + 'a> {
+        Box::new(self)
     }
 }

--- a/diesel_dynamic_schema/src/lib.rs
+++ b/diesel_dynamic_schema/src/lib.rs
@@ -95,7 +95,7 @@ pub use schema::Schema;
 pub use table::Table;
 
 #[doc(inline)]
-pub use self::dynamic_select::DynamicSelectClause;
+pub use self::dynamic_select::{DynamicSelectClause, IntoBoxedField};
 
 /// Create a new [`Table`] with the given name.
 ///

--- a/diesel_dynamic_schema/tests/dynamic_values.rs
+++ b/diesel_dynamic_schema/tests/dynamic_values.rs
@@ -256,6 +256,50 @@ fn dynamic_query() {
 }
 
 #[test]
+#[cfg(any(feature = "postgres", feature = "mysql", feature = "sqlite"))]
+fn mixed_type_boxed_fields() {
+    let connection = &mut super::establish_connection();
+    crate::create_user_table(connection);
+    sql_query("INSERT INTO users (id, name, hair_color) VALUES (42, 'Sean', 'black')")
+        .execute(connection)
+        .unwrap();
+
+    let users = diesel_dynamic_schema::table("users");
+    let id = users.column::<Integer, _>("id");
+    let name = users.column::<Text, _>("name");
+    let hair_color = users.column::<Text, _>("hair_color");
+
+    let mut select = DynamicSelectClause::new();
+
+    // `id` (Integer) and `name`/`hair_color` (Text) are different Rust types, so
+    // they can't be combined via `add_fields`, which requires a single common
+    // type. `box_field` erases that difference (using `select`'s own DB/QS
+    // types to resolve the conversion) so they can all be added to the same
+    // select clause in one `add_boxed_fields` call.
+    let boxed_fields = vec![
+        select.box_field(id),
+        select.box_field(name),
+        select.box_field(hair_color),
+    ];
+
+    select.add_boxed_fields(boxed_fields);
+    assert_eq!(select.len(), 3);
+
+    let actual_data: Vec<DynamicRow<NamedField<MyDynamicValue>>> =
+        users.select(select).load(connection).unwrap();
+
+    assert_eq!(actual_data[0]["id"], MyDynamicValue::Integer(42));
+    assert_eq!(
+        actual_data[0]["name"],
+        MyDynamicValue::String("Sean".into())
+    );
+    assert_eq!(
+        actual_data[0]["hair_color"],
+        MyDynamicValue::String("black".into())
+    );
+}
+
+#[test]
 fn mixed_value_query() {
     use diesel::dsl::sql;
 


### PR DESCRIPTION
DynamicSelectClause::add_fields requires every field to be the same type, so columns with different SQL types can't be collected into one vector and added at once. This PR adds IntoBoxedField/DynamicSelectClause::box_field to box fields of different types into a common Box<dyn QueryFragment<...>>, plus add_boxed_fields to add them in bulk.

I used Gemini for the tests/docs — and reviewed everything before opening the PR.