### PR TITLE
Bump syn to 3.0 and sqlparser to 0.62.0

### DIFF
--- a/diesel_attribute_parser/Cargo.toml
+++ b/diesel_attribute_parser/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/diesel-rs/diesel/"
 autotests = false
 
 [dependencies]
-syn = { version = "2.0", features = ["derive", "fold", "full", "visit-mut"] }
+syn = { version = "3.0", features = ["derive", "fold", "full", "visit-mut"] }
 quote = "1.0.9"
 proc-macro2 = "1.0.27"
 

--- a/diesel_cli/Cargo.toml
+++ b/diesel_cli/Cargo.toml
@@ -54,7 +54,7 @@ regex = "1.0.6"
 serde_regex = "1.1"
 diesel_attribute_parser = { version = "0.1", path = "../diesel_attribute_parser" }
 diesel_table_macro_syntax = { version = "0.3", path = "../diesel_table_macro_syntax" }
-syn = { version = "2", features = ["visit", "extra-traits"] }
+syn = { version = "3", features = ["visit", "extra-traits"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.10", features = ["env-filter"] }
 thiserror = "2.0.0"

--- a/diesel_derives/Cargo.toml
+++ b/diesel_derives/Cargo.toml
@@ -12,7 +12,7 @@ edition.workspace = true
 include = ["src/**/*.rs", "src/tests/snapshots/*", "LICENSE-*", "README.md", "build.rs"]
 
 [dependencies]
-syn = { version = "2.0", features = ["derive", "fold", "full", "visit-mut"] }
+syn = { version = "3.0", features = ["derive", "fold", "full", "visit-mut"] }
 quote = "1.0.9"
 proc-macro2 = "1.0.27"
 diesel_table_macro_syntax = { version = "0.3", path = "../diesel_table_macro_syntax" }
@@ -23,7 +23,7 @@ dsl_auto_type = { version = "0.2", path = "../dsl_auto_type" }
 cfg-if = "1"
 dotenvy = "0.15"
 insta = "1.21"
-prettyplease = "0.2"
+prettyplease = "0.3"
 
 [dev-dependencies.diesel]
 path = "../diesel"

--- a/diesel_derives/src/diesel_public_if.rs
+++ b/diesel_derives/src/diesel_public_if.rs
@@ -16,21 +16,12 @@ impl syn::parse::Parse for CfgInput {
         let mut cfg = Punctuated::<syn::Meta, Token![,]>::parse_terminated(input)?;
         if cfg.len() == 1 {
             Ok(Self {
-                cfg: cfg
-                    .pop()
-                    .expect("There is exactly one element")
-                    .into_value(),
+                cfg: cfg.pop().expect("There is exactly one element"),
                 field_list: Vec::new(),
             })
         } else if cfg.len() == 2 {
-            let value_1 = cfg
-                .pop()
-                .expect("There is exactly one element")
-                .into_value();
-            let value_2 = cfg
-                .pop()
-                .expect("There is exactly one element")
-                .into_value();
+            let value_1 = cfg.pop().expect("There is exactly one element");
+            let value_2 = cfg.pop().expect("There is exactly one element");
             let (cfg, fields) = if matches!(&value_1, syn::Meta::List(v) if v.path.is_ident("public_fields"))
             {
                 (value_2, value_1)

--- a/diesel_derives/src/enum_.rs
+++ b/diesel_derives/src/enum_.rs
@@ -77,6 +77,7 @@ pub fn derive(item: DeriveEnumInput) -> Result<TokenStream> {
     let struct_ty = syn::Type::Path(syn::TypePath {
         qself: None,
         path: item.ident.into(),
+        attrs: Vec::new(),
     });
     let sql_types = item
         .sql_type_attrs

--- a/diesel_derives/src/field.rs
+++ b/diesel_derives/src/field.rs
@@ -220,7 +220,7 @@ fn check_serde_as_supported_type(ty: &Type, attr_name: &str) -> Result<()> {
             ty,
             format!("`{attr_name}` does not support pointer types"),
         )),
-        Type::BareFn(_) => Err(syn::Error::new_spanned(
+        Type::FnPtr(_) => Err(syn::Error::new_spanned(
             ty,
             format!("`{attr_name}` does not support function pointer types"),
         )),

--- a/diesel_derives/src/sql_function.rs
+++ b/diesel_derives/src/sql_function.rs
@@ -1311,6 +1311,7 @@ impl Parse for SqlFunctionDecl {
                 combine_error(e);
                 Type::Never(syn::TypeNever {
                     bang_token: Default::default(),
+                    attrs: Vec::new(),
                 })
             })
         } else {

--- a/diesel_infer_query/Cargo.toml
+++ b/diesel_infer_query/Cargo.toml
@@ -8,7 +8,7 @@ license = "MPL-2.0"
 autotests = false
 
 [dependencies]
-sqlparser = { version = "0.61.0", features = ["visitor"] }
+sqlparser = { version = "0.62.0", features = ["visitor"] }
 thiserror = "2"
 
 [dev-dependencies]

--- a/diesel_infer_query/src/expression.rs
+++ b/diesel_infer_query/src/expression.rs
@@ -277,7 +277,9 @@ fn infer_functions(
                             schema: query_source_lookup.schema.map(|t| t.to_owned()),
                         })
                     }
-                    FunctionArgExpr::Wildcard => Ok(Expression::Unknown),
+                    FunctionArgExpr::WildcardWithOptions(_) | FunctionArgExpr::Wildcard => {
+                        Ok(Expression::Unknown)
+                    }
                 },
             })
             .collect::<Result<Vec<_>, _>>()?,

--- a/diesel_infer_query/src/select.rs
+++ b/diesel_infer_query/src/select.rs
@@ -273,5 +273,8 @@ pub(crate) fn infer_projection(
         ) => Err(Error::UnsupportedSql {
             msg: format!("Unsupported `SELECT` expression: `{s}`"),
         }),
+        s @ SelectItem::ExprWithAliases { .. } => Err(Error::UnsupportedSql {
+            msg: format!("Unsupported `SELECT` expression: `{s}`"),
+        }),
     }
 }

--- a/diesel_table_macro_syntax/Cargo.toml
+++ b/diesel_table_macro_syntax/Cargo.toml
@@ -15,7 +15,7 @@ edition.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-syn = {version = "2", features = ["full"]}
+syn = {version = "3", features = ["full"]}
 
 [lints]
 workspace = true

--- a/diesel_test_helper/Cargo.toml
+++ b/diesel_test_helper/Cargo.toml
@@ -12,4 +12,4 @@ doc = false
 [dependencies]
 proc-macro2 = "1.0.92"
 quote = "1.0.38"
-syn = "2.0.92"
+syn = "3.0.0"

--- a/diesel_test_helper/src/lib.rs
+++ b/diesel_test_helper/src/lib.rs
@@ -12,6 +12,7 @@ pub fn test(_: TokenStream, item: TokenStream) -> TokenStream {
         vis,
         block,
         attrs,
+        modifiers: _,
     } = parse_macro_input!(item as ItemFn);
 
     let cfgs = quote! {

--- a/dsl_auto_type/Cargo.toml
+++ b/dsl_auto_type/Cargo.toml
@@ -10,12 +10,12 @@ rust-version.workspace = true
 include.workspace = true
 
 [dependencies]
-darling = "0.23"
+darling = "0.24"
 either = "1"
 heck = "0.5"
 proc-macro2 = "1"
 quote = "1"
-syn = { version = "2", features = ["extra-traits", "full", "derive", "parsing", "visit"] }
+syn = { version = "3", features = ["extra-traits", "full", "derive", "parsing", "visit"] }
 
 [dev-dependencies]
 diesel = { path = "../diesel" }

--- a/dsl_auto_type/src/auto_type/expression_type_inference.rs
+++ b/dsl_auto_type/src/auto_type/expression_type_inference.rs
@@ -127,6 +127,7 @@ impl TypeInferrer<'_> {
                         .map(|e| self.infer_expression_type(e, None))
                         .collect(),
                     paren_token: Default::default(),
+                    attrs: Vec::new(),
                 })
             }
             (syn::Expr::Path(syn::ExprPath { path, .. }), None) => {
@@ -148,6 +149,7 @@ impl TypeInferrer<'_> {
                     syn::Type::Path(syn::TypePath {
                         path: path.clone(),
                         qself: None,
+                        attrs: Vec::new(),
                     })
                 }
             }
@@ -197,6 +199,7 @@ impl TypeInferrer<'_> {
                 syn::Type::Path(syn::TypePath {
                     path: type_path,
                     qself: None,
+                    attrs: Vec::new(),
                 })
             }
             (
@@ -235,6 +238,7 @@ impl TypeInferrer<'_> {
                     leading_colon: None,
                 },
                 qself: None,
+                attrs: Vec::new(),
             }),
             (syn::Expr::Lit(syn::ExprLit { lit, .. }), None) => match lit {
                 syn::Lit::Str(_) => parse_quote_spanned!(lit.span()=> &'static str),


### PR DESCRIPTION
Also fix the code to continue to compile.

We still depend on syn 2.0 via the following dependencies:

syn v2.0.119
├── recursive-proc-macro-impl v0.1.1 (proc-macro)
├── sqlparser_derive v0.5.0 (proc-macro)
├── synstructure v0.13.2
├── tracing-attributes v0.1.31 (proc-macro)
├── wasm-bindgen-macro-support v0.2.108
├── yoke-derive v0.8.2 (proc-macro)
├── zerofrom-derive v0.1.7 (proc-macro)
└── zerovec-derive v0.11.3 (proc-macro)

<!-- 
Please provide a short brief summary description of your change here. 
Also make sure that your code passes all tests and style checks. 
Checkout the `CONTRIBUTING.md` file in the root of the repository for running these checks locally.
It's also fine to use the CI setup for running these tests, but in this case please indicate that your PR 
is not ready for review yet by marking it as DRAFT until it is ready.

If you submit a notable change please ensure to include it into the CHANGELOG.md file in
the root of the repository.

Also make sure to follow the projects guide lines about the usage of LLM's and AI agents as outlined
in the CONTRIBUTING.md file in the root of the repository.
-->

- [x] I checked for similar changes and make sure to reference them
- [x] I included a changelog entry for relevant new features or changes
