### PR TITLE
Add `BoxedCloneSqlQuery`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 * Added `SqliteConnection::page_count` and `SqliteConnection::freelist_count` to read a database's total and reclaimable page counts, each accepting an optional schema name to target an attached database.
 * Added `SqliteConnection::incremental_vacuum` to return freelist pages to the filesystem on a database in incremental `auto_vacuum` mode, accepting an optional schema name and an optional bound on how many pages to reclaim.
 * Added `SqliteConnection::vacuum` and `SqliteConnection::vacuum_into` to rebuild a database or write a vacuumed copy of it to a new file, each accepting an optional schema name to target an attached database, with the destination path passed as a bind parameter.
+* Added `BoxedCloneQuery` type. This is a boxed query that uses `Arc` to allow the query to be cloned.
 
 ### Fixed
 

--- a/diesel/src/expression/mod.rs
+++ b/diesel/src/expression/mod.rs
@@ -1138,6 +1138,20 @@ impl<QS, ST, DB, GB, IsAggregate> ValidGrouping<GB>
     type IsAggregate = IsAggregate;
 }
 
+impl<QS, ST, DB, GB, IsAggregate> QueryId
+    for dyn BoxableExpression<QS, DB, GB, IsAggregate, SqlType = ST> + Send + Sync + '_
+{
+    type QueryId = ();
+
+    const HAS_STATIC_QUERY_ID: bool = false;
+}
+
+impl<QS, ST, DB, GB, IsAggregate> ValidGrouping<GB>
+    for dyn BoxableExpression<QS, DB, GB, IsAggregate, SqlType = ST> + Send + Sync + '_
+{
+    type IsAggregate = IsAggregate;
+}
+
 /// Converts a tuple of values into a tuple of Diesel expressions.
 #[deprecated(note = "Use `IntoArrayExpression` instead")]
 #[cfg(all(feature = "with-deprecated", not(feature = "without-deprecated")))]

--- a/diesel/src/internal/derives.rs
+++ b/diesel/src/internal/derives.rs
@@ -28,7 +28,7 @@ pub mod multiconnection {
     pub use crate::query_builder::insert_statement::DefaultValues;
     #[doc(hidden)]
     pub use crate::query_builder::limit_offset_clause::{
-        BoxedLimitOffsetClause, LimitOffsetClause,
+        BoxedCloneLimitOffsetClause, BoxedLimitOffsetClause, LimitOffsetClause,
     };
     #[doc(hidden)]
     pub use crate::query_builder::returning::ReturningClause;
@@ -36,6 +36,10 @@ pub mod multiconnection {
     pub use crate::query_builder::select_statement::SelectStatement;
     #[doc(hidden)]
     pub use crate::query_builder::select_statement::boxed::BoxedSelectStatement;
+    #[doc(hidden)]
+    pub use crate::query_builder::select_statement::boxed_clone::{
+        BoxedCloneQueryHelper, BoxedCloneSelectStatement,
+    };
     #[doc(hidden)]
     pub use crate::row::private::RowSealed;
     #[doc(hidden)]

--- a/diesel/src/internal/table_macro.rs
+++ b/diesel/src/internal/table_macro.rs
@@ -19,6 +19,8 @@ pub use crate::query_builder::select_statement::SelectStatement;
 #[doc(hidden)]
 pub use crate::query_builder::select_statement::boxed::BoxedSelectStatement;
 #[doc(hidden)]
+pub use crate::query_builder::select_statement::boxed_clone::BoxedCloneSelectStatement;
+#[doc(hidden)]
 pub use crate::query_source::aliasing::{
     AliasAliasAppearsInFromClause, AliasAliasAppearsInFromClauseSameTable,
     AliasAppearsInFromClause, FieldAliasMapperAssociatedTypesDisjointnessTrick,

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -510,6 +510,9 @@ pub mod helper_types {
     /// Represents the return type of [`.into_boxed::<'a, DB>()`](crate::prelude::QueryDsl::into_boxed)
     pub type IntoBoxed<'a, Source, DB> = <Source as BoxedDsl<'a, DB>>::Output;
 
+    /// Represents the return type of [`.into_boxed_clone::<'a, DB>()`](crate::prelude::QueryDsl::into_boxed_clone)
+    pub type IntoBoxedClone<'a, Source, DB> = <Source as BoxedCloneDsl<'a, DB>>::Output;
+
     /// Represents the return type of [`.distinct()`](crate::prelude::QueryDsl::distinct)
     pub type Distinct<Source> = <Source as DistinctDsl>::Output;
 

--- a/diesel/src/mysql/query_builder/limit_offset.rs
+++ b/diesel/src/mysql/query_builder/limit_offset.rs
@@ -1,9 +1,12 @@
 use crate::mysql::Mysql;
 use crate::query_builder::limit_clause::{LimitClause, NoLimitClause};
-use crate::query_builder::limit_offset_clause::{BoxedLimitOffsetClause, LimitOffsetClause};
+use crate::query_builder::limit_offset_clause::{
+    BoxedCloneLimitOffsetClause, BoxedLimitOffsetClause, LimitOffsetClause,
+};
 use crate::query_builder::offset_clause::{NoOffsetClause, OffsetClause};
-use crate::query_builder::{AstPass, IntoBoxedClause, QueryFragment};
+use crate::query_builder::{AstPass, IntoBoxedClause, IntoBoxedCloneClause, QueryFragment};
 use crate::result::QueryResult;
+use alloc::sync::Arc;
 
 impl QueryFragment<Mysql> for LimitOffsetClause<NoLimitClause, NoOffsetClause> {
     fn walk_ast<'b>(&'b self, _out: AstPass<'_, 'b, Mysql>) -> QueryResult<()> {
@@ -99,6 +102,67 @@ where
         BoxedLimitOffsetClause {
             limit: Some(Box::new(self.limit_clause)),
             offset: Some(Box::new(self.offset_clause)),
+        }
+    }
+}
+
+impl QueryFragment<Mysql> for BoxedCloneLimitOffsetClause<'_, Mysql> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Mysql>) -> QueryResult<()> {
+        match (self.limit.as_ref(), self.offset.as_ref()) {
+            (Some(limit), Some(offset)) => {
+                limit.walk_ast(out.reborrow())?;
+                offset.walk_ast(out.reborrow())?;
+            }
+            (Some(limit), None) => {
+                limit.walk_ast(out.reborrow())?;
+            }
+            (None, Some(offset)) => {
+                out.push_sql(" LIMIT 18446744073709551615 ");
+                offset.walk_ast(out.reborrow())?;
+            }
+            (None, None) => {}
+        }
+        Ok(())
+    }
+}
+
+impl<'a> IntoBoxedCloneClause<'a, Mysql> for LimitOffsetClause<NoLimitClause, NoOffsetClause> {
+    type BoxedCloneClause = BoxedCloneLimitOffsetClause<'a, Mysql>;
+
+    fn into_boxed_clone(self) -> Self::BoxedCloneClause {
+        BoxedCloneLimitOffsetClause {
+            limit: None,
+            offset: None,
+        }
+    }
+}
+
+impl<'a, L> IntoBoxedCloneClause<'a, Mysql> for LimitOffsetClause<LimitClause<L>, NoOffsetClause>
+where
+    L: QueryFragment<Mysql> + Send + Sync + 'a,
+{
+    type BoxedCloneClause = BoxedCloneLimitOffsetClause<'a, Mysql>;
+
+    fn into_boxed_clone(self) -> Self::BoxedCloneClause {
+        BoxedCloneLimitOffsetClause {
+            limit: Some(Arc::new(self.limit_clause)),
+            offset: None,
+        }
+    }
+}
+
+impl<'a, L, O> IntoBoxedCloneClause<'a, Mysql>
+    for LimitOffsetClause<LimitClause<L>, OffsetClause<O>>
+where
+    L: QueryFragment<Mysql> + Send + Sync + 'a,
+    O: QueryFragment<Mysql> + Send + Sync + 'a,
+{
+    type BoxedCloneClause = BoxedCloneLimitOffsetClause<'a, Mysql>;
+
+    fn into_boxed_clone(self) -> Self::BoxedCloneClause {
+        BoxedCloneLimitOffsetClause {
+            limit: Some(Arc::new(self.limit_clause)),
+            offset: Some(Arc::new(self.offset_clause)),
         }
     }
 }

--- a/diesel/src/pg/query_builder/limit_offset.rs
+++ b/diesel/src/pg/query_builder/limit_offset.rs
@@ -1,7 +1,37 @@
 use crate::pg::Pg;
-use crate::query_builder::limit_offset_clause::{BoxedLimitOffsetClause, LimitOffsetClause};
-use crate::query_builder::{AstPass, IntoBoxedClause, QueryFragment};
+use crate::query_builder::limit_offset_clause::{
+    BoxedCloneLimitOffsetClause, BoxedLimitOffsetClause, LimitOffsetClause,
+};
+use crate::query_builder::{AstPass, IntoBoxedClause, IntoBoxedCloneClause, QueryFragment};
 use crate::result::QueryResult;
+use alloc::sync::Arc;
+
+impl<'a, L, O> IntoBoxedCloneClause<'a, Pg> for LimitOffsetClause<L, O>
+where
+    L: QueryFragment<Pg> + Send + Sync + 'a,
+    O: QueryFragment<Pg> + Send + Sync + 'a,
+{
+    type BoxedCloneClause = BoxedCloneLimitOffsetClause<'a, Pg>;
+
+    fn into_boxed_clone(self) -> Self::BoxedCloneClause {
+        BoxedCloneLimitOffsetClause {
+            limit: Some(Arc::new(self.limit_clause)),
+            offset: Some(Arc::new(self.offset_clause)),
+        }
+    }
+}
+
+impl QueryFragment<Pg> for BoxedCloneLimitOffsetClause<'_, Pg> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
+        if let Some(ref limit) = self.limit {
+            limit.walk_ast(out.reborrow())?;
+        }
+        if let Some(ref offset) = self.offset {
+            offset.walk_ast(out.reborrow())?;
+        }
+        Ok(())
+    }
+}
 
 impl<'a, L, O> IntoBoxedClause<'a, Pg> for LimitOffsetClause<L, O>
 where

--- a/diesel/src/query_builder/delete_statement/mod.rs
+++ b/diesel/src/query_builder/delete_statement/mod.rs
@@ -1,5 +1,5 @@
 use crate::backend::DieselReserveSpecialization;
-use crate::dsl::{Filter, IntoBoxed, OrFilter};
+use crate::dsl::{Filter, IntoBoxed, IntoBoxedClone, OrFilter};
 use crate::expression::{AppearsOnTable, Expression, SelectableExpression};
 use crate::query_builder::returning::{
     DeleteStmt, NoReturningClause, ReturningClause, ReturningQuerySource,
@@ -7,7 +7,7 @@ use crate::query_builder::returning::{
 use crate::query_builder::where_clause::*;
 use crate::query_builder::*;
 use crate::query_dsl::RunQueryDslSupport;
-use crate::query_dsl::methods::{BoxedDsl, FilterDsl, OrFilterDsl};
+use crate::query_dsl::methods::{BoxedCloneDsl, BoxedDsl, FilterDsl, OrFilterDsl};
 use crate::query_source::{QuerySource, Table};
 
 #[must_use = "Queries are only executed when calling `load`, `get_result` or similar."]
@@ -74,6 +74,10 @@ where
 /// A `DELETE` statement with a boxed `WHERE` clause
 pub type BoxedDeleteStatement<'a, DB, T, Ret = NoReturningClause> =
     DeleteStatement<T, BoxedWhereClause<'a, DB>, Ret>;
+
+/// A `DELETE` statement with a boxed cloneable `WHERE` clause
+pub type BoxedCloneDeleteStatement<'a, DB, T, Ret = NoReturningClause> =
+    DeleteStatement<T, BoxedCloneWhereClause<'a, DB>, Ret>;
 
 impl<T: QuerySource, U> DeleteStatement<T, U, NoReturningClause> {
     pub(crate) fn new(table: T, where_clause: U) -> Self {
@@ -199,6 +203,57 @@ impl<T: QuerySource, U> DeleteStatement<T, U, NoReturningClause> {
     {
         BoxedDsl::internal_into_boxed(self)
     }
+
+    /// Wraps the `WHERE` clause of this delete statement in an [`Arc`].
+    ///
+    /// This is useful for cases where you want to clone and conditionally
+    /// modify a query, but need the type to remain the same. The backend
+    /// must be specified as part of this. It is not possible to box a query
+    /// and have it be useable on multiple backends.
+    ///
+    /// A cloneable boxed query will incur a slightly greater performance penalty
+    /// than a standard boxed query. In both cases, the query builder can no longer
+    /// be inlined by the compiler. For most applications this cost will be minimal.
+    ///
+    /// ### Example
+    ///
+    /// ```rust
+    /// # include!("../../doctest_setup.rs");
+    /// #
+    /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use std::collections::HashMap;
+    /// #     use schema::users::dsl::*;
+    /// #     let connection = &mut establish_connection();
+    /// #     let mut params = HashMap::new();
+    /// #     params.insert("sean_has_been_a_jerk", true);
+    /// let query = diesel::delete(users).into_boxed_clone();
+    /// let mut query = query.clone();
+    ///
+    /// if params["sean_has_been_a_jerk"] {
+    ///     query = query.filter(name.eq("Sean"));
+    /// }
+    ///
+    /// let deleted_rows = query.execute(connection)?;
+    /// assert_eq!(1, deleted_rows);
+    ///
+    /// let expected_names = vec!["Tess"];
+    /// let names = users.select(name).load::<String>(connection)?;
+    ///
+    /// assert_eq!(expected_names, names);
+    /// #     Ok(())
+    /// # }
+    /// ```
+    pub fn into_boxed_clone<'a, DB>(self) -> IntoBoxedClone<'a, Self, DB>
+    where
+        DB: Backend,
+        Self: BoxedCloneDsl<'a, DB>,
+    {
+        BoxedCloneDsl::internal_into_boxed_clone(self)
+    }
 }
 
 impl<T, U, Ret, Predicate> FilterDsl<Predicate> for DeleteStatement<T, U, Ret>
@@ -243,6 +298,22 @@ where
     type Output = BoxedDeleteStatement<'a, DB, T, Ret>;
 
     fn internal_into_boxed(self) -> Self::Output {
+        DeleteStatement {
+            where_clause: self.where_clause.into(),
+            returning: self.returning,
+            from_clause: self.from_clause,
+        }
+    }
+}
+
+impl<'a, T, U, Ret, DB> BoxedCloneDsl<'a, DB> for DeleteStatement<T, U, Ret>
+where
+    U: Into<BoxedCloneWhereClause<'a, DB>>,
+    T: QuerySource,
+{
+    type Output = BoxedCloneDeleteStatement<'a, DB, T, Ret>;
+
+    fn internal_into_boxed_clone(self) -> Self::Output {
         DeleteStatement {
             where_clause: self.where_clause.into(),
             returning: self.returning,

--- a/diesel/src/query_builder/has_query.rs
+++ b/diesel/src/query_builder/has_query.rs
@@ -1,5 +1,8 @@
 use super::group_by_clause::ValidGroupByClause;
-use super::{BoxedSelectStatement, FromClause, NoFromClause, Query, QueryId, SelectStatement};
+use super::{
+    BoxedCloneSelectStatement, BoxedSelectStatement, FromClause, NoFromClause, Query, QueryId,
+    SelectStatement,
+};
 use crate::backend::Backend;
 use crate::expression::ValidGrouping;
 use crate::query_dsl::methods::SelectDsl;
@@ -154,6 +157,25 @@ mod private {
     }
 
     impl<'a, ST, F, DB, GB> AcceptedQueries for BoxedSelectStatement<'a, ST, FromClause<F>, DB, GB>
+    where
+        F: QuerySource,
+        GB: ValidGroupByClause,
+    {
+        type From = F;
+
+        type GroupBy = GB::Expressions;
+    }
+
+    impl<'a, ST, DB, GB> AcceptedQueries for BoxedCloneSelectStatement<'a, ST, NoFromClause, DB, GB>
+    where
+        GB: ValidGroupByClause,
+    {
+        type From = NoFromClause;
+
+        type GroupBy = GB::Expressions;
+    }
+
+    impl<'a, ST, F, DB, GB> AcceptedQueries for BoxedCloneSelectStatement<'a, ST, FromClause<F>, DB, GB>
     where
         F: QuerySource,
         GB: ValidGroupByClause,

--- a/diesel/src/query_builder/limit_offset_clause.rs
+++ b/diesel/src/query_builder/limit_offset_clause.rs
@@ -1,6 +1,7 @@
 use super::QueryFragment;
 use crate::query_builder::QueryId;
 use alloc::boxed::Box;
+use alloc::sync::Arc;
 
 /// A helper query node that contains both limit and offset clauses
 ///
@@ -30,4 +31,28 @@ pub struct BoxedLimitOffsetClause<'a, DB> {
     pub limit: Option<Box<dyn QueryFragment<DB> + Send + 'a>>,
     /// The offset clause
     pub offset: Option<Box<dyn QueryFragment<DB> + Send + 'a>>,
+}
+
+/// A cloneable boxed variant of [`LimitOffsetClause`](LimitOffsetClause)
+///
+/// This type is only relevant for implementing custom backends
+#[allow(missing_debug_implementations)]
+#[cfg_attr(
+    diesel_docsrs,
+    doc(cfg(feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"))
+)]
+pub struct BoxedCloneLimitOffsetClause<'a, DB> {
+    /// The limit clause
+    pub limit: Option<Arc<dyn QueryFragment<DB> + Send + Sync + 'a>>,
+    /// The offset clause
+    pub offset: Option<Arc<dyn QueryFragment<DB> + Send + Sync + 'a>>,
+}
+
+impl<DB> Clone for BoxedCloneLimitOffsetClause<'_, DB> {
+    fn clone(&self) -> Self {
+        Self {
+            limit: self.limit.as_ref().map(Arc::clone),
+            offset: self.offset.as_ref().map(Arc::clone),
+        }
+    }
 }

--- a/diesel/src/query_builder/mod.rs
+++ b/diesel/src/query_builder/mod.rs
@@ -43,7 +43,9 @@ pub use self::collected_query::CollectedQuery;
 #[doc(inline)]
 pub use self::debug_query::DebugQuery;
 #[doc(inline)]
-pub use self::delete_statement::{BoxedDeleteStatement, DeleteStatement};
+pub use self::delete_statement::{
+    BoxedCloneDeleteStatement, BoxedDeleteStatement, DeleteStatement,
+};
 #[doc(inline)]
 pub use self::insert_statement::{
     IncompleteInsertOrIgnoreStatement, IncompleteInsertStatement, IncompleteReplaceStatement,
@@ -52,7 +54,7 @@ pub use self::insert_statement::{
 #[doc(inline)]
 pub use self::query_id::QueryId;
 #[doc(inline)]
-pub use self::sql_query::{BoxedSqlQuery, SqlQuery};
+pub use self::sql_query::{BoxedCloneSqlQuery, BoxedSqlQuery, SqlQuery};
 #[doc(inline)]
 pub use self::upsert::into_conflict_clause::IntoConflictValueClause;
 #[doc(inline)]
@@ -65,7 +67,9 @@ pub use self::update_statement::changeset::AsChangeset;
 #[doc(inline)]
 pub use self::update_statement::target::{IntoUpdateTarget, UpdateTarget};
 #[doc(inline)]
-pub use self::update_statement::{BoxedUpdateStatement, UpdateStatement};
+pub use self::update_statement::{
+    BoxedCloneUpdateStatement, BoxedUpdateStatement, UpdateStatement,
+};
 
 #[cfg(feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes")]
 pub use self::combination_clause::{
@@ -74,7 +78,9 @@ pub use self::combination_clause::{
 #[cfg(feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes")]
 pub use self::limit_clause::{LimitClause, NoLimitClause};
 #[cfg(feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes")]
-pub use self::limit_offset_clause::{BoxedLimitOffsetClause, LimitOffsetClause};
+pub use self::limit_offset_clause::{
+    BoxedCloneLimitOffsetClause, BoxedLimitOffsetClause, LimitOffsetClause,
+};
 #[cfg(feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes")]
 pub use self::offset_clause::{NoOffsetClause, OffsetClause};
 #[cfg(feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes")]
@@ -116,6 +122,11 @@ pub(crate) use self::select_clause::SelectClauseExpression;
     feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
 )]
 pub(crate) use self::from_clause::{FromClause, NoFromClause};
+#[diesel_derives::__diesel_public_if(
+    feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
+)]
+#[doc(inline)]
+pub(crate) use self::select_statement::BoxedCloneSelectStatement;
 #[diesel_derives::__diesel_public_if(
     feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
 )]
@@ -372,6 +383,20 @@ pub trait IntoBoxedClause<'a, DB> {
 
     /// Convert the given query node in it's boxed representation
     fn into_boxed(self) -> Self::BoxedClause;
+}
+
+/// A trait used to construct type erased boxed cloneable variant of the current query node
+///
+/// Mainly useful for implementing third party backends
+#[diagnostic::on_unimplemented(
+    note = "this usually means that `{Self}` is no valid SQL for `{DB}`"
+)]
+pub trait IntoBoxedCloneClause<'a, DB> {
+    /// Resulting type
+    type BoxedCloneClause;
+
+    /// Convert the given query node in it's boxed cloneable representation
+    fn into_boxed_clone(self) -> Self::BoxedCloneClause;
 }
 
 /// Types that can be converted into a complete, typed SQL query.

--- a/diesel/src/query_builder/order_clause.rs
+++ b/diesel/src/query_builder/order_clause.rs
@@ -1,6 +1,7 @@
 use alloc::boxed::Box;
 
 use crate::expression::{ValidGrouping, is_aggregate};
+use alloc::sync::Arc;
 
 simple_clause!(
     /// DSL node that represents that no order clause is set
@@ -21,6 +22,25 @@ where
 }
 
 impl<DB> From<NoOrderClause> for Option<Box<dyn QueryFragment<DB> + Send + '_>>
+where
+    DB: Backend,
+{
+    fn from(_: NoOrderClause) -> Self {
+        None
+    }
+}
+
+impl<'a, DB, Expr> From<OrderClause<Expr>> for Option<Arc<dyn QueryFragment<DB> + Send + Sync + 'a>>
+where
+    DB: Backend,
+    Expr: QueryFragment<DB> + Send + Sync + 'a,
+{
+    fn from(order: OrderClause<Expr>) -> Self {
+        Some(Arc::new(order.0))
+    }
+}
+
+impl<DB> From<NoOrderClause> for Option<Arc<dyn QueryFragment<DB> + Send + Sync + '_>>
 where
     DB: Backend,
 {

--- a/diesel/src/query_builder/select_statement/boxed_clone.rs
+++ b/diesel/src/query_builder/select_statement/boxed_clone.rs
@@ -1,0 +1,638 @@
+use core::marker::PhantomData;
+
+use crate::backend::{DieselReserveSpecialization, sql_dialect};
+use crate::dsl::AsExprOf;
+use crate::expression::subselect::ValidSubselect;
+use crate::expression::*;
+use crate::insertable::Insertable;
+use crate::query_builder::combination_clause::*;
+use crate::query_builder::distinct_clause::DistinctClause;
+use crate::query_builder::group_by_clause::ValidGroupByClause;
+use crate::query_builder::having_clause::HavingClause;
+use crate::query_builder::insert_statement::InsertFromSelect;
+use crate::query_builder::limit_clause::LimitClause;
+use crate::query_builder::limit_offset_clause::BoxedCloneLimitOffsetClause;
+use crate::query_builder::offset_clause::OffsetClause;
+use crate::query_builder::order_clause::OrderClause;
+use crate::query_builder::where_clause::{BoxedCloneWhereClause, WhereAnd, WhereOr};
+use crate::query_builder::*;
+use crate::query_dsl::methods::*;
+use crate::query_dsl::*;
+use crate::query_source::joins::*;
+use crate::query_source::{QuerySource, Table};
+use crate::sql_types::{BigInt, BoolOrNullableBool, IntoNullable};
+use alloc::sync::Arc;
+
+// This is used by the table macro internally
+/// This type represents a boxed select query
+///
+/// Using this type directly is only meaningful for custom backends
+/// that need to provide a custom [`QueryFragment`] implementation
+#[allow(missing_debug_implementations)]
+#[diesel_derives::__diesel_public_if(
+    feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes",
+    public_fields(
+        select,
+        from,
+        distinct,
+        where_clause,
+        order,
+        limit_offset,
+        group_by,
+        having
+    )
+)]
+pub struct BoxedCloneSelectStatement<'a, ST, QS, DB, GB = ()> {
+    /// The select clause of the query
+    select: Arc<dyn QueryFragment<DB> + Send + Sync + 'a>,
+    /// The from clause of the query
+    from: QS,
+    /// The distinct clause of the query
+    distinct: Arc<dyn QueryFragment<DB> + Send + Sync + 'a>,
+    /// The where clause of the query
+    where_clause: BoxedCloneWhereClause<'a, DB>,
+    /// The order clause of the query
+    order: Option<Arc<dyn QueryFragment<DB> + Send + Sync + 'a>>,
+    /// The combined limit/offset clause of the query
+    limit_offset: BoxedCloneLimitOffsetClause<'a, DB>,
+    /// The group by clause of the query
+    group_by: Arc<dyn QueryFragment<DB> + Send + Sync + 'a>,
+    /// The having clause of the query
+    having: Arc<dyn QueryFragment<DB> + Send + Sync + 'a>,
+    _marker: PhantomData<(ST, GB)>,
+}
+
+impl<ST, QS: Clone, DB, GB> Clone for BoxedCloneSelectStatement<'_, ST, QS, DB, GB> {
+    fn clone(&self) -> Self {
+        Self {
+            select: Arc::clone(&self.select),
+            from: self.from.clone(),
+            distinct: Arc::clone(&self.distinct),
+            where_clause: self.where_clause.clone(),
+            order: self.order.as_ref().map(Arc::clone),
+            limit_offset: self.limit_offset.clone(),
+            group_by: Arc::clone(&self.group_by),
+            having: Arc::clone(&self.having),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<'a, ST, QS: QuerySource, DB, GB> BoxedCloneSelectStatement<'a, ST, FromClause<QS>, DB, GB> {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new<S, G>(
+        select: S,
+        from: FromClause<QS>,
+        distinct: Arc<dyn QueryFragment<DB> + Send + Sync + 'a>,
+        where_clause: BoxedCloneWhereClause<'a, DB>,
+        order: Option<Arc<dyn QueryFragment<DB> + Send + Sync + 'a>>,
+        limit_offset: BoxedCloneLimitOffsetClause<'a, DB>,
+        group_by: G,
+        having: Arc<dyn QueryFragment<DB> + Send + Sync + 'a>,
+    ) -> Self
+    where
+        DB: Backend,
+        G: ValidGroupByClause<Expressions = GB> + QueryFragment<DB> + Send + Sync + 'a,
+        S: SelectClauseExpression<FromClause<QS>, SelectClauseSqlType = ST>
+            + QueryFragment<DB>
+            + Send
+            + Sync
+            + 'a,
+        S::Selection: ValidGrouping<GB>,
+    {
+        BoxedCloneSelectStatement {
+            select: Arc::new(select),
+            from,
+            distinct,
+            where_clause,
+            order,
+            limit_offset,
+            group_by: Arc::new(group_by),
+            having,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<'a, ST, DB, GB> BoxedCloneSelectStatement<'a, ST, NoFromClause, DB, GB> {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new_no_from_clause<S, G>(
+        select: S,
+        from: NoFromClause,
+        distinct: Arc<dyn QueryFragment<DB> + Send + Sync + 'a>,
+        where_clause: BoxedCloneWhereClause<'a, DB>,
+        order: Option<Arc<dyn QueryFragment<DB> + Send + Sync + 'a>>,
+        limit_offset: BoxedCloneLimitOffsetClause<'a, DB>,
+        group_by: G,
+        having: Arc<dyn QueryFragment<DB> + Send + Sync + 'a>,
+    ) -> Self
+    where
+        DB: Backend,
+        G: ValidGroupByClause<Expressions = GB> + QueryFragment<DB> + Send + Sync + 'a,
+        S: SelectClauseExpression<NoFromClause, SelectClauseSqlType = ST>
+            + QueryFragment<DB>
+            + Send
+            + Sync
+            + 'a,
+        S::Selection: ValidGrouping<GB>,
+    {
+        BoxedCloneSelectStatement {
+            select: Arc::new(select),
+            from,
+            distinct,
+            where_clause,
+            order,
+            limit_offset,
+            group_by: Arc::new(group_by),
+            having,
+            _marker: PhantomData,
+        }
+    }
+}
+
+// that's a trait to control who can access these methods
+#[doc(hidden)] // exported via internal::derives::multiconnection
+pub trait BoxedCloneQueryHelper<'a, QS, DB> {
+    fn build_query<'b, 'c>(
+        &'b self,
+        out: AstPass<'_, 'c, DB>,
+        where_clause_handler: impl Fn(
+            &'b BoxedCloneWhereClause<'a, DB>,
+            AstPass<'_, 'c, DB>,
+        ) -> QueryResult<()>,
+    ) -> QueryResult<()>
+    where
+        DB: Backend,
+        QS: QueryFragment<DB>,
+        BoxedCloneLimitOffsetClause<'a, DB>: QueryFragment<DB>,
+        'b: 'c;
+}
+
+impl<'a, ST, QS, DB, GB> BoxedCloneQueryHelper<'a, QS, DB>
+    for BoxedCloneSelectStatement<'a, ST, QS, DB, GB>
+{
+    fn build_query<'b, 'c>(
+        &'b self,
+        mut out: AstPass<'_, 'c, DB>,
+        where_clause_handler: impl Fn(
+            &'b BoxedCloneWhereClause<'a, DB>,
+            AstPass<'_, 'c, DB>,
+        ) -> QueryResult<()>,
+    ) -> QueryResult<()>
+    where
+        DB: Backend,
+        QS: QueryFragment<DB>,
+        BoxedCloneLimitOffsetClause<'a, DB>: QueryFragment<DB>,
+        'b: 'c,
+    {
+        out.push_sql("SELECT ");
+        self.distinct.walk_ast(out.reborrow())?;
+        self.select.walk_ast(out.reborrow())?;
+        self.from.walk_ast(out.reborrow())?;
+        where_clause_handler(&self.where_clause, out.reborrow())?;
+        self.group_by.walk_ast(out.reborrow())?;
+        self.having.walk_ast(out.reborrow())?;
+
+        if let Some(ref order) = self.order {
+            out.push_sql(" ORDER BY ");
+            order.walk_ast(out.reborrow())?;
+        }
+        self.limit_offset.walk_ast(out.reborrow())?;
+        Ok(())
+    }
+}
+
+impl<ST, QS, DB, GB> Query for BoxedCloneSelectStatement<'_, ST, QS, DB, GB>
+where
+    DB: Backend,
+{
+    type SqlType = ST;
+}
+
+impl<ST, QS, DB, GB> SelectQuery for BoxedCloneSelectStatement<'_, ST, QS, DB, GB>
+where
+    DB: Backend,
+{
+    type SqlType = ST;
+}
+
+impl<ST, QS, QS2, DB, GB> ValidSubselect<QS2> for BoxedCloneSelectStatement<'_, ST, QS, DB, GB> where
+    Self: Query<SqlType = ST>
+{
+}
+
+impl<ST, QS, DB, GB> QueryFragment<DB> for BoxedCloneSelectStatement<'_, ST, QS, DB, GB>
+where
+    DB: Backend,
+    Self: QueryFragment<DB, DB::SelectStatementSyntax>,
+{
+    fn walk_ast<'b>(&'b self, pass: AstPass<'_, 'b, DB>) -> QueryResult<()> {
+        <Self as QueryFragment<DB, DB::SelectStatementSyntax>>::walk_ast(self, pass)
+    }
+}
+
+impl<'a, ST, QS, DB, GB>
+    QueryFragment<DB, sql_dialect::select_statement_syntax::AnsiSqlSelectStatement>
+    for BoxedCloneSelectStatement<'a, ST, QS, DB, GB>
+where
+    DB: Backend<
+            SelectStatementSyntax = sql_dialect::select_statement_syntax::AnsiSqlSelectStatement,
+        > + DieselReserveSpecialization,
+    QS: QueryFragment<DB>,
+    BoxedCloneLimitOffsetClause<'a, DB>: QueryFragment<DB>,
+{
+    fn walk_ast<'b>(&'b self, out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
+        self.build_query(out, |where_clause, out| where_clause.walk_ast(out))
+    }
+}
+
+impl<ST, QS, DB, GB> QueryId for BoxedCloneSelectStatement<'_, ST, QS, DB, GB> {
+    type QueryId = ();
+
+    const HAS_STATIC_QUERY_ID: bool = false;
+}
+
+impl<'a, ST, QS, DB, Rhs, Kind, On, GB> InternalJoinDsl<Rhs, Kind, On>
+    for BoxedCloneSelectStatement<'a, ST, FromClause<QS>, DB, GB>
+where
+    QS: QuerySource,
+    Rhs: QuerySource,
+    JoinOn<Join<QS, Rhs, Kind>, On>: QuerySource,
+    BoxedCloneSelectStatement<'a, ST, FromClause<JoinOn<Join<QS, Rhs, Kind>, On>>, DB, GB>: AsQuery,
+{
+    type Output =
+        BoxedCloneSelectStatement<'a, ST, FromClause<JoinOn<Join<QS, Rhs, Kind>, On>>, DB, GB>;
+
+    fn join(self, rhs: Rhs, kind: Kind, on: On) -> Self::Output {
+        BoxedCloneSelectStatement {
+            select: self.select,
+            from: FromClause::new(Join::new(self.from.source, rhs, kind).on(on)),
+            distinct: self.distinct,
+            where_clause: self.where_clause,
+            order: self.order,
+            limit_offset: self.limit_offset,
+            group_by: self.group_by,
+            having: self.having,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<ST, QS, DB, GB> DistinctDsl for BoxedCloneSelectStatement<'_, ST, QS, DB, GB>
+where
+    DB: Backend,
+    DistinctClause: QueryFragment<DB>,
+{
+    type Output = Self;
+
+    fn distinct(mut self) -> Self::Output {
+        self.distinct = Arc::new(DistinctClause);
+        self
+    }
+}
+
+impl<'a, ST, QS, DB, Selection, GB> SelectDsl<Selection>
+    for BoxedCloneSelectStatement<'a, ST, FromClause<QS>, DB, GB>
+where
+    DB: Backend,
+    QS: QuerySource,
+    Selection: SelectableExpression<QS> + QueryFragment<DB> + ValidGrouping<GB> + Send + Sync + 'a,
+{
+    type Output = BoxedCloneSelectStatement<'a, Selection::SqlType, FromClause<QS>, DB, GB>;
+
+    fn select(self, selection: Selection) -> Self::Output {
+        BoxedCloneSelectStatement {
+            select: Arc::new(selection),
+            from: self.from,
+            distinct: self.distinct,
+            where_clause: self.where_clause,
+            order: self.order,
+            limit_offset: self.limit_offset,
+            group_by: self.group_by,
+            having: self.having,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<'a, ST, DB, Selection, GB> SelectDsl<Selection>
+    for BoxedCloneSelectStatement<'a, ST, NoFromClause, DB, GB>
+where
+    DB: Backend,
+    Selection: SelectableExpression<NoFromClause>
+        + QueryFragment<DB>
+        + ValidGrouping<GB>
+        + Send
+        + Sync
+        + 'a,
+{
+    type Output = BoxedCloneSelectStatement<'a, Selection::SqlType, NoFromClause, DB, GB>;
+
+    fn select(self, selection: Selection) -> Self::Output {
+        BoxedCloneSelectStatement {
+            select: Arc::new(selection),
+            from: self.from,
+            distinct: self.distinct,
+            where_clause: self.where_clause,
+            order: self.order,
+            limit_offset: self.limit_offset,
+            group_by: self.group_by,
+            having: self.having,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<'a, ST, QS, DB, Predicate, GB> FilterDsl<Predicate>
+    for BoxedCloneSelectStatement<'a, ST, FromClause<QS>, DB, GB>
+where
+    QS: QuerySource,
+    BoxedCloneWhereClause<'a, DB>: WhereAnd<Predicate, Output = BoxedCloneWhereClause<'a, DB>>,
+    Predicate: AppearsOnTable<QS> + NonAggregate,
+    Predicate::SqlType: BoolOrNullableBool,
+{
+    type Output = Self;
+
+    fn filter(mut self, predicate: Predicate) -> Self::Output {
+        self.where_clause = self.where_clause.and(predicate);
+        self
+    }
+}
+
+impl<'a, ST, DB, Predicate, GB> FilterDsl<Predicate>
+    for BoxedCloneSelectStatement<'a, ST, NoFromClause, DB, GB>
+where
+    BoxedCloneWhereClause<'a, DB>: WhereAnd<Predicate, Output = BoxedCloneWhereClause<'a, DB>>,
+    Predicate: AppearsOnTable<NoFromClause> + NonAggregate,
+    Predicate::SqlType: BoolOrNullableBool,
+{
+    type Output = Self;
+
+    fn filter(mut self, predicate: Predicate) -> Self::Output {
+        self.where_clause = self.where_clause.and(predicate);
+        self
+    }
+}
+
+impl<'a, ST, QS, DB, Predicate, GB> OrFilterDsl<Predicate>
+    for BoxedCloneSelectStatement<'a, ST, FromClause<QS>, DB, GB>
+where
+    QS: QuerySource,
+    BoxedCloneWhereClause<'a, DB>: WhereOr<Predicate, Output = BoxedCloneWhereClause<'a, DB>>,
+    Predicate: AppearsOnTable<QS> + NonAggregate,
+    Predicate::SqlType: BoolOrNullableBool,
+{
+    type Output = Self;
+
+    fn or_filter(mut self, predicate: Predicate) -> Self::Output {
+        self.where_clause = self.where_clause.or(predicate);
+        self
+    }
+}
+
+impl<'a, ST, DB, Predicate, GB> OrFilterDsl<Predicate>
+    for BoxedCloneSelectStatement<'a, ST, NoFromClause, DB, GB>
+where
+    BoxedCloneWhereClause<'a, DB>: WhereOr<Predicate, Output = BoxedCloneWhereClause<'a, DB>>,
+    Predicate: AppearsOnTable<NoFromClause> + NonAggregate,
+    Predicate::SqlType: BoolOrNullableBool,
+{
+    type Output = Self;
+
+    fn or_filter(mut self, predicate: Predicate) -> Self::Output {
+        self.where_clause = self.where_clause.or(predicate);
+        self
+    }
+}
+
+impl<ST, QS, DB, GB> LimitDsl for BoxedCloneSelectStatement<'_, ST, QS, DB, GB>
+where
+    DB: Backend,
+    LimitClause<AsExprOf<i64, BigInt>>: QueryFragment<DB>,
+{
+    type Output = Self;
+
+    fn limit(mut self, limit: i64) -> Self::Output {
+        self.limit_offset.limit = Some(Arc::new(LimitClause(limit.into_sql::<BigInt>())));
+        self
+    }
+}
+
+impl<ST, QS, DB, GB> OffsetDsl for BoxedCloneSelectStatement<'_, ST, QS, DB, GB>
+where
+    DB: Backend,
+    OffsetClause<AsExprOf<i64, BigInt>>: QueryFragment<DB>,
+{
+    type Output = Self;
+
+    fn offset(mut self, offset: i64) -> Self::Output {
+        self.limit_offset.offset = Some(Arc::new(OffsetClause(offset.into_sql::<BigInt>())));
+        self
+    }
+}
+
+// no impls for `NoFromClause` here because order is not really supported there yet
+impl<'a, ST, QS, DB, Order, GB> OrderDsl<Order>
+    for BoxedCloneSelectStatement<'a, ST, FromClause<QS>, DB, GB>
+where
+    DB: Backend,
+    QS: QuerySource,
+    Order: QueryFragment<DB> + AppearsOnTable<QS> + Send + Sync + 'a,
+{
+    type Output = Self;
+
+    fn order(mut self, order: Order) -> Self::Output {
+        self.order = OrderClause(order).into();
+        self
+    }
+}
+
+impl<'a, ST, QS, DB, Order, GB> ThenOrderDsl<Order>
+    for BoxedCloneSelectStatement<'a, ST, FromClause<QS>, DB, GB>
+where
+    DB: Backend + 'a,
+    QS: QuerySource,
+    Order: QueryFragment<DB> + AppearsOnTable<QS> + Send + Sync + 'a,
+{
+    type Output = Self;
+
+    fn then_order_by(mut self, order: Order) -> Self::Output {
+        self.order = match self.order {
+            Some(old) => Some(Arc::new((old, order))),
+            None => Some(Arc::new(order)),
+        };
+        self
+    }
+}
+
+impl<ST, QS, DB, Rhs> JoinTo<Rhs> for BoxedCloneSelectStatement<'_, ST, FromClause<QS>, DB, ()>
+where
+    QS: JoinTo<Rhs> + QuerySource,
+{
+    type FromClause = <QS as JoinTo<Rhs>>::FromClause;
+    type OnClause = QS::OnClause;
+
+    fn join_target(rhs: Rhs) -> (Self::FromClause, Self::OnClause) {
+        QS::join_target(rhs)
+    }
+}
+
+impl<ST, QS, DB, GB> QueryDsl for BoxedCloneSelectStatement<'_, ST, QS, DB, GB> {}
+
+impl<ST, QS, DB, GB> RunQueryDslSupport for BoxedCloneSelectStatement<'_, ST, QS, DB, GB> {}
+
+impl<ST, QS, DB, T, GB> Insertable<T> for BoxedCloneSelectStatement<'_, ST, QS, DB, GB>
+where
+    T: Table,
+    Self: Query,
+    <T::AllColumns as ValidGrouping<()>>::IsAggregate:
+        MixedAggregates<is_aggregate::No, Output = is_aggregate::No>,
+{
+    type Values = InsertFromSelect<Self, T::AllColumns>;
+
+    fn values(self) -> Self::Values {
+        InsertFromSelect::new(self)
+    }
+}
+
+impl<ST, QS, DB, T, GB> Insertable<T> for &BoxedCloneSelectStatement<'_, ST, QS, DB, GB>
+where
+    T: Table,
+    Self: Query,
+    <T::AllColumns as ValidGrouping<()>>::IsAggregate:
+        MixedAggregates<is_aggregate::No, Output = is_aggregate::No>,
+{
+    type Values = InsertFromSelect<Self, T::AllColumns>;
+
+    fn values(self) -> Self::Values {
+        InsertFromSelect::new(self)
+    }
+}
+
+impl<'a, ST, QS, DB, GB> SelectNullableDsl for BoxedCloneSelectStatement<'a, ST, QS, DB, GB>
+where
+    ST: IntoNullable,
+{
+    type Output = BoxedCloneSelectStatement<'a, ST::Nullable, QS, DB>;
+
+    fn nullable(self) -> Self::Output {
+        BoxedCloneSelectStatement {
+            select: self.select,
+            from: self.from,
+            distinct: self.distinct,
+            where_clause: self.where_clause,
+            order: self.order,
+            limit_offset: self.limit_offset,
+            group_by: self.group_by,
+            having: self.having,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<'a, ST, QS, DB, GB, Predicate> HavingDsl<Predicate>
+    for BoxedCloneSelectStatement<'a, ST, FromClause<QS>, DB, GB>
+where
+    QS: QuerySource,
+    DB: Backend,
+    GB: Expression,
+    HavingClause<Predicate>: QueryFragment<DB> + Send + Sync + 'a,
+    Predicate: AppearsOnTable<QS>,
+    Predicate::SqlType: BoolOrNullableBool,
+{
+    type Output = Self;
+
+    fn having(mut self, predicate: Predicate) -> Self::Output {
+        self.having = Arc::new(HavingClause(predicate));
+        self
+    }
+}
+
+impl<ST, QS, DB, GB> CombineDsl for BoxedCloneSelectStatement<'_, ST, QS, DB, GB>
+where
+    Self: Query,
+{
+    type Query = Self;
+
+    fn union<Rhs>(self, rhs: Rhs) -> crate::dsl::Union<Self, Rhs>
+    where
+        Rhs: AsQuery<SqlType = <Self::Query as Query>::SqlType>,
+    {
+        CombinationClause::new(Union, Distinct, self, rhs.as_query())
+    }
+
+    fn union_all<Rhs>(self, rhs: Rhs) -> crate::dsl::UnionAll<Self, Rhs>
+    where
+        Rhs: AsQuery<SqlType = <Self::Query as Query>::SqlType>,
+    {
+        CombinationClause::new(Union, All, self, rhs.as_query())
+    }
+
+    fn intersect<Rhs>(self, rhs: Rhs) -> crate::dsl::Intersect<Self, Rhs>
+    where
+        Rhs: AsQuery<SqlType = <Self::Query as Query>::SqlType>,
+    {
+        CombinationClause::new(Intersect, Distinct, self, rhs.as_query())
+    }
+
+    fn intersect_all<Rhs>(self, rhs: Rhs) -> crate::dsl::IntersectAll<Self, Rhs>
+    where
+        Rhs: AsQuery<SqlType = <Self::Query as Query>::SqlType>,
+    {
+        CombinationClause::new(Intersect, All, self, rhs.as_query())
+    }
+
+    fn except<Rhs>(self, rhs: Rhs) -> crate::dsl::Except<Self, Rhs>
+    where
+        Rhs: AsQuery<SqlType = <Self::Query as Query>::SqlType>,
+    {
+        CombinationClause::new(Except, Distinct, self, rhs.as_query())
+    }
+
+    fn except_all<Rhs>(self, rhs: Rhs) -> crate::dsl::ExceptAll<Self, Rhs>
+    where
+        Rhs: AsQuery<SqlType = <Self::Query as Query>::SqlType>,
+    {
+        CombinationClause::new(Except, All, self, rhs.as_query())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::prelude::*;
+
+    table! {
+        users {
+            id -> Integer,
+        }
+    }
+
+    fn assert_send<T>(_: T)
+    where
+        T: Send,
+    {
+    }
+
+    macro_rules! assert_boxed_query_send {
+        ($backend:ty) => {{
+            assert_send(users::table.into_boxed_clone::<$backend>());
+            assert_send(
+                users::table
+                    .filter(users::id.eq(10))
+                    .into_boxed_clone::<$backend>(),
+            );
+        };};
+    }
+
+    #[diesel_test_helper::test]
+    fn boxed_is_send() {
+        #[cfg(feature = "postgres")]
+        assert_boxed_query_send!(crate::pg::Pg);
+
+        #[cfg(feature = "__sqlite-shared")]
+        assert_boxed_query_send!(crate::sqlite::Sqlite);
+
+        #[cfg(feature = "mysql")]
+        assert_boxed_query_send!(crate::mysql::Mysql);
+    }
+}

--- a/diesel/src/query_builder/select_statement/dsl_impls.rs
+++ b/diesel/src/query_builder/select_statement/dsl_impls.rs
@@ -1,3 +1,4 @@
+use super::BoxedCloneSelectStatement;
 use super::BoxedSelectStatement;
 use crate::associations::HasTable;
 use crate::backend::Backend;
@@ -13,7 +14,9 @@ use crate::query_builder::from_clause::FromClause;
 use crate::query_builder::group_by_clause::*;
 use crate::query_builder::insert_statement::InsertFromSelect;
 use crate::query_builder::limit_clause::*;
-use crate::query_builder::limit_offset_clause::{BoxedLimitOffsetClause, LimitOffsetClause};
+use crate::query_builder::limit_offset_clause::{
+    BoxedCloneLimitOffsetClause, BoxedLimitOffsetClause, LimitOffsetClause,
+};
 use crate::query_builder::locking_clause::*;
 use crate::query_builder::offset_clause::*;
 use crate::query_builder::order_clause::*;
@@ -21,7 +24,8 @@ use crate::query_builder::select_clause::*;
 use crate::query_builder::update_statement::target::*;
 use crate::query_builder::where_clause::*;
 use crate::query_builder::{
-    AsQuery, IntoBoxedClause, Query, QueryFragment, SelectQuery, SelectStatement,
+    AsQuery, IntoBoxedClause, IntoBoxedCloneClause, Query, QueryFragment, SelectQuery,
+    SelectStatement,
 };
 use crate::query_dsl::group_by_dsl::ValidDistinctForGroupBy;
 use crate::query_dsl::methods::*;
@@ -31,6 +35,7 @@ use crate::query_source::QuerySource;
 use crate::query_source::joins::{Join, JoinOn, JoinTo};
 use crate::sql_types::{BigInt, BoolOrNullableBool};
 use alloc::boxed::Box;
+use alloc::sync::Arc;
 
 impl<F, D, W, O, LOf, G, H, LC, Rhs, Kind, On> InternalJoinDsl<Rhs, Kind, On>
     for SelectStatement<FromClause<F>, DefaultSelectClause<FromClause<F>>, D, W, O, LOf, G, H, LC>
@@ -598,6 +603,38 @@ where
     }
 }
 
+impl<'a, F, S, D, W, O, LOf, G, H, DB> BoxedCloneDsl<'a, DB>
+    for SelectStatement<FromClause<F>, S, D, W, O, LOf, G, H>
+where
+    Self: AsQuery,
+    DB: Backend,
+    F: QuerySource,
+    S: SelectClauseExpression<FromClause<F>> + QueryFragment<DB> + Send + Sync + 'a,
+    S::Selection: ValidGrouping<G::Expressions>,
+    D: QueryFragment<DB> + Send + Sync + 'a,
+    W: Into<BoxedCloneWhereClause<'a, DB>>,
+    O: Into<Option<Arc<dyn QueryFragment<DB> + Send + Sync + 'a>>>,
+    LOf: IntoBoxedCloneClause<'a, DB, BoxedCloneClause = BoxedCloneLimitOffsetClause<'a, DB>>,
+    G: ValidGroupByClause + QueryFragment<DB> + Send + Sync + 'a,
+    H: QueryFragment<DB> + Send + Sync + 'a,
+{
+    type Output =
+        BoxedCloneSelectStatement<'a, S::SelectClauseSqlType, FromClause<F>, DB, G::Expressions>;
+
+    fn internal_into_boxed_clone(self) -> Self::Output {
+        BoxedCloneSelectStatement::new(
+            self.select,
+            self.from,
+            Arc::new(self.distinct),
+            self.where_clause.into(),
+            self.order.into(),
+            self.limit_offset.into_boxed_clone(),
+            self.group_by,
+            Arc::new(self.having),
+        )
+    }
+}
+
 impl<'a, S, D, W, O, LOf, G, H, DB> BoxedDsl<'a, DB>
     for SelectStatement<NoFromClause, S, D, W, O, LOf, G, H>
 where
@@ -625,6 +662,37 @@ where
             self.limit_offset.into_boxed(),
             self.group_by,
             Box::new(self.having),
+        )
+    }
+}
+
+impl<'a, S, D, W, O, LOf, G, H, DB> BoxedCloneDsl<'a, DB>
+    for SelectStatement<NoFromClause, S, D, W, O, LOf, G, H>
+where
+    Self: AsQuery,
+    DB: Backend,
+    S: SelectClauseExpression<NoFromClause> + QueryFragment<DB> + Send + Sync + 'a,
+    S::Selection: ValidGrouping<G::Expressions>,
+    D: QueryFragment<DB> + Send + Sync + 'a,
+    W: Into<BoxedCloneWhereClause<'a, DB>>,
+    O: Into<Option<Arc<dyn QueryFragment<DB> + Send + Sync + 'a>>>,
+    LOf: IntoBoxedCloneClause<'a, DB, BoxedCloneClause = BoxedCloneLimitOffsetClause<'a, DB>>,
+    G: ValidGroupByClause + QueryFragment<DB> + Send + Sync + 'a,
+    H: QueryFragment<DB> + Send + Sync + 'a,
+{
+    type Output =
+        BoxedCloneSelectStatement<'a, S::SelectClauseSqlType, NoFromClause, DB, G::Expressions>;
+
+    fn internal_into_boxed_clone(self) -> Self::Output {
+        BoxedCloneSelectStatement::new_no_from_clause(
+            self.select,
+            self.from,
+            Arc::new(self.distinct),
+            self.where_clause.into(),
+            self.order.into(),
+            self.limit_offset.into_boxed_clone(),
+            self.group_by,
+            Arc::new(self.having),
         )
     }
 }

--- a/diesel/src/query_builder/select_statement/mod.rs
+++ b/diesel/src/query_builder/select_statement/mod.rs
@@ -12,11 +12,16 @@
 //! LC: For Update Clause
 
 pub(crate) mod boxed;
+pub(crate) mod boxed_clone;
 mod dsl_impls;
 #[diesel_derives::__diesel_public_if(
     feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
 )]
 pub(crate) use self::boxed::BoxedSelectStatement;
+#[diesel_derives::__diesel_public_if(
+    feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
+)]
+pub(crate) use self::boxed_clone::BoxedCloneSelectStatement;
 
 use super::NoFromClause;
 use super::distinct_clause::NoDistinctClause;

--- a/diesel/src/query_builder/sql_query.rs
+++ b/diesel/src/query_builder/sql_query.rs
@@ -8,6 +8,7 @@ use crate::sql_types::{HasSqlType, Untyped};
 use alloc::boxed::Box;
 use alloc::string::String;
 use alloc::string::ToString;
+use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::marker::PhantomData;
 
@@ -139,8 +140,76 @@ impl<Inner> SqlQuery<Inner> {
     ///
     /// This allows doing things you otherwise couldn't do, e.g. `bind`ing in a
     /// loop.
+    ///
+    /// Boxed queries are not cloneable.
+    /// If you need cloning, use [`into_boxed_clone`] to create a [`BoxedCloneSqlQuery`].
+    ///
+    /// [`into_boxed_clone`]: SqlQuery::into_boxed_clone()
     pub fn into_boxed<'f, DB: Backend>(self) -> BoxedSqlQuery<'f, DB, Self> {
         BoxedSqlQuery::new(self)
+    }
+
+    /// Internally wraps the query in an [`Arc`], which allows to  calls `bind` and `sql` so that
+    /// they don't change the type nor the instance. This allows to clone the query and call
+    /// `bind` or `sql` in a loop, e.g.:
+    ///
+    /// ```
+    /// # include!("../doctest_setup.rs");
+    /// #
+    /// # use schema::users;
+    /// #
+    /// # #[derive(QueryableByName, Debug, PartialEq)]
+    /// # struct User {
+    /// #     id: i32,
+    /// #     name: String,
+    /// # }
+    /// #
+    /// # fn main() {
+    /// #     use diesel::sql_query;
+    /// #     use diesel::sql_types::{Integer};
+    /// #
+    /// #     let connection = &mut establish_connection();
+    /// #     diesel::insert_into(users::table)
+    /// #         .values(users::name.eq("Jim"))
+    /// #         .execute(connection).unwrap();
+    /// let q = diesel::sql_query("SELECT * FROM users WHERE id IN(").into_boxed_clone();
+    /// let mut q = q.clone();
+    /// for (idx, user_id) in [3, 4, 5].into_iter().enumerate() {
+    ///     if idx != 0 {
+    ///         q = q.sql(", ");
+    ///     }
+    /// # #[cfg(feature = "postgres")]
+    /// # {
+    ///     q = q
+    ///         // postgresql bind syntax
+    ///         .sql(format!("${}", idx + 1))
+    ///         .bind::<Integer, _>(user_id);
+    /// # }
+    /// # #[cfg(not(feature = "postgres"))]
+    /// # {
+    /// #   q = q
+    /// #       .sql(format!("?"))
+    /// #       .bind::<Integer, _>(user_id);
+    /// # }
+    /// }
+    /// let users = q.sql(");").get_results(connection);
+    /// let expected_users = vec![User {
+    ///     id: 3,
+    ///     name: "Jim".into(),
+    /// }];
+    /// assert_eq!(Ok(expected_users), users);
+    /// # }
+    /// ```
+    ///
+    /// This allows doing things you otherwise couldn't do, e.g. `bind`ing in a
+    /// loop.
+    ///
+    /// In cases where the query does not need to be cloned, [`BoxedSqlQuery`] (created with
+    /// [`into_boxed`]) provides better performance.
+    ///
+    /// [`into_boxed`]: SqlQuery::into_boxed()
+    pub fn into_boxed_clone<'f, DB: Backend>(self) -> BoxedCloneSqlQuery<'f, DB, Self> {
+        BoxedCloneSqlQuery::new(self)
     }
 
     /// Appends a piece of SQL code at the end.
@@ -208,6 +277,10 @@ impl<Query, Value, ST> UncheckedBind<Query, Value, ST> {
 
     pub fn into_boxed<'f, DB: Backend>(self) -> BoxedSqlQuery<'f, DB, Self> {
         BoxedSqlQuery::new(self)
+    }
+
+    pub fn into_boxed_clone<'f, DB: Backend>(self) -> BoxedCloneSqlQuery<'f, DB, Self> {
+        BoxedCloneSqlQuery::new(self)
     }
 
     /// Construct a full SQL query using raw SQL.
@@ -315,6 +388,18 @@ pub struct BoxedSqlQuery<'f, DB: Backend, Query> {
     binds: Vec<Box<dyn QueryFragment<DB> + Send + 'f>>,
 }
 
+#[derive(Clone)]
+#[must_use = "Queries are only executed when calling `load`, `get_result`, or similar."]
+/// See [`SqlQuery::into_boxed_clone`].
+///
+/// [`SqlQuery::into_boxed_clone`]: SqlQuery::into_boxed_clone()
+#[allow(missing_debug_implementations)]
+pub struct BoxedCloneSqlQuery<'f, DB: Backend, Query> {
+    query: Query,
+    sql: String,
+    binds: Vec<Arc<dyn QueryFragment<DB> + Send + Sync + 'f>>,
+}
+
 struct RawBind<ST, U> {
     value: U,
     p: PhantomData<ST>,
@@ -395,6 +480,72 @@ where
 }
 
 impl<DB: Backend, Query> RunQueryDslSupport for BoxedSqlQuery<'_, DB, Query> {}
+
+impl<'f, DB: Backend, Query> BoxedCloneSqlQuery<'f, DB, Query> {
+    pub(crate) fn new(query: Query) -> Self {
+        BoxedCloneSqlQuery {
+            query,
+            sql: "".to_string(),
+            binds: alloc::vec![],
+        }
+    }
+
+    /// See [`SqlQuery::bind`].
+    ///
+    /// [`SqlQuery::bind`]: SqlQuery::bind()
+    pub fn bind<BindSt, Value>(mut self, b: Value) -> Self
+    where
+        DB: HasSqlType<BindSt>,
+        Value: ToSql<BindSt, DB> + Send + Sync + 'f,
+        BindSt: Send + Sync + 'f,
+    {
+        self.binds.push(Arc::new(RawBind {
+            value: b,
+            p: PhantomData,
+        }) as Arc<_>);
+        self
+    }
+
+    /// See [`SqlQuery::sql`].
+    ///
+    /// [`SqlQuery::sql`]: SqlQuery::sql()
+    pub fn sql<T: AsRef<str>>(mut self, sql: T) -> Self {
+        self.sql += sql.as_ref();
+        self
+    }
+}
+
+impl<DB, Query> QueryFragment<DB> for BoxedCloneSqlQuery<'_, DB, Query>
+where
+    DB: Backend + DieselReserveSpecialization,
+    Query: QueryFragment<DB>,
+{
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
+        out.unsafe_to_cache_prepared();
+        self.query.walk_ast(out.reborrow())?;
+        out.push_sql(&self.sql);
+
+        for b in &self.binds {
+            b.walk_ast(out.reborrow())?;
+        }
+        Ok(())
+    }
+}
+
+impl<DB: Backend, Query> QueryId for BoxedCloneSqlQuery<'_, DB, Query> {
+    type QueryId = ();
+
+    const HAS_STATIC_QUERY_ID: bool = false;
+}
+
+impl<DB, Q> Query for BoxedCloneSqlQuery<'_, DB, Q>
+where
+    DB: Backend,
+{
+    type SqlType = Untyped;
+}
+
+impl<DB: Backend, Query> RunQueryDslSupport for BoxedCloneSqlQuery<'_, DB, Query> {}
 
 mod private {
     use crate::backend::{Backend, DieselReserveSpecialization};

--- a/diesel/src/query_builder/update_statement/mod.rs
+++ b/diesel/src/query_builder/update_statement/mod.rs
@@ -6,7 +6,7 @@ use private::AllowFilterForUpdate;
 
 use crate::QuerySource;
 use crate::backend::DieselReserveSpecialization;
-use crate::dsl::{Filter, IntoBoxed};
+use crate::dsl::{Filter, IntoBoxed, IntoBoxedClone};
 use crate::expression::{
     AppearsOnTable, Expression, MixedAggregates, SelectableExpression, ValidGrouping, is_aggregate,
 };
@@ -16,7 +16,7 @@ use crate::query_builder::returning::{
 use crate::query_builder::where_clause::*;
 use crate::query_builder::*;
 use crate::query_dsl::RunQueryDslSupport;
-use crate::query_dsl::methods::{BoxedDsl, FilterDsl};
+use crate::query_dsl::methods::{BoxedCloneDsl, BoxedDsl, FilterDsl};
 use crate::query_source::Table;
 use crate::result::EmptyChangeset;
 use crate::result::Error::QueryBuilderError;
@@ -73,6 +73,10 @@ pub struct UpdateStatement<T: QuerySource, U, V = SetNotCalled, Ret = NoReturnin
 /// An `UPDATE` statement with a boxed `WHERE` clause.
 pub type BoxedUpdateStatement<'a, DB, T, V = SetNotCalled, Ret = NoReturningClause> =
     UpdateStatement<T, BoxedWhereClause<'a, DB>, V, Ret>;
+
+/// An `UPDATE` statement with a boxed cloneable `WHERE` clause.
+pub type BoxedCloneUpdateStatement<'a, DB, T, V = SetNotCalled, Ret = NoReturningClause> =
+    UpdateStatement<T, BoxedCloneWhereClause<'a, DB>, V, Ret>;
 
 impl<T: QuerySource, U, V, Ret> UpdateStatement<T, U, V, Ret> {
     /// Adds the given predicate to the `WHERE` clause of the statement being
@@ -158,6 +162,57 @@ impl<T: QuerySource, U, V, Ret> UpdateStatement<T, U, V, Ret> {
     {
         BoxedDsl::internal_into_boxed(self)
     }
+
+    /// Wraps the `WHERE` clause of this update statement in an [`Arc`].
+    ///
+    /// This is useful for cases where you want to clone and conditionally
+    /// modify a query, but need the type to remain the same. The backend
+    /// must be specified as part of this. It is not possible to box a query
+    /// and have it be useable on multiple backends.
+    ///
+    /// A cloneable boxed query will incur a slightly greater performance penalty
+    /// than a standard boxed query. In both cases, the query builder can no longer
+    /// be inlined by the compiler. For most applications this cost will be minimal.
+    ///
+    /// ### Example
+    ///
+    /// ```rust
+    /// # include!("../../doctest_setup.rs");
+    /// #
+    /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
+    /// #     use std::collections::HashMap;
+    /// #     use schema::users::dsl::*;
+    /// #     let connection = &mut establish_connection();
+    /// #     let mut params = HashMap::new();
+    /// #     params.insert("tess_has_been_a_jerk", false);
+    /// let query = diesel::update(users).set(name.eq("Jerk")).into_boxed_clone();
+    /// let mut query = query.clone();
+    ///
+    /// if !params["tess_has_been_a_jerk"] {
+    ///     query = query.filter(name.ne("Tess"));
+    /// }
+    ///
+    /// let updated_rows = query.execute(connection)?;
+    /// assert_eq!(1, updated_rows);
+    ///
+    /// let expected_names = vec!["Jerk", "Tess"];
+    /// let names = users.select(name).order(id).load::<String>(connection)?;
+    ///
+    /// assert_eq!(expected_names, names);
+    /// #     Ok(())
+    /// # }
+    /// ```
+    pub fn into_boxed_clone<'a, DB>(self) -> IntoBoxedClone<'a, Self, DB>
+    where
+        DB: Backend,
+        Self: BoxedCloneDsl<'a, DB>,
+    {
+        BoxedCloneDsl::internal_into_boxed_clone(self)
+    }
 }
 
 impl<T, U, V, Ret, Predicate> FilterDsl<Predicate> for UpdateStatement<T, U, V, Ret>
@@ -187,6 +242,24 @@ where
     type Output = BoxedUpdateStatement<'a, DB, T, V, Ret>;
 
     fn internal_into_boxed(self) -> Self::Output {
+        UpdateStatement {
+            from_clause: self.from_clause,
+            where_clause: self.where_clause.into(),
+            set_clause: self.set_clause,
+            values: self.values,
+            returning: self.returning,
+        }
+    }
+}
+
+impl<'a, T, U, V, Ret, DB> BoxedCloneDsl<'a, DB> for UpdateStatement<T, U, V, Ret>
+where
+    T: QuerySource,
+    U: Into<BoxedCloneWhereClause<'a, DB>>,
+{
+    type Output = BoxedCloneUpdateStatement<'a, DB, T, V, Ret>;
+
+    fn internal_into_boxed_clone(self) -> Self::Output {
         UpdateStatement {
             from_clause: self.from_clause,
             where_clause: self.where_clause.into(),
@@ -330,7 +403,9 @@ pub struct SetNotCalled;
 
 pub(crate) mod private {
     use crate::backend::Backend;
-    use crate::query_builder::where_clause::{BoxedWhereClause, NoWhereClause, WhereClause};
+    use crate::query_builder::where_clause::{
+        BoxedCloneWhereClause, BoxedWhereClause, NoWhereClause, WhereClause,
+    };
 
     use super::changeset::Assign;
 
@@ -372,6 +447,17 @@ pub(crate) mod private {
     where
         DB: Backend,
         T: AllowFilterForUpdate<BoxedWhereClause<'a, DB>>,
+    {
+    }
+
+    impl<'a, DB, C, B> AllowFilterForUpdate<BoxedCloneWhereClause<'a, DB>> for Assign<C, B> where
+        DB: Backend
+    {
+    }
+    impl<'a, DB, T> AllowFilterForUpdate<BoxedCloneWhereClause<'a, DB>> for Option<T>
+    where
+        DB: Backend,
+        T: AllowFilterForUpdate<BoxedCloneWhereClause<'a, DB>>,
     {
     }
 }

--- a/diesel/src/query_builder/where_clause.rs
+++ b/diesel/src/query_builder/where_clause.rs
@@ -5,6 +5,7 @@ use crate::expression::grouped::Grouped;
 use crate::expression::operators::{And, Or};
 use crate::expression::*;
 use crate::sql_types::BoolOrNullableBool;
+use alloc::sync::Arc;
 
 /// Add `Predicate` to the current `WHERE` clause, joining with `AND` if
 /// applicable.
@@ -66,6 +67,12 @@ where
 impl<DB> From<NoWhereClause> for BoxedWhereClause<'_, DB> {
     fn from(_: NoWhereClause) -> Self {
         BoxedWhereClause::None
+    }
+}
+
+impl<DB> From<NoWhereClause> for BoxedCloneWhereClause<'_, DB> {
+    fn from(_: NoWhereClause) -> Self {
+        BoxedCloneWhereClause::None
     }
 }
 
@@ -133,6 +140,16 @@ where
 {
     fn from(where_clause: WhereClause<Predicate>) -> Self {
         BoxedWhereClause::Where(Box::new(where_clause.0))
+    }
+}
+
+impl<'a, DB, Predicate> From<WhereClause<Predicate>> for BoxedCloneWhereClause<'a, DB>
+where
+    DB: Backend,
+    Predicate: QueryFragment<DB> + Send + Sync + 'a,
+{
+    fn from(where_clause: WhereClause<Predicate>) -> Self {
+        BoxedCloneWhereClause::Where(Arc::new(where_clause.0))
     }
 }
 
@@ -213,6 +230,78 @@ where
         match self {
             Where(where_clause) => Where(Box::new(Grouped(Or::new(where_clause, predicate)))),
             BoxedWhereClause::None => Where(Box::new(predicate)),
+        }
+    }
+}
+
+#[allow(missing_debug_implementations)] // We can't...
+pub enum BoxedCloneWhereClause<'a, DB> {
+    Where(Arc<dyn QueryFragment<DB> + Send + Sync + 'a>),
+    None,
+}
+
+impl<DB> Clone for BoxedCloneWhereClause<'_, DB> {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Where(clause) => Self::Where(Arc::clone(clause)),
+            Self::None => Self::None,
+        }
+    }
+}
+
+impl<DB> QueryFragment<DB> for BoxedCloneWhereClause<'_, DB>
+where
+    DB: Backend + DieselReserveSpecialization,
+{
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
+        match *self {
+            BoxedCloneWhereClause::Where(ref where_clause) => {
+                out.push_sql(" WHERE ");
+                where_clause.walk_ast(out)
+            }
+            BoxedCloneWhereClause::None => Ok(()),
+        }
+    }
+}
+
+impl<DB> QueryId for BoxedCloneWhereClause<'_, DB> {
+    type QueryId = ();
+
+    const HAS_STATIC_QUERY_ID: bool = false;
+}
+
+impl<'a, DB, Predicate> WhereAnd<Predicate> for BoxedCloneWhereClause<'a, DB>
+where
+    DB: Backend + 'a,
+    Predicate: QueryFragment<DB> + Send + Sync + 'a,
+    Grouped<And<Arc<dyn QueryFragment<DB> + Send + Sync + 'a>, Predicate>>: QueryFragment<DB>,
+{
+    type Output = Self;
+
+    fn and(self, predicate: Predicate) -> Self::Output {
+        use self::BoxedCloneWhereClause::Where;
+
+        match self {
+            Where(where_clause) => Where(Arc::new(Grouped(And::new(where_clause, predicate)))),
+            BoxedCloneWhereClause::None => Where(Arc::new(predicate)),
+        }
+    }
+}
+
+impl<'a, DB, Predicate> WhereOr<Predicate> for BoxedCloneWhereClause<'a, DB>
+where
+    DB: Backend + 'a,
+    Predicate: QueryFragment<DB> + Send + Sync + 'a,
+    Grouped<Or<Arc<dyn QueryFragment<DB> + Send + Sync + 'a>, Predicate>>: QueryFragment<DB>,
+{
+    type Output = Self;
+
+    fn or(self, predicate: Predicate) -> Self::Output {
+        use self::BoxedCloneWhereClause::Where;
+
+        match self {
+            Where(where_clause) => Where(Arc::new(Grouped(Or::new(where_clause, predicate)))),
+            BoxedCloneWhereClause::None => Where(Arc::new(predicate)),
         }
     }
 }

--- a/diesel/src/query_dsl/boxed_clone_dsl.rs
+++ b/diesel/src/query_dsl/boxed_clone_dsl.rs
@@ -1,0 +1,43 @@
+use crate::Expression;
+use crate::dsl;
+use crate::expression::TypedExpressionType;
+use crate::expression::ValidGrouping;
+use crate::query_builder::AsQuery;
+use crate::query_builder::FromClause;
+use crate::query_builder::SelectStatement;
+use crate::query_source::QueryRelation;
+
+/// The `into_boxed_clone` method
+///
+/// This trait should not be relied on directly by most apps. Its behavior is
+/// provided by [`QueryDsl`]. However, you may need a where clause on this trait
+/// to call `into_boxed_clone` from generic code.
+///
+/// [`QueryDsl`]: crate::QueryDsl
+#[diagnostic::on_unimplemented(
+    message = "cannot box `{Self}` for backend `{DB}`",
+    note = "this either means `{Self}` is no valid SQL for `{DB}`",
+    note = "or this means `{Self}` uses clauses not supporting boxing like the `LOCKING` or `GROUP BY` clause"
+)]
+pub trait BoxedCloneDsl<'a, DB> {
+    /// The return type of `internal_into_boxed_clone`
+    type Output;
+
+    /// See the trait documentation.
+    fn internal_into_boxed_clone(self) -> dsl::IntoBoxedClone<'a, Self, DB>;
+}
+
+#[diagnostic::do_not_recommend]
+impl<'a, T, DB> BoxedCloneDsl<'a, DB> for T
+where
+    T: QueryRelation + AsQuery<Query = SelectStatement<FromClause<T>>>,
+    SelectStatement<FromClause<T>>: BoxedCloneDsl<'a, DB>,
+    T::DefaultSelection: Expression<SqlType = T::SqlType> + ValidGrouping<()>,
+    T::SqlType: TypedExpressionType,
+{
+    type Output = dsl::IntoBoxedClone<'a, SelectStatement<FromClause<T>>, DB>;
+
+    fn internal_into_boxed_clone(self) -> Self::Output {
+        self.as_query().internal_into_boxed_clone()
+    }
+}

--- a/diesel/src/query_dsl/mod.rs
+++ b/diesel/src/query_dsl/mod.rs
@@ -23,6 +23,8 @@ use alloc::vec::Vec;
 
 mod belonging_to_dsl;
 #[doc(hidden)]
+pub mod boxed_clone_dsl;
+#[doc(hidden)]
 pub mod boxed_dsl;
 mod combine_dsl;
 mod distinct_dsl;
@@ -62,6 +64,7 @@ pub use self::save_changes_dsl::{SaveChangesDsl, UpdateAndFetchResults};
 /// However, generic code may need to include a where clause that references
 /// these traits.
 pub mod methods {
+    pub use super::boxed_clone_dsl::BoxedCloneDsl;
     pub use super::boxed_dsl::BoxedDsl;
     pub use super::distinct_dsl::*;
     #[doc(inline)]
@@ -1345,6 +1348,77 @@ pub trait QueryDsl: Sized {
         Self: methods::BoxedDsl<'a, DB>,
     {
         methods::BoxedDsl::internal_into_boxed(self)
+    }
+
+    /// Wraps the pieces of a query into an [`Arc`].
+    ///
+    /// This is useful for cases where you want to clone and conditionally
+    /// modify a query, but need the type to remain the same. The backend
+    /// must be specified as part of this. It is not possible to box a query
+    /// and have it be useable on multiple backends.
+    ///
+    /// A cloneable boxed query will incur a slightly greater performance penalty
+    /// than a standard boxed query. In both cases, the query builder can no longer
+    /// be inlined by the compiler. For most applications this cost will be minimal.
+    ///
+    /// ### Example
+    ///
+    /// ```rust
+    /// # include!("../doctest_setup.rs");
+    /// # use schema::users;
+    /// #
+    /// # fn main() {
+    /// #     use std::collections::HashMap;
+    /// #     let connection = &mut establish_connection();
+    /// #     let mut params = HashMap::new();
+    /// #     params.insert("name", "Sean");
+    /// let query = users::table.into_boxed_clone();
+    /// let mut query = query.clone();
+    /// if let Some(name) = params.get("name") {
+    ///     query = query.filter(users::name.eq(name));
+    /// }
+    /// let users = query.load(connection);
+    /// #     let expected = vec![(1, String::from("Sean"))];
+    /// #     assert_eq!(Ok(expected), users);
+    /// # }
+    /// ```
+    ///
+    /// Diesel queries also have a similar problem to [`Iterator`], where
+    /// returning them from a function requires exposing the implementation of that
+    /// function. The [`helper_types`][helper_types] module exists to help with this,
+    /// but you might want to hide the return type or have it conditionally change.
+    /// Boxing can achieve both.
+    ///
+    /// [helper_types]: crate::helper_types
+    ///
+    /// ### Example
+    ///
+    /// ```rust
+    /// # include!("../doctest_setup.rs");
+    /// # use schema::users;
+    /// #
+    /// # fn main() {
+    /// #     let connection = &mut establish_connection();
+    /// fn users_by_name(name: &str) -> users::BoxedCloneQuery<DB> {
+    ///     users::table.filter(users::name.eq(name)).into_boxed_clone()
+    /// }
+    ///
+    /// assert_eq!(
+    ///     Ok(1),
+    ///     users_by_name("Sean").clone().select(users::id).first(connection)
+    /// );
+    /// assert_eq!(
+    ///     Ok(2),
+    ///     users_by_name("Tess").clone().select(users::id).first(connection)
+    /// );
+    /// # }
+    /// ```
+    fn into_boxed_clone<'a, DB>(self) -> IntoBoxedClone<'a, Self, DB>
+    where
+        DB: Backend,
+        Self: methods::BoxedCloneDsl<'a, DB>,
+    {
+        methods::BoxedCloneDsl::internal_into_boxed_clone(self)
     }
 
     /// Wraps this select statement in parenthesis, allowing it to be used

--- a/diesel/src/query_source/aliasing/dsl_impls.rs
+++ b/diesel/src/query_source/aliasing/dsl_impls.rs
@@ -75,6 +75,21 @@ where
     }
 }
 
+impl<'a, S, DB> BoxedCloneDsl<'a, DB> for Alias<S>
+where
+    Alias<S>: QuerySource + AsQuery<Query = SelectStatement<FromClause<Alias<S>>>>,
+    SelectStatement<FromClause<Alias<S>>>: BoxedCloneDsl<'a, DB>,
+    <Alias<S> as QuerySource>::DefaultSelection:
+        Expression<SqlType = <Alias<S> as AsQuery>::SqlType> + ValidGrouping<()>,
+    <Alias<S> as AsQuery>::SqlType: TypedExpressionType,
+{
+    type Output = dsl::IntoBoxedClone<'a, SelectStatement<FromClause<Alias<S>>>, DB>;
+
+    fn internal_into_boxed_clone(self) -> Self::Output {
+        self.as_query().internal_into_boxed_clone()
+    }
+}
+
 impl<S> CombineDsl for Alias<S>
 where
     S: AliasSource,

--- a/diesel/src/sqlite/query_builder/limit_offset.rs
+++ b/diesel/src/sqlite/query_builder/limit_offset.rs
@@ -1,10 +1,13 @@
 use crate::query_builder::limit_clause::{LimitClause, NoLimitClause};
-use crate::query_builder::limit_offset_clause::{BoxedLimitOffsetClause, LimitOffsetClause};
+use crate::query_builder::limit_offset_clause::{
+    BoxedCloneLimitOffsetClause, BoxedLimitOffsetClause, LimitOffsetClause,
+};
 use crate::query_builder::offset_clause::{NoOffsetClause, OffsetClause};
-use crate::query_builder::{AstPass, IntoBoxedClause, QueryFragment};
+use crate::query_builder::{AstPass, IntoBoxedClause, IntoBoxedCloneClause, QueryFragment};
 use crate::result::QueryResult;
 use crate::sqlite::Sqlite;
 use alloc::boxed::Box;
+use alloc::sync::Arc;
 
 impl QueryFragment<Sqlite> for LimitOffsetClause<NoLimitClause, NoOffsetClause> {
     fn walk_ast<'b>(&'b self, _out: AstPass<'_, 'b, Sqlite>) -> QueryResult<()> {
@@ -49,6 +52,27 @@ where
 }
 
 impl QueryFragment<Sqlite> for BoxedLimitOffsetClause<'_, Sqlite> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Sqlite>) -> QueryResult<()> {
+        match (self.limit.as_ref(), self.offset.as_ref()) {
+            (Some(limit), Some(offset)) => {
+                limit.walk_ast(out.reborrow())?;
+                offset.walk_ast(out.reborrow())?;
+            }
+            (Some(limit), None) => {
+                limit.walk_ast(out.reborrow())?;
+            }
+            (None, Some(offset)) => {
+                // See the `QueryFragment` implementation for `LimitOffsetClause` for details.
+                out.push_sql(" LIMIT -1 ");
+                offset.walk_ast(out.reborrow())?;
+            }
+            (None, None) => {}
+        }
+        Ok(())
+    }
+}
+
+impl QueryFragment<Sqlite> for BoxedCloneLimitOffsetClause<'_, Sqlite> {
     fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Sqlite>) -> QueryResult<()> {
         match (self.limit.as_ref(), self.offset.as_ref()) {
             (Some(limit), Some(offset)) => {
@@ -122,6 +146,61 @@ where
         BoxedLimitOffsetClause {
             limit: Some(Box::new(self.limit_clause)),
             offset: Some(Box::new(self.offset_clause)),
+        }
+    }
+}
+
+impl<'a> IntoBoxedCloneClause<'a, Sqlite> for LimitOffsetClause<NoLimitClause, NoOffsetClause> {
+    type BoxedCloneClause = BoxedCloneLimitOffsetClause<'a, Sqlite>;
+
+    fn into_boxed_clone(self) -> Self::BoxedCloneClause {
+        BoxedCloneLimitOffsetClause {
+            limit: None,
+            offset: None,
+        }
+    }
+}
+
+impl<'a, L> IntoBoxedCloneClause<'a, Sqlite> for LimitOffsetClause<LimitClause<L>, NoOffsetClause>
+where
+    L: QueryFragment<Sqlite> + Send + Sync + 'a,
+{
+    type BoxedCloneClause = BoxedCloneLimitOffsetClause<'a, Sqlite>;
+
+    fn into_boxed_clone(self) -> Self::BoxedCloneClause {
+        BoxedCloneLimitOffsetClause {
+            limit: Some(Arc::new(self.limit_clause)),
+            offset: None,
+        }
+    }
+}
+
+impl<'a, O> IntoBoxedCloneClause<'a, Sqlite> for LimitOffsetClause<NoLimitClause, OffsetClause<O>>
+where
+    O: QueryFragment<Sqlite> + Send + Sync + 'a,
+{
+    type BoxedCloneClause = BoxedCloneLimitOffsetClause<'a, Sqlite>;
+
+    fn into_boxed_clone(self) -> Self::BoxedCloneClause {
+        BoxedCloneLimitOffsetClause {
+            limit: None,
+            offset: Some(Arc::new(self.offset_clause)),
+        }
+    }
+}
+
+impl<'a, L, O> IntoBoxedCloneClause<'a, Sqlite>
+    for LimitOffsetClause<LimitClause<L>, OffsetClause<O>>
+where
+    L: QueryFragment<Sqlite> + Send + Sync + 'a,
+    O: QueryFragment<Sqlite> + Send + Sync + 'a,
+{
+    type BoxedCloneClause = BoxedCloneLimitOffsetClause<'a, Sqlite>;
+
+    fn into_boxed_clone(self) -> Self::BoxedCloneClause {
+        BoxedCloneLimitOffsetClause {
+            limit: Some(Arc::new(self.limit_clause)),
+            offset: Some(Arc::new(self.offset_clause)),
         }
     }
 }

--- a/diesel_compile_tests/tests/fail/boxed_clone_queries_and_group_by.rs
+++ b/diesel_compile_tests/tests/fail/boxed_clone_queries_and_group_by.rs
@@ -1,0 +1,97 @@
+extern crate diesel;
+
+use diesel::*;
+
+table! {
+    users {
+        id -> Integer,
+        name -> Text,
+    }
+}
+
+table! {
+    posts {
+        id -> Integer,
+        user_id -> Integer,
+    }
+}
+
+joinable!(posts -> users (user_id));
+
+fn main() {
+    let mut conn = PgConnection::establish("connection-url").unwrap();
+
+    // a boxed query with group by just works
+    users::table
+        .group_by(users::name)
+        .select(users::name)
+        .into_boxed_clone()
+        .load::<String>(&mut conn);
+
+    // it's fine to change the select clause afterwards as long as it is valid for the
+    // given group by clause
+    users::table
+        .group_by(users::name)
+        .select(users::name)
+        .into_boxed_clone()
+        .select(users::name)
+        .load::<String>(&mut conn);
+
+    let mut q = users::table
+        .group_by(users::name)
+        .select(users::name)
+        .into_boxed_clone();
+
+    q = q.select(users::name);
+    q = q.filter(users::id.eq(42));
+    q = q.or_filter(users::id.eq(42));
+    q = q.order(users::id.asc());
+    q = q.then_order_by(users::id.asc());
+    q = q.distinct();
+    q = q.limit(42);
+    q = q.offset(42);
+
+    // cannot box a query with default select clause + a group by clause
+    users::table.group_by(users::name).into_boxed_clone();
+    //~^ ERROR: cannot box `SelectStatement<..., ..., ..., ..., ..., ..., ...>` for backend `_`
+
+    users::table
+        .group_by(users::name)
+        .select(users::id)
+        //~^ ERROR: type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
+        .into_boxed_clone();
+    //~^ ERROR: cannot box `SelectStatement<..., ..., ..., ..., ..., ..., ...>` for backend `_`
+
+    users::table
+        .group_by(users::name)
+        .select(users::name)
+        .into_boxed_clone()
+        .select(users::id)
+        //~^ ERROR: type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
+        .load::<i32>(&mut conn);
+
+    users::table
+        .group_by(users::name)
+        .select(users::name)
+        .into_boxed_clone()
+        .inner_join(posts::table)
+        //~^ ERROR: mismatched types
+        //~| ERROR: the trait bound `BoxedCloneSelectStatement<'_, ..., ..., _, ...>: QueryRelation` is not satisfied
+        .load::<String>(&mut conn);
+
+    let mut a = users::table.into_boxed_clone();
+
+    // this is a different type now
+    a = users::table.group_by(users::id).into_boxed_clone();
+    //~^ ERROR: mismatched types
+
+    // you cannot call group by after boxing
+    users::table
+        .into_boxed_clone()
+        .group_by(users::id)
+        //~^ ERROR: the trait bound `BoxedCloneSelectStatement<'_, ..., ..., _>: GroupByDsl<_>` is not satisfied
+        //~| ERROR: the trait bound `BoxedCloneSelectStatement<'_, ..., ..., _>: QueryRelation` is not satisfied
+        //~| ERROR: the trait bound `SelectStatement<FromClause<...>>: GroupByDsl<_>` is not satisfied
+        .select(users::name)
+        .load::<String>(&mut conn);
+}

--- a/diesel_compile_tests/tests/fail/boxed_clone_queries_and_group_by.stderr
+++ b/diesel_compile_tests/tests/fail/boxed_clone_queries_and_group_by.stderr
@@ -1,0 +1,239 @@
+error[E0277]: cannot box `SelectStatement<..., ..., ..., ..., ..., ..., ...>` for backend `_`
+   --> tests/fail/boxed_clone_queries_and_group_by.rs:55:40
+    |
+ LL |     users::table.group_by(users::name).into_boxed_clone();
+    |                                        ^^^^^^^^^^^^^^^^ unsatisfied trait bound
+    |
+    = help: the trait `BoxedCloneDsl<'_, _>` is not implemented for `SelectStatement<..., ..., ..., ..., ..., ..., ...>`
+    = note: this either means `SelectStatement<..., ..., ..., ..., ..., ..., ...>` is no valid SQL for `_`
+    = note: or this means `SelectStatement<..., ..., ..., ..., ..., ..., ...>` uses clauses not supporting boxing like the `LOCKING` or `GROUP BY` clause
+help: the following other types implement trait `BoxedCloneDsl<'a, DB>`
+   --> DIESEL/diesel/diesel/src/query_builder/select_statement/dsl_impls.rs
+    |
+LL | / impl<'a, F, S, D, W, O, LOf, G, H, DB> BoxedCloneDsl<'a, DB>
+LL | |     for SelectStatement<FromClause<F>, S, D, W, O, LOf, G, H>
+LL | | where
+LL | |     Self: AsQuery,
+...   |
+LL | |     G: ValidGroupByClause + QueryFragment<DB> + Send + Sync + 'a,
+LL | |     H: QueryFragment<DB> + Send + Sync + 'a,
+    | |____________________________________________^ `SelectStatement<..., ..., ..., ..., ..., ..., ..., ...>`
+...
+LL | / impl<'a, S, D, W, O, LOf, G, H, DB> BoxedCloneDsl<'a, DB>
+LL | |     for SelectStatement<NoFromClause, S, D, W, O, LOf, G, H>
+LL | | where
+LL | |     Self: AsQuery,
+...   |
+LL | |     G: ValidGroupByClause + QueryFragment<DB> + Send + Sync + 'a,
+LL | |     H: QueryFragment<DB> + Send + Sync + 'a,
+    | |____________________________________________^ `SelectStatement<..., ..., ..., ..., ..., ..., ..., ...>`
+ 
+    
+error[E0271]: type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
+  --> tests/fail/boxed_clone_queries_and_group_by.rs:60:10
+   |
+LL |         .select(users::id)
+   |          ^^^^^^ type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
+   |
+note: expected this to be `diesel::expression::is_contained_in_group_by::Yes`
+  --> tests/fail/boxed_clone_queries_and_group_by.rs:5:1
+   |
+ LL | / table! {
+ LL | |     users {
+ LL | |         id -> Integer,
+ LL | |         name -> Text,
+ LL | |     }
+LL | | }
+   | |_^
+note: required for `users::columns::id` to implement `ValidGrouping<users::columns::name>`
+  --> tests/fail/boxed_clone_queries_and_group_by.rs:7:9
+   |
+ LL |         id -> Integer,
+   |         ^^
+   = note: associated types for the current `impl` cannot be restricted in `where` clauses
+   = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ...>` to implement `SelectDsl<users::columns::id>`
+
+      = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: cannot box `SelectStatement<..., ..., ..., ..., ..., ..., ...>` for backend `_`
+   --> tests/fail/boxed_clone_queries_and_group_by.rs:62:10
+    |
+ LL |         .into_boxed_clone();
+    |          ^^^^^^^^^^^^^^^^ unsatisfied trait bound
+    |
+    = help: the trait `BoxedCloneDsl<'_, _>` is not implemented for `SelectStatement<..., ..., ..., ..., ..., ..., ...>`
+    = note: this either means `SelectStatement<..., ..., ..., ..., ..., ..., ...>` is no valid SQL for `_`
+    = note: or this means `SelectStatement<..., ..., ..., ..., ..., ..., ...>` uses clauses not supporting boxing like the `LOCKING` or `GROUP BY` clause
+help: the following other types implement trait `BoxedCloneDsl<'a, DB>`
+   --> DIESEL/diesel/diesel/src/query_builder/select_statement/dsl_impls.rs
+    |
+LL | / impl<'a, F, S, D, W, O, LOf, G, H, DB> BoxedCloneDsl<'a, DB>
+LL | |     for SelectStatement<FromClause<F>, S, D, W, O, LOf, G, H>
+LL | | where
+LL | |     Self: AsQuery,
+...   |
+LL | |     G: ValidGroupByClause + QueryFragment<DB> + Send + Sync + 'a,
+LL | |     H: QueryFragment<DB> + Send + Sync + 'a,
+    | |____________________________________________^ `SelectStatement<..., ..., ..., ..., ..., ..., ..., ...>`
+...
+LL | / impl<'a, S, D, W, O, LOf, G, H, DB> BoxedCloneDsl<'a, DB>
+LL | |     for SelectStatement<NoFromClause, S, D, W, O, LOf, G, H>
+LL | | where
+LL | |     Self: AsQuery,
+...   |
+LL | |     G: ValidGroupByClause + QueryFragment<DB> + Send + Sync + 'a,
+LL | |     H: QueryFragment<DB> + Send + Sync + 'a,
+    | |____________________________________________^ `SelectStatement<..., ..., ..., ..., ..., ..., ..., ...>`
+ 
+    
+error[E0271]: type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
+  --> tests/fail/boxed_clone_queries_and_group_by.rs:69:10
+   |
+LL |         .select(users::id)
+   |          ^^^^^^ type mismatch resolving `<name as IsContainedInGroupBy<id>>::Output == Yes`
+   |
+note: expected this to be `diesel::expression::is_contained_in_group_by::Yes`
+  --> tests/fail/boxed_clone_queries_and_group_by.rs:5:1
+   |
+ LL | / table! {
+ LL | |     users {
+ LL | |         id -> Integer,
+ LL | |         name -> Text,
+ LL | |     }
+LL | | }
+   | |_^
+note: required for `users::columns::id` to implement `ValidGrouping<users::columns::name>`
+  --> tests/fail/boxed_clone_queries_and_group_by.rs:7:9
+   |
+ LL |         id -> Integer,
+   |         ^^
+   = note: associated types for the current `impl` cannot be restricted in `where` clauses
+   = note: required for `BoxedCloneSelectStatement<'_, Text, ..., _, ...>` to implement `SelectDsl<users::columns::id>`
+
+      = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `BoxedCloneSelectStatement<'_, ..., ..., _, ...>: QueryRelation` is not satisfied
+  --> tests/fail/boxed_clone_queries_and_group_by.rs:77:10
+   |
+LL |         .inner_join(posts::table)
+   |          ^^^^^^^^^^ the trait `Table` is not implemented for `BoxedCloneSelectStatement<'_, Text, ..., _, ...>`
+   |
+   = help: the following other types implement trait `Table`:
+             Only<S>
+             Tablesample<S, TSM>
+             pg::metadata_lookup::pg_namespace::table
+             pg::metadata_lookup::pg_type::table
+             posts::table
+             users::table
+   = note: required for `BoxedCloneSelectStatement<'_, Text, ..., _, ...>` to implement `QueryRelation`
+   = note: required for `BoxedCloneSelectStatement<'_, Text, ..., _, ...>` to implement `JoinTo<query_source::joins::OnClauseWrapper<_, _>>`
+   = note: required for `BoxedCloneSelectStatement<'_, Text, ..., _, ...>` to implement `JoinWithImplicitOnClause<OnClauseWrapper<_, _>, ...>`
+
+   
+error[E0308]: mismatched types
+   --> tests/fail/boxed_clone_queries_and_group_by.rs:77:21
+    |
+ LL |         .inner_join(posts::table)
+    |          ---------- ^^^^^^^^^^^^ expected `OnClauseWrapper<_, _>`, found `table`
+    |          |
+    |          arguments to this method are incorrect
+    |
+    = note: expected struct `query_source::joins::OnClauseWrapper<_, _>`
+               found struct `posts::table`
+help: the return type of this call is `posts::table` due to the type of the argument passed
+   --> tests/fail/boxed_clone_queries_and_group_by.rs:73:5
+    |
+ LL | /     users::table
+ LL | |         .group_by(users::name)
+ LL | |         .select(users::name)
+ LL | |         .into_boxed_clone()
+ LL | |         .inner_join(posts::table)
+    | |_____________________------------^
+    |                       |
+    |                       this argument influences the return type of `inner_join`
+note: method defined here
+   --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+    |
+LL |     fn inner_join<Rhs>(self, rhs: Rhs) -> InnerJoin<Self, Rhs>
+    |        ^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> tests/fail/boxed_clone_queries_and_group_by.rs:85:9
+   |
+LL |     let mut a = users::table.into_boxed_clone();
+   |                 ------------------------------- expected due to this value
+...
+LL |     a = users::table.group_by(users::id).into_boxed_clone();
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `BoxedCloneSelectStatement<'_, ..., ..., _>`, found `BoxedCloneSelectStatement<'_, ..., ..., _, ...>`
+   |
+   = note: expected struct `diesel::query_builder::select_statement::boxed_clone::BoxedCloneSelectStatement<'_, _, _, _, ()>`
+              found struct `diesel::query_builder::select_statement::boxed_clone::BoxedCloneSelectStatement<'_, _, _, _, users::columns::id>`
+
+error[E0277]: the trait bound `BoxedCloneSelectStatement<'_, ..., ..., _>: GroupByDsl<_>` is not satisfied
+   --> tests/fail/boxed_clone_queries_and_group_by.rs:91:10
+    |
+ LL |         .group_by(users::id)
+    |          ^^^^^^^^ the trait `GroupByDsl<_>` is not implemented for `BoxedCloneSelectStatement<'_, (..., ...), ..., _>`
+    |
+help: the following other types implement trait `GroupByDsl<Expr>`
+   --> DIESEL/diesel/diesel/src/query_builder/select_statement/dsl_impls.rs
+    |
+LL | / impl<F, S, D, W, O, LOf, G, H, Expr> GroupByDsl<Expr> for SelectStatement<F, S, D, W, O, ...
+LL | | where
+LL | |     SelectStatement<F, S, D, W, O, LOf, GroupByClause<Expr>, H>: SelectQuery,
+LL | |     Expr: Expression + AppearsOnTable<F>,
+    | |_________________________________________^ `SelectStatement<F, S, D, W, O, LOf, G, H>`
+    |
+   ::: DIESEL/diesel/diesel/src/query_source/aliasing/dsl_impls.rs
+    |
+LL | / impl<S, Expr> GroupByDsl<Expr> for Alias<S>
+LL | | where
+LL | |     Expr: Expression,
+LL | |     Self: QuerySource + AsQuery<Query = SelectStatement<FromClause<Self>>>,
+...   |
+LL | |     <Self as AsQuery>::SqlType: TypedExpressionType,
+LL | |     <Self as AsQuery>::Query: GroupByDsl<Expr>,
+    | |_______________________________________________^ `Alias<S>`
+ 
+    
+error[E0277]: the trait bound `SelectStatement<FromClause<...>>: GroupByDsl<_>` is not satisfied
+   --> tests/fail/boxed_clone_queries_and_group_by.rs:91:10
+    |
+ LL |         .group_by(users::id)
+    |          ^^^^^^^^ the trait `GroupByDsl<_>` is not implemented for `SelectStatement<FromClause<...>>`
+    |
+help: the trait `GroupByDsl<Expr>` is implemented for `SelectStatement<F, S, D, W, O, LOf, G, H>`
+   --> DIESEL/diesel/diesel/src/query_builder/select_statement/dsl_impls.rs
+    |
+LL | / impl<F, S, D, W, O, LOf, G, H, Expr> GroupByDsl<Expr> for SelectStatement<F, S, D, W, O, ...
+LL | | where
+LL | |     SelectStatement<F, S, D, W, O, LOf, GroupByClause<Expr>, H>: SelectQuery,
+LL | |     Expr: Expression + AppearsOnTable<F>,
+    | |_________________________________________^
+ 
+    
+error[E0277]: the trait bound `BoxedCloneSelectStatement<'_, ..., ..., _>: QueryRelation` is not satisfied
+   --> tests/fail/boxed_clone_queries_and_group_by.rs:91:10
+    |
+ LL |         .group_by(users::id)
+    |          ^^^^^^^^ the trait `GroupByDsl<_>` is not implemented for `BoxedCloneSelectStatement<'_, (..., ...), ..., _>`
+    |
+help: the following other types implement trait `GroupByDsl<Expr>`
+   --> DIESEL/diesel/diesel/src/query_builder/select_statement/dsl_impls.rs
+    |
+LL | / impl<F, S, D, W, O, LOf, G, H, Expr> GroupByDsl<Expr> for SelectStatement<F, S, D, W, O, ...
+LL | | where
+LL | |     SelectStatement<F, S, D, W, O, LOf, GroupByClause<Expr>, H>: SelectQuery,
+LL | |     Expr: Expression + AppearsOnTable<F>,
+    | |_________________________________________^ `SelectStatement<F, S, D, W, O, LOf, G, H>`
+    |
+   ::: DIESEL/diesel/diesel/src/query_source/aliasing/dsl_impls.rs
+    |
+LL | / impl<S, Expr> GroupByDsl<Expr> for Alias<S>
+LL | | where
+LL | |     Expr: Expression,
+LL | |     Self: QuerySource + AsQuery<Query = SelectStatement<FromClause<Self>>>,
+...   |
+LL | |     <Self as AsQuery>::SqlType: TypedExpressionType,
+LL | |     <Self as AsQuery>::Query: GroupByDsl<Expr>,
+    | |_______________________________________________^ `Alias<S>`

--- a/diesel_compile_tests/tests/fail/boxed_clone_queries_must_be_used_with_proper_connection.rs
+++ b/diesel_compile_tests/tests/fail/boxed_clone_queries_must_be_used_with_proper_connection.rs
@@ -1,0 +1,18 @@
+extern crate diesel;
+
+use diesel::pg::Pg;
+use diesel::*;
+
+table! {
+    users {
+        id -> Integer,
+    }
+}
+
+fn main() {
+    let mut connection = SqliteConnection::establish("").unwrap();
+    users::table
+        .into_boxed_clone::<Pg>()
+        .load::<(i32,)>(&mut connection);
+    //~^ ERROR: type mismatch resolving `<SqliteConnection as Connection>::Backend == Pg`
+}

--- a/diesel_compile_tests/tests/fail/boxed_clone_queries_must_be_used_with_proper_connection.stderr
+++ b/diesel_compile_tests/tests/fail/boxed_clone_queries_must_be_used_with_proper_connection.stderr
@@ -1,0 +1,19 @@
+error[E0271]: type mismatch resolving `<SqliteConnection as Connection>::Backend == Pg`
+    --> tests/fail/boxed_clone_queries_must_be_used_with_proper_connection.rs:16:25
+     |
+  LL |         .load::<(i32,)>(&mut connection);
+     |          ----           ^^^^^^^^^^^^^^^ expected `Pg`, found `Sqlite`
+     |          |
+     |          required by a bound introduced by this call
+     |
+     = note: required for `BoxedCloneSelectStatement<'_, (...,), ..., ...>` to implement `LoadQuery<'_, diesel::SqliteConnection, (i32,)>`
+note: required by a bound in `load`
+    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+     |
+LL |     fn load<'query, U>(self, conn: &mut Conn) -> QueryResult<Vec<U>>
+     |        ---- required by a bound in this associated function
+LL |     where
+LL |         Self: LoadQuery<'query, Conn, U>,
+     |               ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `RunQueryDsl::load`
+  
+     For more information about this error, try `rustc --explain E0271`.

--- a/diesel_compile_tests/tests/fail/boxed_clone_queries_require_selectable_expression_for_filter.rs
+++ b/diesel_compile_tests/tests/fail/boxed_clone_queries_require_selectable_expression_for_filter.rs
@@ -1,0 +1,27 @@
+extern crate diesel;
+
+use diesel::pg::Pg;
+use diesel::*;
+
+table! {
+    users {
+        id -> Integer,
+        name -> VarChar,
+    }
+}
+
+table! {
+    posts {
+        id -> Integer,
+        title -> VarChar,
+    }
+}
+
+allow_tables_to_appear_in_same_query!(users, posts);
+
+fn main() {
+    users::table
+        .into_boxed_clone::<Pg>()
+        .filter(posts::title.eq("Hello"));
+    //~^ ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
+}

--- a/diesel_compile_tests/tests/fail/boxed_clone_queries_require_selectable_expression_for_filter.stderr
+++ b/diesel_compile_tests/tests/fail/boxed_clone_queries_require_selectable_expression_for_filter.stderr
@@ -1,0 +1,18 @@
+error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
+  --> tests/fail/boxed_clone_queries_require_selectable_expression_for_filter.rs:25:10
+   |
+LL |         .filter(posts::title.eq("Hello"));
+   |          ^^^^^^ expected `Once`, found `Never`
+   |
+note: required for `posts::columns::title` to implement `AppearsOnTable<users::table>`
+  --> tests/fail/boxed_clone_queries_require_selectable_expression_for_filter.rs:16:9
+   |
+LL |         title -> VarChar,
+   |         ^^^^^
+   = note: associated types for the current `impl` cannot be restricted in `where` clauses
+   = note: 2 redundant requirements hidden
+   = note: required for `Grouped<Eq<title, Bound<Text, &str>>>` to implement `AppearsOnTable<users::table>`
+   = note: required for `BoxedCloneSelectStatement<'_, ..., ..., ...>` to implement `FilterDsl<Grouped<Eq<title, Bound<Text, &str>>>>`
+
+      = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+For more information about this error, try `rustc --explain E0271`.

--- a/diesel_compile_tests/tests/fail/boxed_clone_queries_require_selectable_expression_for_order.rs
+++ b/diesel_compile_tests/tests/fail/boxed_clone_queries_require_selectable_expression_for_order.rs
@@ -1,0 +1,25 @@
+extern crate diesel;
+
+use diesel::pg::Pg;
+use diesel::*;
+
+table! {
+    users {
+        id -> Integer,
+        name -> VarChar,
+    }
+}
+
+table! {
+    posts {
+        id -> Integer,
+        title -> VarChar,
+    }
+}
+
+allow_tables_to_appear_in_same_query!(users, posts);
+
+fn main() {
+    users::table.into_boxed_clone::<Pg>().order(posts::title.desc());
+    //~^ ERROR: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
+}

--- a/diesel_compile_tests/tests/fail/boxed_clone_queries_require_selectable_expression_for_order.stderr
+++ b/diesel_compile_tests/tests/fail/boxed_clone_queries_require_selectable_expression_for_order.stderr
@@ -1,0 +1,18 @@
+error[E0271]: type mismatch resolving `<table as AppearsInFromClause<table>>::Count == Once`
+  --> tests/fail/boxed_clone_queries_require_selectable_expression_for_order.rs:23:43
+   |
+LL |     users::table.into_boxed_clone::<Pg>().order(posts::title.desc());
+   |                                           ^^^^^ expected `Once`, found `Never`
+   |
+note: required for `posts::columns::title` to implement `AppearsOnTable<users::table>`
+  --> tests/fail/boxed_clone_queries_require_selectable_expression_for_order.rs:16:9
+   |
+LL |         title -> VarChar,
+   |         ^^^^^
+   = note: associated types for the current `impl` cannot be restricted in `where` clauses
+   = note: 1 redundant requirement hidden
+   = note: required for `diesel::expression::operators::Desc<posts::columns::title>` to implement `AppearsOnTable<users::table>`
+   = note: required for `BoxedCloneSelectStatement<'_, ..., ..., ...>` to implement `OrderDsl<Desc<title>>`
+
+      = note: this error originates in the macro `table` (in Nightly builds, run with -Z macro-backtrace for more info)
+For more information about this error, try `rustc --explain E0271`.

--- a/diesel_compile_tests/tests/fail/cannot_join_to_non_joinable_table.stderr
+++ b/diesel_compile_tests/tests/fail/cannot_join_to_non_joinable_table.stderr
@@ -19,6 +19,7 @@ help: the trait `JoinTo<posts::table>` is not implemented for `users::table`
               JoinTo<Tablesample<S, TSM>>
               JoinTo<SelectStatement<..., ..., ..., ..., ..., ..., ..., ...>>
               JoinTo<BoxedSelectStatement<'_, ..., ..., ...>>
+              JoinTo<BoxedCloneSelectStatement<'_, ..., ..., ...>>
               JoinTo<query_source::joins::Join<Left, Right, Kind>>
               JoinTo<query_source::joins::JoinOn<Join, On>>
     = note: required for `users::table` to implement `JoinWithImplicitOnClause<table, Inner>`
@@ -54,6 +55,7 @@ help: the trait `JoinTo<posts::table>` is not implemented for `users::table`
               JoinTo<Tablesample<S, TSM>>
               JoinTo<SelectStatement<..., ..., ..., ..., ..., ..., ..., ...>>
               JoinTo<BoxedSelectStatement<'_, ..., ..., ...>>
+              JoinTo<BoxedCloneSelectStatement<'_, ..., ..., ...>>
               JoinTo<query_source::joins::Join<Left, Right, Kind>>
               JoinTo<query_source::joins::JoinOn<Join, On>>
     = note: required for `users::table` to implement `JoinWithImplicitOnClause<table, LeftOuter>`
@@ -88,6 +90,7 @@ LL | |     posts {
              JoinTo<comments::table>
              JoinTo<SelectStatement<..., ..., ..., ..., ..., ..., ..., ...>>
              JoinTo<BoxedSelectStatement<'_, ..., ..., ...>>
+             JoinTo<BoxedCloneSelectStatement<'_, ..., ..., ...>>
              JoinTo<query_source::joins::Join<Left, Right, Kind>>
              JoinTo<query_source::joins::JoinOn<Join, On>>
    = note: required for `Join<table, table, Inner>` to implement `JoinTo<users::table>`

--- a/diesel_compile_tests/tests/fail/exists_can_only_take_subselects.stderr
+++ b/diesel_compile_tests/tests/fail/exists_can_only_take_subselects.stderr
@@ -28,6 +28,13 @@ LL | / impl<ST, QS, DB, GB> SelectQuery for BoxedSelectStatement<'_, ST, QS, DB,
 LL | | where
 LL | |     DB: Backend,
     | |________________^ `BoxedSelectStatement<'_, ST, QS, DB, GB>`
+    |
+   ::: DIESEL/diesel/diesel/src/query_builder/select_statement/boxed_clone.rs
+    |
+LL | / impl<ST, QS, DB, GB> SelectQuery for BoxedCloneSelectStatement<'_, ST, QS, DB, GB>
+LL | | where
+LL | |     DB: Backend,
+    | |________________^ `BoxedCloneSelectStatement<'_, ST, QS, DB, GB>`
     = note: required for `Subselect<bool, Bool>` to implement `Expression`
     = note: 1 redundant requirement hidden
     = note: required for `diesel::expression::exists::Exists<bool>` to implement `Expression`
@@ -69,6 +76,13 @@ LL | / impl<ST, QS, DB, GB> SelectQuery for BoxedSelectStatement<'_, ST, QS, DB,
 LL | | where
 LL | |     DB: Backend,
     | |________________^ `BoxedSelectStatement<'_, ST, QS, DB, GB>`
+    |
+   ::: DIESEL/diesel/diesel/src/query_builder/select_statement/boxed_clone.rs
+    |
+LL | / impl<ST, QS, DB, GB> SelectQuery for BoxedCloneSelectStatement<'_, ST, QS, DB, GB>
+LL | | where
+LL | |     DB: Backend,
+    | |________________^ `BoxedCloneSelectStatement<'_, ST, QS, DB, GB>`
     = note: required for `Subselect<id, Bool>` to implement `Expression`
     = note: 1 redundant requirement hidden
     = note: required for `diesel::expression::exists::Exists<users::columns::id>` to implement `Expression`

--- a/diesel_compile_tests/tests/fail/mysql_does_not_support_offset_without_limit.stderr
+++ b/diesel_compile_tests/tests/fail/mysql_does_not_support_offset_without_limit.stderr
@@ -11,7 +11,7 @@ error[E0277]: `LimitOffsetClause<NoLimitClause, ...>` is no valid SQL fragment f
 help: the following other types implement trait `QueryFragment<DB, SP>`
     --> DIESEL/diesel/diesel/src/mysql/query_builder/limit_offset.rs
      |
-   LL |   impl QueryFragment<Mysql> for LimitOffsetClause<NoLimitClause, NoOffsetClause> {
+  LL |   impl QueryFragment<Mysql> for LimitOffsetClause<NoLimitClause, NoOffsetClause> {
      |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `LimitOffsetClause<NoLimitClause, NoOffsetClause>`
 ...
   LL | / impl<L> QueryFragment<Mysql> for LimitOffsetClause<LimitClause<L>, NoOffsetClause>

--- a/diesel_compile_tests/tests/fail/valid_grouping_and_boxed_expressions.stderr
+++ b/diesel_compile_tests/tests/fail/valid_grouping_and_boxed_expressions.stderr
@@ -12,14 +12,17 @@ error[E0277]: the trait bound `dyn BoxableExpression<..., ..., SqlType = ...>: V
   LL |         .select(some_ungrouped_expression(true))
      |          ^^^^^^ unsatisfied trait bound
      |
-help: the trait `ValidGrouping<columns::id>` is not implemented for `dyn BoxableExpression<table, Pg, SqlType = ...>`
-      but trait `ValidGrouping<()>` is implemented for it
+     = help: the trait `ValidGrouping<columns::id>` is not implemented for `dyn BoxableExpression<table, Pg, SqlType = ...>`
+help: the following other types implement trait `ValidGrouping<GroupByClause>`
     --> DIESEL/diesel/diesel/src/expression/mod.rs
      |
 LL | / impl<QS, ST, DB, GB, IsAggregate> ValidGrouping<GB>
 LL | |     for dyn BoxableExpression<QS, DB, GB, IsAggregate, SqlType = ST> + '_
-     | |_________________________________________________________________________^
-     = help: for that trait implementation, expected `()`, found `columns::id`
+     | |_________________________________________________________________________^ `dyn BoxableExpression<..., ..., ..., ..., SqlType = ...>`
+...
+LL | / impl<QS, ST, DB, GB, IsAggregate> ValidGrouping<GB>
+LL | |     for dyn BoxableExpression<QS, DB, GB, IsAggregate, SqlType = ST> + Send + Sync + '_
+     | |_______________________________________________________________________________________^ `dyn BoxableExpression<..., ..., ..., ..., SqlType = ...> + Send + Sync`
      = note: required for `Box<...>` to implement `ValidGrouping<columns::id>`
      = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ...>` to implement `SelectDsl<Box<...>>`
   
@@ -32,14 +35,17 @@ error[E0277]: the trait bound `dyn BoxableExpression<..., ..., SqlType = ...>: V
      |          |
      |          required by a bound introduced by this call
      |
-help: the trait `ValidGrouping<columns::id>` is not implemented for `dyn BoxableExpression<table, Pg, SqlType = ...>`
-      but trait `ValidGrouping<()>` is implemented for it
+     = help: the trait `ValidGrouping<columns::id>` is not implemented for `dyn BoxableExpression<table, Pg, SqlType = ...>`
+help: the following other types implement trait `ValidGrouping<GroupByClause>`
     --> DIESEL/diesel/diesel/src/expression/mod.rs
      |
 LL | / impl<QS, ST, DB, GB, IsAggregate> ValidGrouping<GB>
 LL | |     for dyn BoxableExpression<QS, DB, GB, IsAggregate, SqlType = ST> + '_
-     | |_________________________________________________________________________^
-     = help: for that trait implementation, expected `()`, found `columns::id`
+     | |_________________________________________________________________________^ `dyn BoxableExpression<..., ..., ..., ..., SqlType = ...>`
+...
+LL | / impl<QS, ST, DB, GB, IsAggregate> ValidGrouping<GB>
+LL | |     for dyn BoxableExpression<QS, DB, GB, IsAggregate, SqlType = ST> + Send + Sync + '_
+     | |_______________________________________________________________________________________^ `dyn BoxableExpression<..., ..., ..., ..., SqlType = ...> + Send + Sync`
      = note: required for `Box<...>` to implement `ValidGrouping<columns::id>`
      = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ...>` to implement `Query`
      = note: required for `SelectStatement<..., ..., ..., ..., ..., ..., ...>` to implement `LoadQuery<'_, _, i32>`

--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -1968,6 +1968,7 @@ fn derive_multiconnection_inner(input: proc_macro2::TokenStream) -> proc_macro2:
 /// * Insert from select statements
 /// * Query constructed by `diesel::sql_query`
 /// * Expressions using `diesel::dsl::sql`
+/// * Boxed queries constructed by `.into_boxed()` and `.into_boxed_clone()`
 ///
 /// For these cases a manual type annotation is required. See the "Annotating Types" section below
 /// for details.

--- a/diesel_derives/src/multiconnection.rs
+++ b/diesel_derives/src/multiconnection.rs
@@ -1799,6 +1799,103 @@ fn generate_querybuilder(
             }
         }
 
+        impl<'a, ST, QS, GB>
+            diesel::query_builder::QueryFragment<
+            super::backend::MultiBackend,
+            super::backend::MultiSelectStatementSyntax,
+        >
+            for diesel::internal::derives::multiconnection::BoxedCloneSelectStatement<
+                'a,
+                ST,
+                QS,
+                super::backend::MultiBackend,
+                GB,
+            >
+        where
+            QS: diesel::query_builder::QueryFragment<super::backend::MultiBackend>
+        {
+            fn walk_ast<'b>(
+                &'b self,
+                pass: diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
+            ) -> diesel::QueryResult<()> {
+                use diesel::internal::derives::multiconnection::BoxedCloneQueryHelper;
+                self.build_query(pass, |where_clause, pass| where_clause.walk_ast(pass))
+            }
+        }
+
+        impl diesel::query_builder::QueryFragment<super::backend::MultiBackend>
+            for diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause<
+                '_,
+                super::backend::MultiBackend,
+            >
+        {
+            fn walk_ast<'b>(
+                &'b self,
+                mut pass: diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
+            ) -> diesel::QueryResult<()> {
+                if let Some(limit) = &self.limit {
+                    limit.walk_ast(pass.reborrow())?;
+                }
+                if let Some(offset) = &self.offset {
+                    offset.walk_ast(pass.reborrow())?;
+                }
+                Ok(())
+            }
+        }
+
+        impl<'a> diesel::query_builder::IntoBoxedCloneClause<'a, super::multi_connection_impl::backend::MultiBackend>
+            for diesel::internal::derives::multiconnection::LimitOffsetClause<diesel::internal::derives::multiconnection::NoLimitClause, diesel::internal::derives::multiconnection::NoOffsetClause>
+        {
+            type BoxedCloneClause = diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause<'a, super::multi_connection_impl::backend::MultiBackend>;
+
+            fn into_boxed_clone(self) -> Self::BoxedCloneClause {
+                diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause {
+                    limit: None,
+                    offset: None,
+                }
+            }
+        }
+        impl<'a, L> diesel::query_builder::IntoBoxedCloneClause<'a, super::multi_connection_impl::backend::MultiBackend>
+            for diesel::internal::derives::multiconnection::LimitOffsetClause<diesel::internal::derives::multiconnection::LimitClause<L>, diesel::internal::derives::multiconnection::NoOffsetClause>
+        where diesel::internal::derives::multiconnection::LimitClause<L>: diesel::query_builder::QueryFragment<super::backend::MultiBackend> + Send + Sync + 'static,
+        {
+            type BoxedCloneClause = diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause<'a, super::multi_connection_impl::backend::MultiBackend>;
+            fn into_boxed_clone(self) -> Self::BoxedCloneClause {
+                diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause {
+                    limit: Some(std::sync::Arc::new(self.limit_clause)),
+                    offset: None,
+                }
+            }
+        }
+        impl<'a, O> diesel::query_builder::IntoBoxedCloneClause<'a, super::multi_connection_impl::backend::MultiBackend>
+            for diesel::internal::derives::multiconnection::LimitOffsetClause<diesel::internal::derives::multiconnection::NoLimitClause, diesel::internal::derives::multiconnection::OffsetClause<O>>
+        where diesel::internal::derives::multiconnection::OffsetClause<O>: diesel::query_builder::QueryFragment<super::backend::MultiBackend> + Send + Sync + 'static,
+
+        {
+            type BoxedCloneClause = diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause<'a, super::multi_connection_impl::backend::MultiBackend>;
+            fn into_boxed_clone(self) -> Self::BoxedCloneClause {
+                diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause {
+                    limit: None,
+                    offset: Some(std::sync::Arc::new(self.offset_clause)),
+                }
+            }
+        }
+        impl<'a, L, O> diesel::query_builder::IntoBoxedCloneClause<'a, super::multi_connection_impl::backend::MultiBackend>
+            for diesel::internal::derives::multiconnection::LimitOffsetClause<diesel::internal::derives::multiconnection::LimitClause<L>, diesel::internal::derives::multiconnection::OffsetClause<O>>
+        where L: diesel::query_builder::QueryFragment<super::backend::MultiBackend> + Send + Sync + 'a,
+              O: diesel::query_builder::QueryFragment<super::backend::MultiBackend> + Send + Sync + 'a,
+              diesel::internal::derives::multiconnection::LimitClause<L>: diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
+              diesel::internal::derives::multiconnection::OffsetClause<O>: diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
+        {
+            type BoxedCloneClause = diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause<'a, super::multi_connection_impl::backend::MultiBackend>;
+            fn into_boxed_clone(self) -> Self::BoxedCloneClause {
+                diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause {
+                    limit: Some(std::sync::Arc::new(self.limit_clause)),
+                    offset: Some(std::sync::Arc::new(self.offset_clause)),
+                }
+            }
+        }
+
         impl<Col, Expr> diesel::insertable::InsertValues<super::multi_connection_impl::backend::MultiBackend, Col::Table>
             for diesel::insertable::DefaultableColumnInsertValue<diesel::insertable::ColumnInsertValue<Col, Expr>>
         where

--- a/diesel_derives/src/table.rs
+++ b/diesel_derives/src/table.rs
@@ -601,6 +601,10 @@ fn expand(input: TableDecl, kind: QuerySourceMacroKind) -> TokenStream {
             #[doc = concat!("Helper type for representing a boxed query from this ", #kind_name)]
             pub type BoxedQuery<'a, DB, ST = SqlType> = diesel::internal::table_macro::BoxedSelectStatement<'a, ST, diesel::internal::table_macro::FromClause<#query_source_ident>, DB>;
 
+            #[doc = concat!("Helper type for representing a boxed cloneable query from this ", #kind_name)]
+            pub type BoxedCloneQuery<'a, DB, ST = SqlType> = diesel::internal::table_macro::BoxedCloneSelectStatement<'a, ST, diesel::internal::table_macro::FromClause<#query_source_ident>, DB>;
+
+
             impl diesel::QuerySource for #query_source_ident {
                 type FromClause = diesel::internal::table_macro::StaticQueryFragmentInstance<#query_source_ident>;
                 type DefaultSelection = <Self as diesel::query_source::QueryRelation>::AllColumns;
@@ -738,6 +742,18 @@ fn expand(input: TableDecl, kind: QuerySourceMacroKind) -> TokenStream {
                 type OnClause = <diesel::internal::table_macro::BoxedSelectStatement<'a, diesel::internal::table_macro::FromClause<QS>, ST, DB> as diesel::JoinTo<Self>>::OnClause;
                 fn join_target(__diesel_internal_rhs: diesel::internal::table_macro::BoxedSelectStatement<'a, diesel::internal::table_macro::FromClause<QS>, ST, DB>) -> (Self::FromClause, Self::OnClause) {
                     let (_, __diesel_internal_on_clause) = diesel::internal::table_macro::BoxedSelectStatement::join_target(Self);
+                    (__diesel_internal_rhs, __diesel_internal_on_clause)
+                }
+            }
+
+            impl<'a, QS, ST, DB> diesel::JoinTo<diesel::internal::table_macro::BoxedCloneSelectStatement<'a, diesel::internal::table_macro::FromClause<QS>, ST, DB>> for #query_source_ident where
+                diesel::internal::table_macro::BoxedCloneSelectStatement<'a, diesel::internal::table_macro::FromClause<QS>, ST, DB>: diesel::JoinTo<Self>,
+                QS: diesel::query_source::QuerySource,
+            {
+                type FromClause = diesel::internal::table_macro::BoxedCloneSelectStatement<'a, diesel::internal::table_macro::FromClause<QS>, ST, DB>;
+                type OnClause = <diesel::internal::table_macro::BoxedCloneSelectStatement<'a, diesel::internal::table_macro::FromClause<QS>, ST, DB> as diesel::JoinTo<Self>>::OnClause;
+                fn join_target(__diesel_internal_rhs: diesel::internal::table_macro::BoxedCloneSelectStatement<'a, diesel::internal::table_macro::FromClause<QS>, ST, DB>) -> (Self::FromClause, Self::OnClause) {
+                    let (_, __diesel_internal_on_clause) = diesel::internal::table_macro::BoxedCloneSelectStatement::join_target(Self);
                     (__diesel_internal_rhs, __diesel_internal_on_clause)
                 }
             }

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__multiconnection_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__multiconnection_1.snap
@@ -847,6 +847,163 @@ mod multi_connection_impl {
             }
         }
         impl<
+            'a,
+            ST,
+            QS,
+            GB,
+        > diesel::query_builder::QueryFragment<
+            super::backend::MultiBackend,
+            super::backend::MultiSelectStatementSyntax,
+        >
+        for diesel::internal::derives::multiconnection::BoxedCloneSelectStatement<
+            'a,
+            ST,
+            QS,
+            super::backend::MultiBackend,
+            GB,
+        >
+        where
+            QS: diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
+        {
+            fn walk_ast<'b>(
+                &'b self,
+                pass: diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
+            ) -> diesel::QueryResult<()> {
+                use diesel::internal::derives::multiconnection::BoxedCloneQueryHelper;
+                self.build_query(pass, |where_clause, pass| where_clause.walk_ast(pass))
+            }
+        }
+        impl diesel::query_builder::QueryFragment<super::backend::MultiBackend>
+        for diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause<
+            '_,
+            super::backend::MultiBackend,
+        > {
+            fn walk_ast<'b>(
+                &'b self,
+                mut pass: diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
+            ) -> diesel::QueryResult<()> {
+                if let Some(limit) = &self.limit {
+                    limit.walk_ast(pass.reborrow())?;
+                }
+                if let Some(offset) = &self.offset {
+                    offset.walk_ast(pass.reborrow())?;
+                }
+                Ok(())
+            }
+        }
+        impl<
+            'a,
+        > diesel::query_builder::IntoBoxedCloneClause<
+            'a,
+            super::multi_connection_impl::backend::MultiBackend,
+        >
+        for diesel::internal::derives::multiconnection::LimitOffsetClause<
+            diesel::internal::derives::multiconnection::NoLimitClause,
+            diesel::internal::derives::multiconnection::NoOffsetClause,
+        > {
+            type BoxedCloneClause = diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause<
+                'a,
+                super::multi_connection_impl::backend::MultiBackend,
+            >;
+            fn into_boxed_clone(self) -> Self::BoxedCloneClause {
+                diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause {
+                    limit: None,
+                    offset: None,
+                }
+            }
+        }
+        impl<
+            'a,
+            L,
+        > diesel::query_builder::IntoBoxedCloneClause<
+            'a,
+            super::multi_connection_impl::backend::MultiBackend,
+        >
+        for diesel::internal::derives::multiconnection::LimitOffsetClause<
+            diesel::internal::derives::multiconnection::LimitClause<L>,
+            diesel::internal::derives::multiconnection::NoOffsetClause,
+        >
+        where
+            diesel::internal::derives::multiconnection::LimitClause<
+                L,
+            >: diesel::query_builder::QueryFragment<super::backend::MultiBackend> + Send
+                + Sync + 'static,
+        {
+            type BoxedCloneClause = diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause<
+                'a,
+                super::multi_connection_impl::backend::MultiBackend,
+            >;
+            fn into_boxed_clone(self) -> Self::BoxedCloneClause {
+                diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause {
+                    limit: Some(std::sync::Arc::new(self.limit_clause)),
+                    offset: None,
+                }
+            }
+        }
+        impl<
+            'a,
+            O,
+        > diesel::query_builder::IntoBoxedCloneClause<
+            'a,
+            super::multi_connection_impl::backend::MultiBackend,
+        >
+        for diesel::internal::derives::multiconnection::LimitOffsetClause<
+            diesel::internal::derives::multiconnection::NoLimitClause,
+            diesel::internal::derives::multiconnection::OffsetClause<O>,
+        >
+        where
+            diesel::internal::derives::multiconnection::OffsetClause<
+                O,
+            >: diesel::query_builder::QueryFragment<super::backend::MultiBackend> + Send
+                + Sync + 'static,
+        {
+            type BoxedCloneClause = diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause<
+                'a,
+                super::multi_connection_impl::backend::MultiBackend,
+            >;
+            fn into_boxed_clone(self) -> Self::BoxedCloneClause {
+                diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause {
+                    limit: None,
+                    offset: Some(std::sync::Arc::new(self.offset_clause)),
+                }
+            }
+        }
+        impl<
+            'a,
+            L,
+            O,
+        > diesel::query_builder::IntoBoxedCloneClause<
+            'a,
+            super::multi_connection_impl::backend::MultiBackend,
+        >
+        for diesel::internal::derives::multiconnection::LimitOffsetClause<
+            diesel::internal::derives::multiconnection::LimitClause<L>,
+            diesel::internal::derives::multiconnection::OffsetClause<O>,
+        >
+        where
+            L: diesel::query_builder::QueryFragment<super::backend::MultiBackend> + Send
+                + Sync + 'a,
+            O: diesel::query_builder::QueryFragment<super::backend::MultiBackend> + Send
+                + Sync + 'a,
+            diesel::internal::derives::multiconnection::LimitClause<
+                L,
+            >: diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
+            diesel::internal::derives::multiconnection::OffsetClause<
+                O,
+            >: diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
+        {
+            type BoxedCloneClause = diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause<
+                'a,
+                super::multi_connection_impl::backend::MultiBackend,
+            >;
+            fn into_boxed_clone(self) -> Self::BoxedCloneClause {
+                diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause {
+                    limit: Some(std::sync::Arc::new(self.limit_clause)),
+                    offset: Some(std::sync::Arc::new(self.offset_clause)),
+                }
+            }
+        }
+        impl<
             Col,
             Expr,
         > diesel::insertable::InsertValues<

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__multiconnection_2.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__multiconnection_2.snap
@@ -849,6 +849,163 @@ mod multi_connection_impl {
             }
         }
         impl<
+            'a,
+            ST,
+            QS,
+            GB,
+        > diesel::query_builder::QueryFragment<
+            super::backend::MultiBackend,
+            super::backend::MultiSelectStatementSyntax,
+        >
+        for diesel::internal::derives::multiconnection::BoxedCloneSelectStatement<
+            'a,
+            ST,
+            QS,
+            super::backend::MultiBackend,
+            GB,
+        >
+        where
+            QS: diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
+        {
+            fn walk_ast<'b>(
+                &'b self,
+                pass: diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
+            ) -> diesel::QueryResult<()> {
+                use diesel::internal::derives::multiconnection::BoxedCloneQueryHelper;
+                self.build_query(pass, |where_clause, pass| where_clause.walk_ast(pass))
+            }
+        }
+        impl diesel::query_builder::QueryFragment<super::backend::MultiBackend>
+        for diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause<
+            '_,
+            super::backend::MultiBackend,
+        > {
+            fn walk_ast<'b>(
+                &'b self,
+                mut pass: diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
+            ) -> diesel::QueryResult<()> {
+                if let Some(limit) = &self.limit {
+                    limit.walk_ast(pass.reborrow())?;
+                }
+                if let Some(offset) = &self.offset {
+                    offset.walk_ast(pass.reborrow())?;
+                }
+                Ok(())
+            }
+        }
+        impl<
+            'a,
+        > diesel::query_builder::IntoBoxedCloneClause<
+            'a,
+            super::multi_connection_impl::backend::MultiBackend,
+        >
+        for diesel::internal::derives::multiconnection::LimitOffsetClause<
+            diesel::internal::derives::multiconnection::NoLimitClause,
+            diesel::internal::derives::multiconnection::NoOffsetClause,
+        > {
+            type BoxedCloneClause = diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause<
+                'a,
+                super::multi_connection_impl::backend::MultiBackend,
+            >;
+            fn into_boxed_clone(self) -> Self::BoxedCloneClause {
+                diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause {
+                    limit: None,
+                    offset: None,
+                }
+            }
+        }
+        impl<
+            'a,
+            L,
+        > diesel::query_builder::IntoBoxedCloneClause<
+            'a,
+            super::multi_connection_impl::backend::MultiBackend,
+        >
+        for diesel::internal::derives::multiconnection::LimitOffsetClause<
+            diesel::internal::derives::multiconnection::LimitClause<L>,
+            diesel::internal::derives::multiconnection::NoOffsetClause,
+        >
+        where
+            diesel::internal::derives::multiconnection::LimitClause<
+                L,
+            >: diesel::query_builder::QueryFragment<super::backend::MultiBackend> + Send
+                + Sync + 'static,
+        {
+            type BoxedCloneClause = diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause<
+                'a,
+                super::multi_connection_impl::backend::MultiBackend,
+            >;
+            fn into_boxed_clone(self) -> Self::BoxedCloneClause {
+                diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause {
+                    limit: Some(std::sync::Arc::new(self.limit_clause)),
+                    offset: None,
+                }
+            }
+        }
+        impl<
+            'a,
+            O,
+        > diesel::query_builder::IntoBoxedCloneClause<
+            'a,
+            super::multi_connection_impl::backend::MultiBackend,
+        >
+        for diesel::internal::derives::multiconnection::LimitOffsetClause<
+            diesel::internal::derives::multiconnection::NoLimitClause,
+            diesel::internal::derives::multiconnection::OffsetClause<O>,
+        >
+        where
+            diesel::internal::derives::multiconnection::OffsetClause<
+                O,
+            >: diesel::query_builder::QueryFragment<super::backend::MultiBackend> + Send
+                + Sync + 'static,
+        {
+            type BoxedCloneClause = diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause<
+                'a,
+                super::multi_connection_impl::backend::MultiBackend,
+            >;
+            fn into_boxed_clone(self) -> Self::BoxedCloneClause {
+                diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause {
+                    limit: None,
+                    offset: Some(std::sync::Arc::new(self.offset_clause)),
+                }
+            }
+        }
+        impl<
+            'a,
+            L,
+            O,
+        > diesel::query_builder::IntoBoxedCloneClause<
+            'a,
+            super::multi_connection_impl::backend::MultiBackend,
+        >
+        for diesel::internal::derives::multiconnection::LimitOffsetClause<
+            diesel::internal::derives::multiconnection::LimitClause<L>,
+            diesel::internal::derives::multiconnection::OffsetClause<O>,
+        >
+        where
+            L: diesel::query_builder::QueryFragment<super::backend::MultiBackend> + Send
+                + Sync + 'a,
+            O: diesel::query_builder::QueryFragment<super::backend::MultiBackend> + Send
+                + Sync + 'a,
+            diesel::internal::derives::multiconnection::LimitClause<
+                L,
+            >: diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
+            diesel::internal::derives::multiconnection::OffsetClause<
+                O,
+            >: diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
+        {
+            type BoxedCloneClause = diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause<
+                'a,
+                super::multi_connection_impl::backend::MultiBackend,
+            >;
+            fn into_boxed_clone(self) -> Self::BoxedCloneClause {
+                diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause {
+                    limit: Some(std::sync::Arc::new(self.limit_clause)),
+                    offset: Some(std::sync::Arc::new(self.offset_clause)),
+                }
+            }
+        }
+        impl<
             Col,
             Expr,
         > diesel::insertable::InsertValues<

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__table_1 (postgres).snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__table_1 (postgres).snap
@@ -71,6 +71,15 @@ pub mod users {
         diesel::internal::table_macro::FromClause<table>,
         DB,
     >;
+    #[doc = concat!(
+        "Helper type for representing a boxed cloneable query from this ", "table"
+    )]
+    pub type BoxedCloneQuery<'a, DB, ST = SqlType> = diesel::internal::table_macro::BoxedCloneSelectStatement<
+        'a,
+        ST,
+        diesel::internal::table_macro::FromClause<table>,
+        DB,
+    >;
     impl diesel::QuerySource for table {
         type FromClause = diesel::internal::table_macro::StaticQueryFragmentInstance<
             table,
@@ -394,6 +403,54 @@ pub mod users {
             >,
         ) -> (Self::FromClause, Self::OnClause) {
             let (_, __diesel_internal_on_clause) = diesel::internal::table_macro::BoxedSelectStatement::join_target(
+                Self,
+            );
+            (__diesel_internal_rhs, __diesel_internal_on_clause)
+        }
+    }
+    impl<
+        'a,
+        QS,
+        ST,
+        DB,
+    > diesel::JoinTo<
+        diesel::internal::table_macro::BoxedCloneSelectStatement<
+            'a,
+            diesel::internal::table_macro::FromClause<QS>,
+            ST,
+            DB,
+        >,
+    > for table
+    where
+        diesel::internal::table_macro::BoxedCloneSelectStatement<
+            'a,
+            diesel::internal::table_macro::FromClause<QS>,
+            ST,
+            DB,
+        >: diesel::JoinTo<Self>,
+        QS: diesel::query_source::QuerySource,
+    {
+        type FromClause = diesel::internal::table_macro::BoxedCloneSelectStatement<
+            'a,
+            diesel::internal::table_macro::FromClause<QS>,
+            ST,
+            DB,
+        >;
+        type OnClause = <diesel::internal::table_macro::BoxedCloneSelectStatement<
+            'a,
+            diesel::internal::table_macro::FromClause<QS>,
+            ST,
+            DB,
+        > as diesel::JoinTo<Self>>::OnClause;
+        fn join_target(
+            __diesel_internal_rhs: diesel::internal::table_macro::BoxedCloneSelectStatement<
+                'a,
+                diesel::internal::table_macro::FromClause<QS>,
+                ST,
+                DB,
+            >,
+        ) -> (Self::FromClause, Self::OnClause) {
+            let (_, __diesel_internal_on_clause) = diesel::internal::table_macro::BoxedCloneSelectStatement::join_target(
                 Self,
             );
             (__diesel_internal_rhs, __diesel_internal_on_clause)

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__table_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__table_1.snap
@@ -71,6 +71,15 @@ pub mod users {
         diesel::internal::table_macro::FromClause<table>,
         DB,
     >;
+    #[doc = concat!(
+        "Helper type for representing a boxed cloneable query from this ", "table"
+    )]
+    pub type BoxedCloneQuery<'a, DB, ST = SqlType> = diesel::internal::table_macro::BoxedCloneSelectStatement<
+        'a,
+        ST,
+        diesel::internal::table_macro::FromClause<table>,
+        DB,
+    >;
     impl diesel::QuerySource for table {
         type FromClause = diesel::internal::table_macro::StaticQueryFragmentInstance<
             table,
@@ -394,6 +403,54 @@ pub mod users {
             >,
         ) -> (Self::FromClause, Self::OnClause) {
             let (_, __diesel_internal_on_clause) = diesel::internal::table_macro::BoxedSelectStatement::join_target(
+                Self,
+            );
+            (__diesel_internal_rhs, __diesel_internal_on_clause)
+        }
+    }
+    impl<
+        'a,
+        QS,
+        ST,
+        DB,
+    > diesel::JoinTo<
+        diesel::internal::table_macro::BoxedCloneSelectStatement<
+            'a,
+            diesel::internal::table_macro::FromClause<QS>,
+            ST,
+            DB,
+        >,
+    > for table
+    where
+        diesel::internal::table_macro::BoxedCloneSelectStatement<
+            'a,
+            diesel::internal::table_macro::FromClause<QS>,
+            ST,
+            DB,
+        >: diesel::JoinTo<Self>,
+        QS: diesel::query_source::QuerySource,
+    {
+        type FromClause = diesel::internal::table_macro::BoxedCloneSelectStatement<
+            'a,
+            diesel::internal::table_macro::FromClause<QS>,
+            ST,
+            DB,
+        >;
+        type OnClause = <diesel::internal::table_macro::BoxedCloneSelectStatement<
+            'a,
+            diesel::internal::table_macro::FromClause<QS>,
+            ST,
+            DB,
+        > as diesel::JoinTo<Self>>::OnClause;
+        fn join_target(
+            __diesel_internal_rhs: diesel::internal::table_macro::BoxedCloneSelectStatement<
+                'a,
+                diesel::internal::table_macro::FromClause<QS>,
+                ST,
+                DB,
+            >,
+        ) -> (Self::FromClause, Self::OnClause) {
+            let (_, __diesel_internal_on_clause) = diesel::internal::table_macro::BoxedCloneSelectStatement::join_target(
                 Self,
             );
             (__diesel_internal_rhs, __diesel_internal_on_clause)

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__table_with_column_feature_gate (postgres).snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__table_with_column_feature_gate (postgres).snap
@@ -83,6 +83,15 @@ pub mod users {
         diesel::internal::table_macro::FromClause<table>,
         DB,
     >;
+    #[doc = concat!(
+        "Helper type for representing a boxed cloneable query from this ", "table"
+    )]
+    pub type BoxedCloneQuery<'a, DB, ST = SqlType> = diesel::internal::table_macro::BoxedCloneSelectStatement<
+        'a,
+        ST,
+        diesel::internal::table_macro::FromClause<table>,
+        DB,
+    >;
     impl diesel::QuerySource for table {
         type FromClause = diesel::internal::table_macro::StaticQueryFragmentInstance<
             table,
@@ -406,6 +415,54 @@ pub mod users {
             >,
         ) -> (Self::FromClause, Self::OnClause) {
             let (_, __diesel_internal_on_clause) = diesel::internal::table_macro::BoxedSelectStatement::join_target(
+                Self,
+            );
+            (__diesel_internal_rhs, __diesel_internal_on_clause)
+        }
+    }
+    impl<
+        'a,
+        QS,
+        ST,
+        DB,
+    > diesel::JoinTo<
+        diesel::internal::table_macro::BoxedCloneSelectStatement<
+            'a,
+            diesel::internal::table_macro::FromClause<QS>,
+            ST,
+            DB,
+        >,
+    > for table
+    where
+        diesel::internal::table_macro::BoxedCloneSelectStatement<
+            'a,
+            diesel::internal::table_macro::FromClause<QS>,
+            ST,
+            DB,
+        >: diesel::JoinTo<Self>,
+        QS: diesel::query_source::QuerySource,
+    {
+        type FromClause = diesel::internal::table_macro::BoxedCloneSelectStatement<
+            'a,
+            diesel::internal::table_macro::FromClause<QS>,
+            ST,
+            DB,
+        >;
+        type OnClause = <diesel::internal::table_macro::BoxedCloneSelectStatement<
+            'a,
+            diesel::internal::table_macro::FromClause<QS>,
+            ST,
+            DB,
+        > as diesel::JoinTo<Self>>::OnClause;
+        fn join_target(
+            __diesel_internal_rhs: diesel::internal::table_macro::BoxedCloneSelectStatement<
+                'a,
+                diesel::internal::table_macro::FromClause<QS>,
+                ST,
+                DB,
+            >,
+        ) -> (Self::FromClause, Self::OnClause) {
+            let (_, __diesel_internal_on_clause) = diesel::internal::table_macro::BoxedCloneSelectStatement::join_target(
                 Self,
             );
             (__diesel_internal_rhs, __diesel_internal_on_clause)

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__table_with_column_feature_gate.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__table_with_column_feature_gate.snap
@@ -83,6 +83,15 @@ pub mod users {
         diesel::internal::table_macro::FromClause<table>,
         DB,
     >;
+    #[doc = concat!(
+        "Helper type for representing a boxed cloneable query from this ", "table"
+    )]
+    pub type BoxedCloneQuery<'a, DB, ST = SqlType> = diesel::internal::table_macro::BoxedCloneSelectStatement<
+        'a,
+        ST,
+        diesel::internal::table_macro::FromClause<table>,
+        DB,
+    >;
     impl diesel::QuerySource for table {
         type FromClause = diesel::internal::table_macro::StaticQueryFragmentInstance<
             table,
@@ -406,6 +415,54 @@ pub mod users {
             >,
         ) -> (Self::FromClause, Self::OnClause) {
             let (_, __diesel_internal_on_clause) = diesel::internal::table_macro::BoxedSelectStatement::join_target(
+                Self,
+            );
+            (__diesel_internal_rhs, __diesel_internal_on_clause)
+        }
+    }
+    impl<
+        'a,
+        QS,
+        ST,
+        DB,
+    > diesel::JoinTo<
+        diesel::internal::table_macro::BoxedCloneSelectStatement<
+            'a,
+            diesel::internal::table_macro::FromClause<QS>,
+            ST,
+            DB,
+        >,
+    > for table
+    where
+        diesel::internal::table_macro::BoxedCloneSelectStatement<
+            'a,
+            diesel::internal::table_macro::FromClause<QS>,
+            ST,
+            DB,
+        >: diesel::JoinTo<Self>,
+        QS: diesel::query_source::QuerySource,
+    {
+        type FromClause = diesel::internal::table_macro::BoxedCloneSelectStatement<
+            'a,
+            diesel::internal::table_macro::FromClause<QS>,
+            ST,
+            DB,
+        >;
+        type OnClause = <diesel::internal::table_macro::BoxedCloneSelectStatement<
+            'a,
+            diesel::internal::table_macro::FromClause<QS>,
+            ST,
+            DB,
+        > as diesel::JoinTo<Self>>::OnClause;
+        fn join_target(
+            __diesel_internal_rhs: diesel::internal::table_macro::BoxedCloneSelectStatement<
+                'a,
+                diesel::internal::table_macro::FromClause<QS>,
+                ST,
+                DB,
+            >,
+        ) -> (Self::FromClause, Self::OnClause) {
+            let (_, __diesel_internal_on_clause) = diesel::internal::table_macro::BoxedCloneSelectStatement::join_target(
                 Self,
             );
             (__diesel_internal_rhs, __diesel_internal_on_clause)

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__table_with_multiple_feature_gated_columns (postgres).snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__table_with_multiple_feature_gated_columns (postgres).snap
@@ -99,6 +99,15 @@ pub mod users {
         diesel::internal::table_macro::FromClause<table>,
         DB,
     >;
+    #[doc = concat!(
+        "Helper type for representing a boxed cloneable query from this ", "table"
+    )]
+    pub type BoxedCloneQuery<'a, DB, ST = SqlType> = diesel::internal::table_macro::BoxedCloneSelectStatement<
+        'a,
+        ST,
+        diesel::internal::table_macro::FromClause<table>,
+        DB,
+    >;
     impl diesel::QuerySource for table {
         type FromClause = diesel::internal::table_macro::StaticQueryFragmentInstance<
             table,
@@ -422,6 +431,54 @@ pub mod users {
             >,
         ) -> (Self::FromClause, Self::OnClause) {
             let (_, __diesel_internal_on_clause) = diesel::internal::table_macro::BoxedSelectStatement::join_target(
+                Self,
+            );
+            (__diesel_internal_rhs, __diesel_internal_on_clause)
+        }
+    }
+    impl<
+        'a,
+        QS,
+        ST,
+        DB,
+    > diesel::JoinTo<
+        diesel::internal::table_macro::BoxedCloneSelectStatement<
+            'a,
+            diesel::internal::table_macro::FromClause<QS>,
+            ST,
+            DB,
+        >,
+    > for table
+    where
+        diesel::internal::table_macro::BoxedCloneSelectStatement<
+            'a,
+            diesel::internal::table_macro::FromClause<QS>,
+            ST,
+            DB,
+        >: diesel::JoinTo<Self>,
+        QS: diesel::query_source::QuerySource,
+    {
+        type FromClause = diesel::internal::table_macro::BoxedCloneSelectStatement<
+            'a,
+            diesel::internal::table_macro::FromClause<QS>,
+            ST,
+            DB,
+        >;
+        type OnClause = <diesel::internal::table_macro::BoxedCloneSelectStatement<
+            'a,
+            diesel::internal::table_macro::FromClause<QS>,
+            ST,
+            DB,
+        > as diesel::JoinTo<Self>>::OnClause;
+        fn join_target(
+            __diesel_internal_rhs: diesel::internal::table_macro::BoxedCloneSelectStatement<
+                'a,
+                diesel::internal::table_macro::FromClause<QS>,
+                ST,
+                DB,
+            >,
+        ) -> (Self::FromClause, Self::OnClause) {
+            let (_, __diesel_internal_on_clause) = diesel::internal::table_macro::BoxedCloneSelectStatement::join_target(
                 Self,
             );
             (__diesel_internal_rhs, __diesel_internal_on_clause)

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__table_with_multiple_feature_gated_columns.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__table_with_multiple_feature_gated_columns.snap
@@ -99,6 +99,15 @@ pub mod users {
         diesel::internal::table_macro::FromClause<table>,
         DB,
     >;
+    #[doc = concat!(
+        "Helper type for representing a boxed cloneable query from this ", "table"
+    )]
+    pub type BoxedCloneQuery<'a, DB, ST = SqlType> = diesel::internal::table_macro::BoxedCloneSelectStatement<
+        'a,
+        ST,
+        diesel::internal::table_macro::FromClause<table>,
+        DB,
+    >;
     impl diesel::QuerySource for table {
         type FromClause = diesel::internal::table_macro::StaticQueryFragmentInstance<
             table,
@@ -422,6 +431,54 @@ pub mod users {
             >,
         ) -> (Self::FromClause, Self::OnClause) {
             let (_, __diesel_internal_on_clause) = diesel::internal::table_macro::BoxedSelectStatement::join_target(
+                Self,
+            );
+            (__diesel_internal_rhs, __diesel_internal_on_clause)
+        }
+    }
+    impl<
+        'a,
+        QS,
+        ST,
+        DB,
+    > diesel::JoinTo<
+        diesel::internal::table_macro::BoxedCloneSelectStatement<
+            'a,
+            diesel::internal::table_macro::FromClause<QS>,
+            ST,
+            DB,
+        >,
+    > for table
+    where
+        diesel::internal::table_macro::BoxedCloneSelectStatement<
+            'a,
+            diesel::internal::table_macro::FromClause<QS>,
+            ST,
+            DB,
+        >: diesel::JoinTo<Self>,
+        QS: diesel::query_source::QuerySource,
+    {
+        type FromClause = diesel::internal::table_macro::BoxedCloneSelectStatement<
+            'a,
+            diesel::internal::table_macro::FromClause<QS>,
+            ST,
+            DB,
+        >;
+        type OnClause = <diesel::internal::table_macro::BoxedCloneSelectStatement<
+            'a,
+            diesel::internal::table_macro::FromClause<QS>,
+            ST,
+            DB,
+        > as diesel::JoinTo<Self>>::OnClause;
+        fn join_target(
+            __diesel_internal_rhs: diesel::internal::table_macro::BoxedCloneSelectStatement<
+                'a,
+                diesel::internal::table_macro::FromClause<QS>,
+                ST,
+                DB,
+            >,
+        ) -> (Self::FromClause, Self::OnClause) {
+            let (_, __diesel_internal_on_clause) = diesel::internal::table_macro::BoxedCloneSelectStatement::join_target(
                 Self,
             );
             (__diesel_internal_rhs, __diesel_internal_on_clause)

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__view_1 (postgres).snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__view_1 (postgres).snap
@@ -71,6 +71,15 @@ pub mod view {
         diesel::internal::table_macro::FromClause<view>,
         DB,
     >;
+    #[doc = concat!(
+        "Helper type for representing a boxed cloneable query from this ", "view"
+    )]
+    pub type BoxedCloneQuery<'a, DB, ST = SqlType> = diesel::internal::table_macro::BoxedCloneSelectStatement<
+        'a,
+        ST,
+        diesel::internal::table_macro::FromClause<view>,
+        DB,
+    >;
     impl diesel::QuerySource for view {
         type FromClause = diesel::internal::table_macro::StaticQueryFragmentInstance<
             view,
@@ -352,6 +361,54 @@ pub mod view {
             >,
         ) -> (Self::FromClause, Self::OnClause) {
             let (_, __diesel_internal_on_clause) = diesel::internal::table_macro::BoxedSelectStatement::join_target(
+                Self,
+            );
+            (__diesel_internal_rhs, __diesel_internal_on_clause)
+        }
+    }
+    impl<
+        'a,
+        QS,
+        ST,
+        DB,
+    > diesel::JoinTo<
+        diesel::internal::table_macro::BoxedCloneSelectStatement<
+            'a,
+            diesel::internal::table_macro::FromClause<QS>,
+            ST,
+            DB,
+        >,
+    > for view
+    where
+        diesel::internal::table_macro::BoxedCloneSelectStatement<
+            'a,
+            diesel::internal::table_macro::FromClause<QS>,
+            ST,
+            DB,
+        >: diesel::JoinTo<Self>,
+        QS: diesel::query_source::QuerySource,
+    {
+        type FromClause = diesel::internal::table_macro::BoxedCloneSelectStatement<
+            'a,
+            diesel::internal::table_macro::FromClause<QS>,
+            ST,
+            DB,
+        >;
+        type OnClause = <diesel::internal::table_macro::BoxedCloneSelectStatement<
+            'a,
+            diesel::internal::table_macro::FromClause<QS>,
+            ST,
+            DB,
+        > as diesel::JoinTo<Self>>::OnClause;
+        fn join_target(
+            __diesel_internal_rhs: diesel::internal::table_macro::BoxedCloneSelectStatement<
+                'a,
+                diesel::internal::table_macro::FromClause<QS>,
+                ST,
+                DB,
+            >,
+        ) -> (Self::FromClause, Self::OnClause) {
+            let (_, __diesel_internal_on_clause) = diesel::internal::table_macro::BoxedCloneSelectStatement::join_target(
                 Self,
             );
             (__diesel_internal_rhs, __diesel_internal_on_clause)

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__view_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__view_1.snap
@@ -71,6 +71,15 @@ pub mod view {
         diesel::internal::table_macro::FromClause<view>,
         DB,
     >;
+    #[doc = concat!(
+        "Helper type for representing a boxed cloneable query from this ", "view"
+    )]
+    pub type BoxedCloneQuery<'a, DB, ST = SqlType> = diesel::internal::table_macro::BoxedCloneSelectStatement<
+        'a,
+        ST,
+        diesel::internal::table_macro::FromClause<view>,
+        DB,
+    >;
     impl diesel::QuerySource for view {
         type FromClause = diesel::internal::table_macro::StaticQueryFragmentInstance<
             view,
@@ -352,6 +361,54 @@ pub mod view {
             >,
         ) -> (Self::FromClause, Self::OnClause) {
             let (_, __diesel_internal_on_clause) = diesel::internal::table_macro::BoxedSelectStatement::join_target(
+                Self,
+            );
+            (__diesel_internal_rhs, __diesel_internal_on_clause)
+        }
+    }
+    impl<
+        'a,
+        QS,
+        ST,
+        DB,
+    > diesel::JoinTo<
+        diesel::internal::table_macro::BoxedCloneSelectStatement<
+            'a,
+            diesel::internal::table_macro::FromClause<QS>,
+            ST,
+            DB,
+        >,
+    > for view
+    where
+        diesel::internal::table_macro::BoxedCloneSelectStatement<
+            'a,
+            diesel::internal::table_macro::FromClause<QS>,
+            ST,
+            DB,
+        >: diesel::JoinTo<Self>,
+        QS: diesel::query_source::QuerySource,
+    {
+        type FromClause = diesel::internal::table_macro::BoxedCloneSelectStatement<
+            'a,
+            diesel::internal::table_macro::FromClause<QS>,
+            ST,
+            DB,
+        >;
+        type OnClause = <diesel::internal::table_macro::BoxedCloneSelectStatement<
+            'a,
+            diesel::internal::table_macro::FromClause<QS>,
+            ST,
+            DB,
+        > as diesel::JoinTo<Self>>::OnClause;
+        fn join_target(
+            __diesel_internal_rhs: diesel::internal::table_macro::BoxedCloneSelectStatement<
+                'a,
+                diesel::internal::table_macro::FromClause<QS>,
+                ST,
+                DB,
+            >,
+        ) -> (Self::FromClause, Self::OnClause) {
+            let (_, __diesel_internal_on_clause) = diesel::internal::table_macro::BoxedCloneSelectStatement::join_target(
                 Self,
             );
             (__diesel_internal_rhs, __diesel_internal_on_clause)

--- a/diesel_tests/tests/boxed_clone_queries.rs
+++ b/diesel_tests/tests/boxed_clone_queries.rs
@@ -1,0 +1,260 @@
+use super::schema::*;
+use diesel::expression::is_aggregate;
+use diesel::*;
+use std::sync::Arc;
+
+#[diesel_test_helper::test]
+fn boxed_clone_queries_can_be_executed() {
+    let connection = &mut connection_with_sean_and_tess_in_users_table();
+    insert_into(users::table)
+        .values(&NewUser::new("Jim", None))
+        .execute(connection)
+        .unwrap();
+    let query_which_fails_unless_all_segments_are_applied = users::table
+        .select(users::name)
+        .filter(users::name.ne("jim"))
+        .order(users::name.desc())
+        .limit(1)
+        .offset(1)
+        .into_boxed_clone();
+
+    let expected_data = vec!["Sean".to_string()];
+    let data = query_which_fails_unless_all_segments_are_applied.load(connection);
+    assert_eq!(Ok(expected_data), data);
+}
+
+#[diesel_test_helper::test]
+fn boxed_clone_queries_can_be_cloned() {
+    let connection = &mut connection_with_sean_and_tess_in_users_table();
+    let query = users::table
+        .select(users::name)
+        .order(users::name.desc())
+        .limit(1)
+        .offset(1)
+        .into_boxed_clone();
+    let cloned_query = query.clone();
+
+    let expected_data = vec!["Sean".to_string()];
+    let data = query.load(connection);
+    let other_data = cloned_query.load(connection);
+    assert_eq!(Ok(expected_data.clone()), data);
+    assert_eq!(Ok(expected_data), other_data);
+}
+
+#[diesel_test_helper::test]
+fn boxed_clone_queries_can_differ_conditionally() {
+    let connection = &mut connection_with_sean_and_tess_in_users_table();
+    insert_into(users::table)
+        .values(&NewUser::new("Jim", None))
+        .execute(connection)
+        .unwrap();
+
+    enum Query {
+        All,
+        Ordered,
+        One,
+    }
+
+    let source = |query| match query {
+        Query::All => users::table.order(users::name.desc()).into_boxed_clone(),
+        Query::Ordered => users::table.order(users::name.desc()).into_boxed_clone(),
+        Query::One => users::table
+            .filter(users::name.ne("jim"))
+            .order(users::name.desc())
+            .limit(1)
+            .offset(1)
+            .into_boxed_clone(),
+    };
+    let sean = find_user_by_name("Sean", connection);
+    let tess = find_user_by_name("Tess", connection);
+    let jim = find_user_by_name("Jim", connection);
+
+    let all = source(Query::All).load(connection);
+    let expected_data = vec![tess.clone(), sean.clone(), jim.clone()];
+    assert_eq!(Ok(expected_data), all);
+
+    let ordered = source(Query::Ordered).load(connection);
+    let expected_data = vec![tess, sean.clone(), jim];
+    assert_eq!(Ok(expected_data), ordered);
+
+    let one = source(Query::One).load(connection);
+    let expected_data = vec![sean];
+    assert_eq!(Ok(expected_data), one);
+}
+
+#[diesel_test_helper::test]
+fn boxed_clone_queries_implement_select_dsl() {
+    let connection = &mut connection_with_sean_and_tess_in_users_table();
+    let data = users::table
+        .into_boxed_clone()
+        .select(users::name)
+        .order(users::name)
+        .load::<String>(connection);
+    assert_eq!(Ok(vec!["Sean".into(), "Tess".into()]), data);
+}
+
+#[diesel_test_helper::test]
+fn boxed_clone_queries_implement_filter_dsl() {
+    let connection = &mut connection_with_sean_and_tess_in_users_table();
+    insert_into(users::table)
+        .values(&NewUser::new("Shane", None))
+        .execute(connection)
+        .unwrap();
+    let data = users::table
+        .into_boxed_clone()
+        .select(users::name)
+        .filter(users::name.ne("Sean"))
+        .filter(users::name.like("S%"))
+        .load(connection);
+    assert_eq!(Ok(vec![String::from("Shane")]), data);
+}
+
+#[diesel_test_helper::test]
+fn boxed_clone_queries_implement_limit_dsl() {
+    let connection = &mut connection_with_sean_and_tess_in_users_table();
+    let data = users::table
+        .into_boxed_clone()
+        .limit(1)
+        .order(users::id)
+        .load(connection);
+    let expected_data = vec![find_user_by_name("Sean", connection)];
+    assert_eq!(Ok(expected_data), data);
+}
+
+#[diesel_test_helper::test]
+fn boxed_clone_queries_implement_offset_dsl() {
+    let connection = &mut connection_with_sean_and_tess_in_users_table();
+    let data = users::table
+        .into_boxed_clone()
+        .limit(1)
+        .offset(1)
+        .order(users::id)
+        .load(connection);
+    let expected_data = vec![find_user_by_name("Tess", connection)];
+    assert_eq!(Ok(expected_data), data);
+}
+
+#[diesel_test_helper::test]
+fn boxed_clone_queries_implement_order_dsl() {
+    let connection = &mut connection_with_sean_and_tess_in_users_table();
+    let data = users::table
+        .into_boxed_clone()
+        .order(users::name.desc())
+        .load(connection);
+    let expected_data = vec![
+        find_user_by_name("Tess", connection),
+        find_user_by_name("Sean", connection),
+    ];
+    assert_eq!(Ok(expected_data), data);
+}
+
+#[diesel_test_helper::test]
+fn boxed_clone_queries_can_use_borrowed_data() {
+    let connection = &mut connection_with_sean_and_tess_in_users_table();
+    let s = String::from("Sean");
+    let data = users::table
+        .into_boxed_clone()
+        .filter(users::name.eq(&s))
+        .load(connection);
+    let expected_data = vec![find_user_by_name("Sean", connection)];
+    assert_eq!(Ok(expected_data), data);
+}
+
+#[diesel_test_helper::test]
+fn queries_with_borrowed_data_can_be_boxed() {
+    let connection = &mut connection_with_sean_and_tess_in_users_table();
+    let s = String::from("Tess");
+    let data = users::table
+        .filter(users::name.eq(&s))
+        .into_boxed_clone()
+        .load(connection);
+    let expected_data = vec![find_user_by_name("Tess", connection)];
+    assert_eq!(Ok(expected_data), data);
+}
+
+#[diesel_test_helper::test]
+fn boxed_clone_queries_implement_or_filter() {
+    let connection = &mut connection_with_sean_and_tess_in_users_table();
+    let data = users::table
+        .into_boxed_clone()
+        .filter(users::name.eq("Sean"))
+        .or_filter(users::name.eq("Tess"))
+        .order(users::name)
+        .load(connection);
+    let expected = vec![
+        find_user_by_name("Sean", connection),
+        find_user_by_name("Tess", connection),
+    ];
+    assert_eq!(Ok(expected), data);
+}
+
+#[diesel_test_helper::test]
+fn can_box_query_with_boxable_expression() {
+    let connection = &mut connection_with_sean_and_tess_in_users_table();
+
+    let expr: Arc<dyn BoxableExpression<users::table, _, SqlType = _> + Send + Sync> =
+        Arc::new(users::name.eq("Sean")) as _;
+
+    let data = users::table
+        .into_boxed_clone()
+        .filter(expr)
+        .load(connection);
+    let expected = vec![find_user_by_name("Sean", connection)];
+    assert_eq!(Ok(expected), data);
+
+    let expr: Arc<dyn BoxableExpression<users::table, _, SqlType = _> + Send + Sync> =
+        Arc::new(users::name.eq("Sean")) as _;
+
+    let data = users::table
+        .filter(expr)
+        .into_boxed_clone()
+        .load(connection);
+    let expected = vec![find_user_by_name("Sean", connection)];
+    assert_eq!(Ok(expected), data);
+}
+
+#[diesel_test_helper::test]
+fn can_box_query_having_with_boxable_expression() {
+    let connection = &mut connection_with_sean_and_tess_in_users_table();
+
+    let expr: Arc<
+        dyn BoxableExpression<
+                users::table,
+                crate::schema::TestBackend,
+                users::id,
+                is_aggregate::Yes,
+                SqlType = _,
+            > + Send
+            + Sync,
+    > = Arc::new(count(users::id).eq(1)) as _;
+
+    use diesel::dsl::count;
+
+    let data = users::table
+        .select(count(users::id))
+        .group_by(users::id)
+        .having(expr)
+        .load::<i64>(connection)
+        .expect("db error");
+    assert_eq!(data, [1, 1]);
+
+    let expr: Arc<
+        dyn BoxableExpression<
+                users::table,
+                crate::schema::TestBackend,
+                users::id,
+                is_aggregate::Yes,
+                SqlType = _,
+            > + Send
+            + Sync,
+    > = Arc::new(count(users::id).eq(1)) as _;
+
+    let data = users::table
+        .select(count(users::id))
+        .group_by(users::id)
+        .into_boxed_clone()
+        .having(expr)
+        .load::<i64>(connection)
+        .expect("db error");
+    assert_eq!(data, [1, 1]);
+}

--- a/diesel_tests/tests/lib.rs
+++ b/diesel_tests/tests/lib.rs
@@ -12,6 +12,7 @@ mod allow_tables_to_appear_in_same_query;
 #[cfg(not(feature = "sqlite"))]
 mod annotations;
 mod associations;
+mod boxed_clone_queries;
 mod boxed_queries;
 mod cast;
 mod collation;


### PR DESCRIPTION
Fixes #1698.

This *does* cause a performance regression, however. The medium complex query benchmarks only regressed by about 3%, although the trivial benchmarks regressed by up to 9%. I only benchmarked SQLite. I understand if you don't want to accept the PR on those grounds.

<details>
<summary>`cargo bench` output</summary>

```text
bench_trivial_query/diesel_boxed/1
                        time:   [1.0413 µs 1.0439 µs 1.0465 µs]
                        change: [+0.4103% +0.6891% +0.9773%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  1 (1.00%) high severe
bench_trivial_query/diesel_boxed/10
                        time:   [2.6271 µs 2.6325 µs 2.6380 µs]
                        change: [+4.5081% +4.7690% +5.0524%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
bench_trivial_query/diesel_boxed/100
                        time:   [19.502 µs 19.559 µs 19.614 µs]
                        change: [+5.3377% +6.0183% +6.6502%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 11 outliers among 100 measurements (11.00%)
  9 (9.00%) low severe
  1 (1.00%) low mild
  1 (1.00%) high severe
bench_trivial_query/diesel_boxed/1000
                        time:   [178.98 µs 180.80 µs 182.29 µs]
                        change: [+7.9179% +8.9442% +9.9805%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 15 outliers among 100 measurements (15.00%)
  4 (4.00%) low severe
  11 (11.00%) low mild
Benchmarking bench_trivial_query/diesel_boxed/10000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 9.1s, enable flat sampling, or reduce sample count to 50.
bench_trivial_query/diesel_boxed/10000
                        time:   [1.8016 ms 1.8054 ms 1.8093 ms]
                        change: [+8.0902% +8.3799% +8.6725%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) low mild
  1 (1.00%) high mild

bench_medium_complex_query/diesel_boxed/1
                        time:   [3.3209 µs 3.3253 µs 3.3298 µs]
                        change: [+0.2180% +0.4016% +0.5786%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe
bench_medium_complex_query/diesel_boxed/10
                        time:   [4.8303 µs 4.8422 µs 4.8549 µs]
                        change: [+1.0210% +1.3993% +1.7617%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
bench_medium_complex_query/diesel_boxed/100
                        time:   [21.032 µs 21.046 µs 21.060 µs]
                        change: [+3.1414% +3.3386% +3.5288%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe
bench_medium_complex_query/diesel_boxed/1000
                        time:   [176.88 µs 177.03 µs 177.18 µs]
                        change: [+2.9889% +3.3086% +3.5931%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
Benchmarking bench_medium_complex_query/diesel_boxed/10000: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 8.8s, enable flat sampling, or reduce sample count to 50.
bench_medium_complex_query/diesel_boxed/10000
                        time:   [1.7279 ms 1.7297 ms 1.7317 ms]
                        change: [+2.7740% +2.9275% +3.0777%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 9 outliers among 100 measurements (9.00%)
  7 (7.00%) high mild
  2 (2.00%) high severe

```

</details>

<details>
<summary>Benchmark system specs</summary>

- CPU: AMD Ryzen 5 5600 (12) @ 4.47 GHz
- RAM: 32GiB DDR4-2400
- Storage: Crucial P2 500GB

</details>

I've attached the criterion HTML reports in case you want to analyse them further: [criterion.tar.gz](https://github.com/user-attachments/files/30646750/criterion.tar.gz)

<!-- 
Please provide a short brief summary description of your change here. 
Also make sure that your code passes all tests and style checks. 
Checkout the `CONTRIBUTING.md` file in the root of the repository for running these checks locally.
It's also fine to use the CI setup for running these tests, but in this case please indicate that your PR 
is not ready for review yet by marking it as DRAFT until it is ready.

If you submit a notable change please ensure to include it into the CHANGELOG.md file in
the root of the repository.

Also make sure to follow the projects guide lines about the usage of LLM's and AI agents as outlined
in the CONTRIBUTING.md file in the root of the repository.
-->

- [x] I checked for similar changes and make sure to reference them
- [x] I included a changelog entry for relevant new features or changes
