### PR TITLE
Import `IntoSql` explicitly in the `auto_type` test

### DIFF
--- a/diesel_derives/tests/auto_type.rs
+++ b/diesel_derives/tests/auto_type.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)] // this is a compile pass test
 use diesel::dsl::*;
+use diesel::expression::IntoSql;
 use diesel::helper_types::*;
 use diesel::prelude::*;
 use diesel::sql_types;


### PR DESCRIPTION
Beta 1.98 added `ambiguous_glob_imported_traits`, which rejects a method call whose trait arrived through a glob import when that same name is also bound to something else. The prelude exports `IntoSql` as a trait and `helper_types`
exports a type alias of the same name, and this test glob-imports both, so `.into_sql()` no longer resolves and every `Check (beta, ...)` job fails on any branch.

Importing the trait anonymously does not help, because the prelude already does that and the name stays ambiguous.