### PR TITLE
Resolve the getting-started test binaries at compile time

### DIFF
--- a/examples/mysql/getting_started_step_1/Cargo.toml
+++ b/examples/mysql/getting_started_step_1/Cargo.toml
@@ -11,7 +11,7 @@ openssl-sys = { workspace = true, features = ["vendored"] }
 dotenvy = "0.15"
 
 [dev-dependencies]
-assert_cmd = "2.0.14"
+assert_cmd = "2.1"
 url = "2.2.2"
 diesel_migrations = { version = "2.3.0", path = "../../../diesel_migrations" }
 

--- a/examples/mysql/getting_started_step_1/tests/step_1.rs
+++ b/examples/mysql/getting_started_step_1/tests/step_1.rs
@@ -1,4 +1,4 @@
-use assert_cmd::Command;
+use assert_cmd::cargo::cargo_bin_cmd;
 use diesel::connection::SimpleConnection;
 use diesel::{Connection, MysqlConnection};
 use diesel_migrations::MigrationHarness;
@@ -34,8 +34,7 @@ fn show_posts() {
     let migrations = diesel_migrations::FileBasedMigrations::find_migrations_directory().unwrap();
     conn.run_pending_migrations(migrations).unwrap();
 
-    let _ = Command::cargo_bin("show_posts")
-        .unwrap()
+    let _ = cargo_bin_cmd!("show_posts_step_1")
         .env("MYSQL_DATABASE_URL", db_url.to_string())
         .assert()
         .append_context("show_posts", "")

--- a/examples/mysql/getting_started_step_2/Cargo.toml
+++ b/examples/mysql/getting_started_step_2/Cargo.toml
@@ -11,7 +11,7 @@ openssl-sys = { workspace = true, features = ["vendored"] }
 dotenvy = "0.15"
 
 [dev-dependencies]
-assert_cmd = "2.0.14"
+assert_cmd = "2.1"
 url = "2.2.2"
 diesel_migrations = { version = "2.3.0", path = "../../../diesel_migrations" }
 

--- a/examples/mysql/getting_started_step_2/tests/step_2.rs
+++ b/examples/mysql/getting_started_step_2/tests/step_2.rs
@@ -1,4 +1,4 @@
-use assert_cmd::Command;
+use assert_cmd::cargo::cargo_bin_cmd;
 use diesel::connection::SimpleConnection;
 use diesel::{Connection, MysqlConnection};
 use diesel_migrations::MigrationHarness;
@@ -34,8 +34,7 @@ fn write_post() {
     let migrations = diesel_migrations::FileBasedMigrations::find_migrations_directory().unwrap();
     conn.run_pending_migrations(migrations).unwrap();
 
-    let _ = Command::cargo_bin("write_post")
-        .unwrap()
+    let _ = cargo_bin_cmd!("write_post_step_2")
         .env("MYSQL_DATABASE_URL", db_url.to_string())
         .write_stdin("Test Title\ntest text\n1 2 3")
         .assert()
@@ -47,8 +46,7 @@ fn write_post() {
                 + " when finished)\n\n\nSaved draft Test Title with id 1\n",
         );
 
-    let _ = Command::cargo_bin("show_posts")
-        .unwrap()
+    let _ = cargo_bin_cmd!("show_posts_step_2")
         .env("MYSQL_DATABASE_URL", db_url.to_string())
         .assert()
         .append_context("show_posts", "")

--- a/examples/mysql/getting_started_step_3/Cargo.toml
+++ b/examples/mysql/getting_started_step_3/Cargo.toml
@@ -11,7 +11,7 @@ openssl-sys = { workspace = true, features = ["vendored"] }
 dotenvy = "0.15"
 
 [dev-dependencies]
-assert_cmd = "2.0.14"
+assert_cmd = "2.1"
 url = "2.2.2"
 diesel_migrations = { version = "2.3.0", path = "../../../diesel_migrations" }
 

--- a/examples/mysql/getting_started_step_3/tests/step_3.rs
+++ b/examples/mysql/getting_started_step_3/tests/step_3.rs
@@ -1,4 +1,4 @@
-use assert_cmd::Command;
+use assert_cmd::cargo::cargo_bin_cmd;
 use diesel::connection::SimpleConnection;
 use diesel::{Connection, MysqlConnection};
 use diesel_migrations::MigrationHarness;
@@ -34,15 +34,13 @@ fn publish_post() {
     let migrations = diesel_migrations::FileBasedMigrations::find_migrations_directory().unwrap();
     conn.run_pending_migrations(migrations).unwrap();
 
-    let _ = Command::cargo_bin("show_posts")
-        .unwrap()
+    let _ = cargo_bin_cmd!("show_posts")
         .env("MYSQL_DATABASE_URL", db_url.to_string())
         .assert()
         .append_context("show_posts", "")
         .stdout("Displaying 0 posts\n");
 
-    let _ = Command::cargo_bin("write_post")
-        .unwrap()
+    let _ = cargo_bin_cmd!("write_post")
         .env("MYSQL_DATABASE_URL", db_url.to_string())
         .write_stdin("Test Title\ntest text\n1 2 3")
         .assert()
@@ -54,31 +52,27 @@ fn publish_post() {
                 + " when finished)\n\n\nSaved draft Test Title with id 1\n",
         );
 
-    let _ = Command::cargo_bin("publish_post")
-        .unwrap()
+    let _ = cargo_bin_cmd!("publish_post")
         .env("MYSQL_DATABASE_URL", db_url.to_string())
         .arg("1")
         .assert()
         .append_context("publish_post", "")
         .stdout("Published post Test Title\n");
 
-    let _ = Command::cargo_bin("show_posts")
-        .unwrap()
+    let _ = cargo_bin_cmd!("show_posts")
         .env("MYSQL_DATABASE_URL", db_url.to_string())
         .assert()
         .append_context("show_posts", "")
         .stdout("Displaying 1 posts\nTest Title\n-----------\n\ntest text\n1 2 3\n");
 
-    let _ = Command::cargo_bin("delete_post")
-        .unwrap()
+    let _ = cargo_bin_cmd!("delete_post")
         .env("MYSQL_DATABASE_URL", db_url.to_string())
         .arg("Test Title")
         .assert()
         .append_context("delete_post", "")
         .stdout("Deleted 1 posts\n");
 
-    let _ = Command::cargo_bin("show_posts")
-        .unwrap()
+    let _ = cargo_bin_cmd!("show_posts")
         .env("MYSQL_DATABASE_URL", db_url.to_string())
         .assert()
         .append_context("show_posts", "")

--- a/examples/postgres/getting_started_step_1/Cargo.toml
+++ b/examples/postgres/getting_started_step_1/Cargo.toml
@@ -11,7 +11,7 @@ openssl-sys = { workspace = true, features = ["vendored"] }
 dotenvy = "0.15"
 
 [dev-dependencies]
-assert_cmd = "2.0.14"
+assert_cmd = "2.1"
 url = "2.2.2"
 diesel_migrations = { version = "2.3.0", path = "../../../diesel_migrations" }
 

--- a/examples/postgres/getting_started_step_1/tests/step_1.rs
+++ b/examples/postgres/getting_started_step_1/tests/step_1.rs
@@ -1,4 +1,4 @@
-use assert_cmd::Command;
+use assert_cmd::cargo::cargo_bin_cmd;
 use diesel::connection::SimpleConnection;
 use diesel::{Connection, PgConnection};
 use diesel_migrations::MigrationHarness;
@@ -34,8 +34,7 @@ fn show_posts() {
     let migrations = diesel_migrations::FileBasedMigrations::find_migrations_directory().unwrap();
     conn.run_pending_migrations(migrations).unwrap();
 
-    let _ = Command::cargo_bin("show_posts")
-        .unwrap()
+    let _ = cargo_bin_cmd!("show_posts_step_1")
         .env("PG_DATABASE_URL", db_url.to_string())
         .assert()
         .append_context("show_posts", "")

--- a/examples/postgres/getting_started_step_2/Cargo.toml
+++ b/examples/postgres/getting_started_step_2/Cargo.toml
@@ -11,7 +11,7 @@ openssl-sys = { workspace = true, features = ["vendored"] }
 dotenvy = "0.15"
 
 [dev-dependencies]
-assert_cmd = "2.0.14"
+assert_cmd = "2.1"
 url = "2.2.2"
 diesel_migrations = { version = "2.3.0", path = "../../../diesel_migrations" }
 

--- a/examples/postgres/getting_started_step_2/tests/step_2.rs
+++ b/examples/postgres/getting_started_step_2/tests/step_2.rs
@@ -1,4 +1,4 @@
-use assert_cmd::Command;
+use assert_cmd::cargo::cargo_bin_cmd;
 use diesel::connection::SimpleConnection;
 use diesel::{Connection, PgConnection};
 use diesel_migrations::MigrationHarness;
@@ -34,8 +34,7 @@ fn write_post() {
     let migrations = diesel_migrations::FileBasedMigrations::find_migrations_directory().unwrap();
     conn.run_pending_migrations(migrations).unwrap();
 
-    let _ = Command::cargo_bin("write_post")
-        .unwrap()
+    let _ = cargo_bin_cmd!("write_post_step_2")
         .env("PG_DATABASE_URL", db_url.to_string())
         .write_stdin("Test Title\ntest text\n1 2 3")
         .assert()
@@ -47,8 +46,7 @@ fn write_post() {
                 + " when finished)\n\n\nSaved draft Test Title with id 1\n",
         );
 
-    let _ = Command::cargo_bin("show_posts")
-        .unwrap()
+    let _ = cargo_bin_cmd!("show_posts_step_2")
         .env("PG_DATABASE_URL", db_url.to_string())
         .assert()
         .append_context("show_posts", "")

--- a/examples/postgres/getting_started_step_3/Cargo.toml
+++ b/examples/postgres/getting_started_step_3/Cargo.toml
@@ -11,7 +11,7 @@ openssl-sys = { workspace = true, features = ["vendored"] }
 dotenvy = "0.15"
 
 [dev-dependencies]
-assert_cmd = "2.0.14"
+assert_cmd = "2.1"
 url = "2.2.2"
 diesel_migrations = { version = "2.3.0", path = "../../../diesel_migrations" }
 

--- a/examples/postgres/getting_started_step_3/tests/step_3.rs
+++ b/examples/postgres/getting_started_step_3/tests/step_3.rs
@@ -1,4 +1,4 @@
-use assert_cmd::Command;
+use assert_cmd::cargo::cargo_bin_cmd;
 use diesel::connection::SimpleConnection;
 use diesel::{Connection, PgConnection};
 use diesel_migrations::MigrationHarness;
@@ -34,15 +34,13 @@ fn publish_post() {
     let migrations = diesel_migrations::FileBasedMigrations::find_migrations_directory().unwrap();
     conn.run_pending_migrations(migrations).unwrap();
 
-    let _ = Command::cargo_bin("show_posts")
-        .unwrap()
+    let _ = cargo_bin_cmd!("show_posts")
         .env("PG_DATABASE_URL", db_url.to_string())
         .assert()
         .append_context("show_posts", "")
         .stdout("Displaying 0 posts\n");
 
-    let _ = Command::cargo_bin("write_post")
-        .unwrap()
+    let _ = cargo_bin_cmd!("write_post")
         .env("PG_DATABASE_URL", db_url.to_string())
         .write_stdin("Test Title\ntest text\n1 2 3")
         .assert()
@@ -54,31 +52,27 @@ fn publish_post() {
                 + " when finished)\n\n\nSaved draft Test Title with id 1\n",
         );
 
-    let _ = Command::cargo_bin("publish_post")
-        .unwrap()
+    let _ = cargo_bin_cmd!("publish_post")
         .env("PG_DATABASE_URL", db_url.to_string())
         .arg("1")
         .assert()
         .append_context("publish_post", "")
         .stdout("Published post Test Title\n");
 
-    let _ = Command::cargo_bin("show_posts")
-        .unwrap()
+    let _ = cargo_bin_cmd!("show_posts")
         .env("PG_DATABASE_URL", db_url.to_string())
         .assert()
         .append_context("show_posts", "")
         .stdout("Displaying 1 posts\nTest Title\n-----------\n\ntest text\n1 2 3\n");
 
-    let _ = Command::cargo_bin("delete_post")
-        .unwrap()
+    let _ = cargo_bin_cmd!("delete_post")
         .env("PG_DATABASE_URL", db_url.to_string())
         .arg("Test Title")
         .assert()
         .append_context("delete_post", "")
         .stdout("Deleted 1 posts\n");
 
-    let _ = Command::cargo_bin("show_posts")
-        .unwrap()
+    let _ = cargo_bin_cmd!("show_posts")
         .env("PG_DATABASE_URL", db_url.to_string())
         .assert()
         .append_context("show_posts", "")

--- a/examples/sqlite/getting_started_step_1/Cargo.toml
+++ b/examples/sqlite/getting_started_step_1/Cargo.toml
@@ -12,7 +12,7 @@ libsqlite3-sys = { workspace = true, features = ["bundled"] }
 dotenvy = "0.15"
 
 [dev-dependencies]
-assert_cmd = "2.0.14"
+assert_cmd = "2.1"
 tempfile = "3"
 diesel_migrations = { version = "2.3.0", path = "../../../diesel_migrations" }
 

--- a/examples/sqlite/getting_started_step_1/tests/step_1.rs
+++ b/examples/sqlite/getting_started_step_1/tests/step_1.rs
@@ -1,4 +1,4 @@
-use assert_cmd::Command;
+use assert_cmd::cargo::cargo_bin_cmd;
 use diesel::Connection;
 use diesel::SqliteConnection;
 use diesel_migrations::MigrationHarness;
@@ -11,8 +11,7 @@ fn show_posts() {
     let migrations = diesel_migrations::FileBasedMigrations::find_migrations_directory().unwrap();
     conn.run_pending_migrations(migrations).unwrap();
 
-    let _ = Command::cargo_bin("show_posts")
-        .unwrap()
+    let _ = cargo_bin_cmd!("show_posts_step_1")
         .env("SQLITE_DATABASE_URL", &db_url)
         .assert()
         .append_context("show_posts", "")

--- a/examples/sqlite/getting_started_step_2/Cargo.toml
+++ b/examples/sqlite/getting_started_step_2/Cargo.toml
@@ -11,7 +11,7 @@ libsqlite3-sys = { workspace = true, features = ["bundled"] }
 dotenvy = "0.15"
 
 [dev-dependencies]
-assert_cmd = "2.0.14"
+assert_cmd = "2.1"
 tempfile = "3"
 diesel_migrations = { version = "2.3.0", path = "../../../diesel_migrations" }
 

--- a/examples/sqlite/getting_started_step_2/tests/step_2.rs
+++ b/examples/sqlite/getting_started_step_2/tests/step_2.rs
@@ -1,4 +1,4 @@
-use assert_cmd::Command;
+use assert_cmd::cargo::cargo_bin_cmd;
 use diesel::Connection;
 use diesel::SqliteConnection;
 use diesel_migrations::MigrationHarness;
@@ -11,8 +11,7 @@ fn write_post() {
     let migrations = diesel_migrations::FileBasedMigrations::find_migrations_directory().unwrap();
     conn.run_pending_migrations(migrations).unwrap();
 
-    let _ = Command::cargo_bin("write_post")
-        .unwrap()
+    let _ = cargo_bin_cmd!("write_post_step_2")
         .env("SQLITE_DATABASE_URL", &db_url)
         .write_stdin("Test Title\ntest text\n1 2 3")
         .assert()
@@ -21,11 +20,10 @@ fn write_post() {
             "What would you like your title to be?\n\nOk! Let's write Test Title (Press "
                 .to_owned()
                 + EOF
-                + " when finished)\n\n\nSaved draft Test Title\n",
+                + " when finished)\n\n\nSaved draft Test Title with id 1\n",
         );
 
-    let _ = Command::cargo_bin("show_posts")
-        .unwrap()
+    let _ = cargo_bin_cmd!("show_posts_step_2")
         .env("SQLITE_DATABASE_URL", &db_url)
         .assert()
         .append_context("show_posts", "")

--- a/examples/sqlite/getting_started_step_3/Cargo.toml
+++ b/examples/sqlite/getting_started_step_3/Cargo.toml
@@ -11,7 +11,7 @@ libsqlite3-sys = { workspace = true, features = ["bundled"] }
 dotenvy = "0.15"
 
 [dev-dependencies]
-assert_cmd = "2.0.14"
+assert_cmd = "2.1"
 tempfile = "3"
 diesel_migrations = { version = "2.3.0", path = "../../../diesel_migrations" }
 

--- a/examples/sqlite/getting_started_step_3/tests/step_3.rs
+++ b/examples/sqlite/getting_started_step_3/tests/step_3.rs
@@ -1,4 +1,4 @@
-use assert_cmd::Command;
+use assert_cmd::cargo::cargo_bin_cmd;
 use diesel::Connection;
 use diesel::SqliteConnection;
 use diesel_migrations::MigrationHarness;
@@ -11,15 +11,13 @@ fn publish_post() {
     let migrations = diesel_migrations::FileBasedMigrations::find_migrations_directory().unwrap();
     conn.run_pending_migrations(migrations).unwrap();
 
-    let _ = Command::cargo_bin("show_posts")
-        .unwrap()
+    let _ = cargo_bin_cmd!("show_posts")
         .env("SQLITE_DATABASE_URL", &db_url)
         .assert()
         .append_context("show_posts", "")
         .stdout("Displaying 0 posts\n");
 
-    let _ = Command::cargo_bin("write_post")
-        .unwrap()
+    let _ = cargo_bin_cmd!("write_post")
         .env("SQLITE_DATABASE_URL", &db_url)
         .write_stdin("Test Title\ntest text\n1 2 3")
         .assert()
@@ -31,31 +29,27 @@ fn publish_post() {
                 + " when finished)\n\n\nSaved draft Test Title\n",
         );
 
-    let _ = Command::cargo_bin("publish_post")
-        .unwrap()
+    let _ = cargo_bin_cmd!("publish_post")
         .env("SQLITE_DATABASE_URL", &db_url)
         .arg("1")
         .assert()
         .append_context("publish_post", "")
         .stdout("Published post Test Title\n");
 
-    let _ = Command::cargo_bin("show_posts")
-        .unwrap()
+    let _ = cargo_bin_cmd!("show_posts")
         .env("SQLITE_DATABASE_URL", &db_url)
         .assert()
         .append_context("show_posts", "")
         .stdout("Displaying 1 posts\nTest Title\n----------\n\ntest text\n1 2 3\n");
 
-    let _ = Command::cargo_bin("delete_post")
-        .unwrap()
+    let _ = cargo_bin_cmd!("delete_post")
         .env("SQLITE_DATABASE_URL", &db_url)
         .arg("Test Title")
         .assert()
         .append_context("delete_post", "")
         .stdout("Deleted 1 posts\n");
 
-    let _ = Command::cargo_bin("show_posts")
-        .unwrap()
+    let _ = cargo_bin_cmd!("show_posts")
         .env("SQLITE_DATABASE_URL", &db_url)
         .assert()
         .append_context("show_posts", "")


### PR DESCRIPTION
The step 1 and step 2 tests asked `assert_cmd` for `show_posts` and `write_post`, but those packages build `show_posts_step_1`, `show_posts_step_2` and `write_post_step_2`. With no matching `CARGO_BIN_EXE_*` set, `assert_cmd` fell back to searching the shared target directory, found step 3's binaries there and ran those instead.

Nightly stopped resolving that fallback, which is what finally turned it into a failure.

Therefore, I switched to `cargo_bin_cmd!`, which resolves the target through `env!` at compile time. A name that does not match a binary in the same package is now a build error instead of a silent substitution.

That needs `assert_cmd` 2.1, and the sqlite step 2 expectation changes to what step 2 actually prints.

**LLM disclosure: I launched Fable against this because it was way too cursed**