### PR TITLE
docs: cover AsExpression not_sized derive

### DIFF
--- a/diesel_derives/build.rs
+++ b/diesel_derives/build.rs
@@ -179,10 +179,7 @@ fn main() {
         (
             "as_expression",
             vec![
-                Example::with_heading(
-                    "diesel_derives__tests__as_expression_1.snap",
-                    "Basic usage",
-                ),
+                Example::with_heading("diesel_derives__tests__as_expression_1.snap", "Basic usage"),
                 Example::with_heading(
                     "diesel_derives__tests__as_expression_not_sized_1.snap",
                     "With `#[diesel(not_sized)]`",

--- a/diesel_derives/build.rs
+++ b/diesel_derives/build.rs
@@ -178,7 +178,16 @@ fn main() {
         ),
         (
             "as_expression",
-            vec![Example::new("diesel_derives__tests__as_expression_1.snap")],
+            vec![
+                Example::with_heading(
+                    "diesel_derives__tests__as_expression_1.snap",
+                    "Without attributes",
+                ),
+                Example::with_heading(
+                    "diesel_derives__tests__as_expression_not_sized_1.snap",
+                    "With `#[diesel(not_sized)]`",
+                ),
+            ],
         ),
         (
             "associations",

--- a/diesel_derives/build.rs
+++ b/diesel_derives/build.rs
@@ -181,7 +181,7 @@ fn main() {
             vec![
                 Example::with_heading(
                     "diesel_derives__tests__as_expression_1.snap",
-                    "Without attributes",
+                    "Basic usage",
                 ),
                 Example::with_heading(
                     "diesel_derives__tests__as_expression_not_sized_1.snap",

--- a/diesel_derives/src/tests/as_expression.rs
+++ b/diesel_derives/src/tests/as_expression.rs
@@ -24,7 +24,7 @@ pub(crate) fn as_expression_not_sized_1() {
     let input = quote::quote! {
         #[diesel(sql_type = diesel::sql_type::Text)]
         #[diesel(not_sized)]
-        struct Foo(str);
+        struct StringSlice(str);
     };
     expand_with(
         &crate::derive_as_expression_inner as &dyn Fn(_) -> _,

--- a/diesel_derives/src/tests/as_expression.rs
+++ b/diesel_derives/src/tests/as_expression.rs
@@ -18,3 +18,18 @@ pub(crate) fn as_expression_1() {
         "as_expression_1",
     );
 }
+
+#[test]
+pub(crate) fn as_expression_not_sized_1() {
+    let input = quote::quote! {
+        #[diesel(sql_type = diesel::sql_type::Text)]
+        #[diesel(not_sized)]
+        struct Foo(str);
+    };
+    expand_with(
+        &crate::derive_as_expression_inner as &dyn Fn(_) -> _,
+        input,
+        derive(syn::parse_quote!(#[derive(AsExpression)])),
+        "as_expression_not_sized_1",
+    );
+}

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_expression_not_sized_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_expression_not_sized_1.snap
@@ -1,0 +1,90 @@
+---
+source: diesel_derives/src/tests/mod.rs
+expression: out
+info:
+  input: "#[derive(AsExpression)]\n#[diesel(sql_type = diesel::sql_type::Text)]\n#[diesel(not_sized)]\nstruct Foo(str);\n"
+---
+const _: () = {
+    use diesel;
+    impl<'__expr> diesel::expression::AsExpression<diesel::sql_type::Text>
+    for &'__expr Foo {
+        type Expression = diesel::internal::derives::as_expression::Bound<
+            diesel::sql_type::Text,
+            Self,
+        >;
+        fn as_expression(
+            self,
+        ) -> <Self as diesel::expression::AsExpression<
+            diesel::sql_type::Text,
+        >>::Expression {
+            diesel::internal::derives::as_expression::Bound::new(self)
+        }
+    }
+    #[diagnostic::do_not_recommend]
+    impl<
+        '__expr,
+    > diesel::expression::AsExpression<
+        diesel::sql_types::Nullable<diesel::sql_type::Text>,
+    > for &'__expr Foo {
+        type Expression = diesel::internal::derives::as_expression::Bound<
+            diesel::sql_types::Nullable<diesel::sql_type::Text>,
+            Self,
+        >;
+        fn as_expression(
+            self,
+        ) -> <Self as diesel::expression::AsExpression<
+            diesel::sql_types::Nullable<diesel::sql_type::Text>,
+        >>::Expression {
+            diesel::internal::derives::as_expression::Bound::new(self)
+        }
+    }
+    #[diagnostic::do_not_recommend]
+    impl<'__expr, '__expr2> diesel::expression::AsExpression<diesel::sql_type::Text>
+    for &'__expr2 &'__expr Foo {
+        type Expression = diesel::internal::derives::as_expression::Bound<
+            diesel::sql_type::Text,
+            Self,
+        >;
+        fn as_expression(
+            self,
+        ) -> <Self as diesel::expression::AsExpression<
+            diesel::sql_type::Text,
+        >>::Expression {
+            diesel::internal::derives::as_expression::Bound::new(self)
+        }
+    }
+    #[diagnostic::do_not_recommend]
+    impl<
+        '__expr,
+        '__expr2,
+    > diesel::expression::AsExpression<
+        diesel::sql_types::Nullable<diesel::sql_type::Text>,
+    > for &'__expr2 &'__expr Foo {
+        type Expression = diesel::internal::derives::as_expression::Bound<
+            diesel::sql_types::Nullable<diesel::sql_type::Text>,
+            Self,
+        >;
+        fn as_expression(
+            self,
+        ) -> <Self as diesel::expression::AsExpression<
+            diesel::sql_types::Nullable<diesel::sql_type::Text>,
+        >>::Expression {
+            diesel::internal::derives::as_expression::Bound::new(self)
+        }
+    }
+    impl<
+        __DB,
+    > diesel::serialize::ToSql<diesel::sql_types::Nullable<diesel::sql_type::Text>, __DB>
+    for Foo
+    where
+        __DB: diesel::backend::Backend,
+        Self: diesel::serialize::ToSql<diesel::sql_type::Text, __DB>,
+    {
+        fn to_sql<'__b>(
+            &'__b self,
+            out: &mut diesel::serialize::Output<'__b, '_, __DB>,
+        ) -> diesel::serialize::Result {
+            diesel::serialize::ToSql::<diesel::sql_type::Text, __DB>::to_sql(self, out)
+        }
+    }
+};

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_expression_not_sized_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_expression_not_sized_1.snap
@@ -2,12 +2,12 @@
 source: diesel_derives/src/tests/mod.rs
 expression: out
 info:
-  input: "#[derive(AsExpression)]\n#[diesel(sql_type = diesel::sql_type::Text)]\n#[diesel(not_sized)]\nstruct Foo(str);\n"
+  input: "#[derive(AsExpression)]\n#[diesel(sql_type = diesel::sql_type::Text)]\n#[diesel(not_sized)]\nstruct StringSlice(str);\n"
 ---
 const _: () = {
     use diesel;
     impl<'__expr> diesel::expression::AsExpression<diesel::sql_type::Text>
-    for &'__expr Foo {
+    for &'__expr StringSlice {
         type Expression = diesel::internal::derives::as_expression::Bound<
             diesel::sql_type::Text,
             Self,
@@ -25,7 +25,7 @@ const _: () = {
         '__expr,
     > diesel::expression::AsExpression<
         diesel::sql_types::Nullable<diesel::sql_type::Text>,
-    > for &'__expr Foo {
+    > for &'__expr StringSlice {
         type Expression = diesel::internal::derives::as_expression::Bound<
             diesel::sql_types::Nullable<diesel::sql_type::Text>,
             Self,
@@ -40,7 +40,7 @@ const _: () = {
     }
     #[diagnostic::do_not_recommend]
     impl<'__expr, '__expr2> diesel::expression::AsExpression<diesel::sql_type::Text>
-    for &'__expr2 &'__expr Foo {
+    for &'__expr2 &'__expr StringSlice {
         type Expression = diesel::internal::derives::as_expression::Bound<
             diesel::sql_type::Text,
             Self,
@@ -59,7 +59,7 @@ const _: () = {
         '__expr2,
     > diesel::expression::AsExpression<
         diesel::sql_types::Nullable<diesel::sql_type::Text>,
-    > for &'__expr2 &'__expr Foo {
+    > for &'__expr2 &'__expr StringSlice {
         type Expression = diesel::internal::derives::as_expression::Bound<
             diesel::sql_types::Nullable<diesel::sql_type::Text>,
             Self,
@@ -75,7 +75,7 @@ const _: () = {
     impl<
         __DB,
     > diesel::serialize::ToSql<diesel::sql_types::Nullable<diesel::sql_type::Text>, __DB>
-    for Foo
+    for StringSlice
     where
         __DB: diesel::backend::Backend,
         Self: diesel::serialize::ToSql<diesel::sql_type::Text, __DB>,


### PR DESCRIPTION
## Summary
- add an `AsExpression` derive snapshot covering `#[diesel(not_sized)]`
- include the example in the generated derive documentation

Relates to #4840

## Validation
- `cargo test -p diesel_derives --lib tests::as_expression`
- `RUSTFLAGS="--cfg diesel_docsrs" cargo check -p diesel_derives`
- `git diff --check`

The full integration test command was not usable on this Windows host without a system SQLite import library; the targeted derive tests and docs-generation check passed. Rustfmt is also unavailable in the installed toolchain.

I was thinking of keeping this to the remaining `not_sized` example called out in the issue, so the generated docs show both the ordinary and unsized forms without changing derive behavior.

## Assistance disclosure
I used an AI coding assistant to help inspect the repository, draft the test fixture, and check the generated documentation. I reviewed the final diff and ran the commands listed above.
