### PR TITLE
Rebuild the generic arguments of `QueryId` derive

### DIFF
--- a/diesel_derives/src/query_id.rs
+++ b/diesel_derives/src/query_id.rs
@@ -38,7 +38,20 @@ pub fn derive(mut item: DeriveInput) -> TokenStream {
     });
 
     let struct_name = &item.ident;
-    let lifetimes = item.generics.lifetimes();
+    // Arguments must follow the declaration order of the parameters, so walk them in
+    // order rather than grouping by kind. Lifetimes become `'static`, which is both
+    // required (`Any` implies `'static`) and correct (a lifetime cannot change the SQL).
+    let query_id_args = item.generics.params.iter().map(|param| match param {
+        syn::GenericParam::Lifetime(_) => quote!('static),
+        syn::GenericParam::Type(ty_param) => {
+            let ident = &ty_param.ident;
+            quote!(<#ident as diesel::query_builder::QueryId>::QueryId)
+        }
+        syn::GenericParam::Const(const_param) => {
+            let ident = &const_param.ident;
+            quote!(#ident)
+        }
+    });
 
     let ty_params = item
         .generics
@@ -46,15 +59,6 @@ pub fn derive(mut item: DeriveInput) -> TokenStream {
         .map(|ty_param| &ty_param.ident)
         .collect::<Vec<_>>();
 
-    let consts = item
-        .generics
-        .const_params()
-        .map(|const_param| &const_param.ident)
-        .collect::<Vec<_>>();
-
-    let query_id_ty_params = ty_params
-        .iter()
-        .map(|ty_param| quote!(<#ty_param as diesel::query_builder::QueryId>::QueryId));
     let has_static_query_id = ty_params
         .iter()
         .map(|ty_param| quote!(<#ty_param as diesel::query_builder::QueryId>::HAS_STATIC_QUERY_ID));
@@ -72,7 +76,7 @@ pub fn derive(mut item: DeriveInput) -> TokenStream {
         impl #impl_generics diesel::query_builder::QueryId for #struct_name #ty_generics
         #where_clause
         {
-            type QueryId = #struct_name<#(#lifetimes,)* #(#query_id_ty_params,)* #(#consts,)*>;
+            type QueryId = #struct_name<#(#query_id_args,)*>;
 
             const HAS_STATIC_QUERY_ID: bool = #(#has_static_query_id &&)* true;
 

--- a/diesel_derives/src/tests/query_id.rs
+++ b/diesel_derives/src/tests/query_id.rs
@@ -15,3 +15,45 @@ pub(crate) fn query_id_1() {
         "query_id_1",
     );
 }
+
+#[test]
+pub(crate) fn query_id_lifetime() {
+    let input = quote::quote! {
+        struct Query<'a> { f: &'a str }
+    };
+
+    expand_with(
+        &crate::derive_query_id_inner as &dyn Fn(_) -> _,
+        input,
+        derive(syn::parse_quote!(#[derive(QueryId)])),
+        "query_id_lifetime",
+    );
+}
+
+#[test]
+pub(crate) fn query_id_bounded_lifetimes() {
+    let input = quote::quote! {
+        struct Query<'a: 'b, 'b> { f: &'a str, g: &'b str }
+    };
+
+    expand_with(
+        &crate::derive_query_id_inner as &dyn Fn(_) -> _,
+        input,
+        derive(syn::parse_quote!(#[derive(QueryId)])),
+        "query_id_bounded_lifetimes",
+    );
+}
+
+#[test]
+pub(crate) fn query_id_const_before_type() {
+    let input = quote::quote! {
+        struct Query<'a, const N: usize, T> { f: &'a str, g: T }
+    };
+
+    expand_with(
+        &crate::derive_query_id_inner as &dyn Fn(_) -> _,
+        input,
+        derive(syn::parse_quote!(#[derive(QueryId)])),
+        "query_id_const_before_type",
+    );
+}

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__query_id_bounded_lifetimes.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__query_id_bounded_lifetimes.snap
@@ -1,0 +1,15 @@
+---
+source: diesel_derives/src/tests/mod.rs
+expression: out
+info:
+  input: "#[derive(QueryId)]\nstruct Query<'a: 'b, 'b> {\n    f: &'a str,\n    g: &'b str,\n}\n"
+---
+const _: () = {
+    use diesel;
+    #[allow(non_camel_case_types)]
+    impl<'a: 'b, 'b> diesel::query_builder::QueryId for Query<'a, 'b> {
+        type QueryId = Query<'static, 'static>;
+        const HAS_STATIC_QUERY_ID: bool = true;
+        const IS_WINDOW_FUNCTION: bool = false;
+    }
+};

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__query_id_const_before_type.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__query_id_const_before_type.snap
@@ -1,0 +1,21 @@
+---
+source: diesel_derives/src/tests/mod.rs
+expression: out
+info:
+  input: "#[derive(QueryId)]\nstruct Query<'a, const N: usize, T> {\n    f: &'a str,\n    g: T,\n}\n"
+---
+const _: () = {
+    use diesel;
+    #[allow(non_camel_case_types)]
+    impl<
+        'a,
+        const N: usize,
+        T: diesel::query_builder::QueryId,
+    > diesel::query_builder::QueryId for Query<'a, N, T> {
+        type QueryId = Query<'static, N, <T as diesel::query_builder::QueryId>::QueryId>;
+        const HAS_STATIC_QUERY_ID: bool = <T as diesel::query_builder::QueryId>::HAS_STATIC_QUERY_ID
+            && true;
+        const IS_WINDOW_FUNCTION: bool = <T as diesel::query_builder::QueryId>::IS_WINDOW_FUNCTION
+            || false;
+    }
+};

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__query_id_lifetime.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__query_id_lifetime.snap
@@ -1,0 +1,15 @@
+---
+source: diesel_derives/src/tests/mod.rs
+expression: out
+info:
+  input: "#[derive(QueryId)]\nstruct Query<'a> {\n    f: &'a str,\n}\n"
+---
+const _: () = {
+    use diesel;
+    #[allow(non_camel_case_types)]
+    impl<'a> diesel::query_builder::QueryId for Query<'a> {
+        type QueryId = Query<'static>;
+        const HAS_STATIC_QUERY_ID: bool = true;
+        const IS_WINDOW_FUNCTION: bool = false;
+    }
+};

--- a/diesel_derives/tests/query_id.rs
+++ b/diesel_derives/tests/query_id.rs
@@ -1,0 +1,168 @@
+use core::any::TypeId;
+use diesel::query_builder::QueryId;
+
+#[derive(QueryId)]
+struct Borrowed<'a> {
+    _value: &'a str,
+}
+
+#[derive(QueryId)]
+struct BoundedLifetimes<'a: 'b, 'b> {
+    _outer: &'a str,
+    _inner: &'b str,
+}
+
+#[derive(QueryId)]
+struct Mixed<'a, T> {
+    _value: &'a str,
+    _other: T,
+}
+
+#[derive(QueryId)]
+struct MarkerA;
+
+#[derive(QueryId)]
+struct MarkerB;
+
+fn query_id_of<T: QueryId>(_: &T) -> Option<TypeId> {
+    T::query_id()
+}
+
+#[test]
+fn a_lifetime_does_not_change_the_query_id() {
+    let owned = String::from("borrowed for a short time");
+    let short = Borrowed { _value: &owned };
+    let long = Borrowed {
+        _value: "borrowed for the whole program",
+    };
+
+    // The two values hold different lifetimes but render the same SQL, so they must
+    // share a prepared statement.
+    assert_eq!(query_id_of(&short), query_id_of(&long));
+    assert_eq!(
+        query_id_of(&short),
+        Some(TypeId::of::<Borrowed<'static>>()),
+        "the lifetime should be erased to 'static"
+    );
+}
+
+#[test]
+fn a_bounded_lifetime_is_erased_as_well() {
+    let outer = String::from("outer");
+    let inner = String::from("inner");
+    let value = BoundedLifetimes {
+        _outer: &outer,
+        _inner: &inner,
+    };
+
+    assert_eq!(
+        query_id_of(&value),
+        Some(TypeId::of::<BoundedLifetimes<'static, 'static>>())
+    );
+}
+
+#[test]
+fn a_type_parameter_still_contributes_to_the_query_id() {
+    let owned = String::from("value");
+    let with_a = Mixed {
+        _value: &owned,
+        _other: MarkerA,
+    };
+    let with_b = Mixed {
+        _value: &owned,
+        _other: MarkerB,
+    };
+
+    assert_ne!(query_id_of(&with_a), query_id_of(&with_b));
+}
+
+#[derive(QueryId)]
+struct ConstBeforeType<'a, const N: usize, T> {
+    _value: &'a str,
+    _other: T,
+}
+
+#[test]
+fn generic_arguments_keep_their_declared_order() {
+    let owned = String::from("value");
+    let value: ConstBeforeType<'_, 3, MarkerA> = ConstBeforeType {
+        _value: &owned,
+        _other: MarkerA,
+    };
+
+    assert_eq!(
+        query_id_of(&value),
+        Some(TypeId::of::<ConstBeforeType<'static, 3, MarkerA>>())
+    );
+}
+
+#[derive(QueryId)]
+struct TypeParamBorrowedForALifetime<'a, T: 'a> {
+    _value: &'a T,
+}
+
+#[derive(QueryId)]
+struct ConstBetweenTypes<A, const N: usize, B> {
+    _a: A,
+    _n: [u8; N],
+    _b: B,
+}
+
+#[derive(QueryId)]
+enum BorrowedOrOwned<'a, T> {
+    _Borrowed(&'a str),
+    _Owned(T),
+}
+
+#[derive(QueryId)]
+struct Defaulted<T = MarkerA, const N: usize = 3> {
+    _value: T,
+    _n: [u8; N],
+}
+
+#[test]
+fn a_type_parameter_may_borrow_for_the_erased_lifetime() {
+    // `T::QueryId` has to outlive the erased `'static`, which only holds because
+    // `QueryId::QueryId` is bound by `Any`.
+    let marker = MarkerA;
+    let value = TypeParamBorrowedForALifetime { _value: &marker };
+
+    assert_eq!(
+        query_id_of(&value),
+        Some(TypeId::of::<TypeParamBorrowedForALifetime<'static, MarkerA>>())
+    );
+}
+
+#[test]
+fn a_const_between_two_type_parameters_stays_put() {
+    let value: ConstBetweenTypes<MarkerA, 2, MarkerB> = ConstBetweenTypes {
+        _a: MarkerA,
+        _n: [0, 0],
+        _b: MarkerB,
+    };
+
+    assert_eq!(
+        query_id_of(&value),
+        Some(TypeId::of::<ConstBetweenTypes<MarkerA, 2, MarkerB>>())
+    );
+}
+
+#[test]
+fn an_enum_is_handled_like_a_struct() {
+    let value: BorrowedOrOwned<'_, MarkerA> = BorrowedOrOwned::_Owned(MarkerA);
+
+    assert_eq!(
+        query_id_of(&value),
+        Some(TypeId::of::<BorrowedOrOwned<'static, MarkerA>>())
+    );
+}
+
+#[test]
+fn defaulted_parameters_are_not_repeated_in_the_query_id() {
+    let value: Defaulted = Defaulted {
+        _value: MarkerA,
+        _n: [0, 0, 0],
+    };
+
+    assert_eq!(query_id_of(&value), Some(TypeId::of::<Defaulted>()));
+}

--- a/diesel_derives/tests/tests.rs
+++ b/diesel_derives/tests/tests.rs
@@ -15,6 +15,7 @@ mod enum_;
 mod identifiable;
 mod insertable;
 mod multiconnection;
+mod query_id;
 mod queryable;
 mod queryable_by_name;
 mod selectable;


### PR DESCRIPTION
`#[derive(QueryId)]` rebuilt the type's generic arguments grouped by category, lifetimes then types then consts, rather than in the order they were declared. That breaks three ways

* A lifetime is carried over verbatim, so `struct Query<'a>` yields `type QueryId = Query<'a>` and fails the `Any` bound on `QueryId::QueryId`.
* A bounded lifetime is emitted together with its bounds, so `struct Query<'a: 'b, 'b>` produces `Query<'a: 'b, 'b>` in type position and does not parse at all.
* And a const declared before a type parameter comes back swapped, so `struct Query<const N: usize, T>` is rejected with `E0747`.

The arguments are now built by walking the parameters in order and mapping each to its argument form. Lifetimes become `'static`, since they cannot affect the generated SQL and the associated type exists only as a cache key, so two values of one type holding different lifetimes correctly share a prepared statement.