### PR TITLE
Preserve output bind lengths across the post-truncation rebind in MySQL backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 * Tighten requirements for `SqliteConnection::deserialize_readonly_database` to closely match the upstream requirements
 * `diesel print-schema` now generates `joinable!` and `allow_tables_to_appear_in_same_query!` for PostgreSQL foreign keys across multiple configured schemas
 * Fixed `FromSql`/`ToSql` for `chrono::NaiveTime` on MySQL dropping the fractional-seconds component of `TIME` values, so a `TIME(N)` column now round-trips its microseconds like `DATETIME` / `TIMESTAMP` already did.
+* Fixed the MySQL backend returning empty strings for every variable-length column in the first row of a result set when diesel is linked against MariaDB Connector/C (whose `mysql_stmt_bind_result` zeroes the caller's length values at bind time, destroying the lengths of the row that was just fetched during diesel's post-truncation rebind)
 
 ### Changed
 

--- a/diesel/src/mysql/connection/bind.rs
+++ b/diesel/src/mysql/connection/bind.rs
@@ -88,7 +88,22 @@ impl OutputBinds {
             }
         }
 
-        unsafe { self.with_mysql_binds(|bind_ptr| stmt.bind_result(bind_ptr)) }
+        // MariaDB Connector/C's `mysql_stmt_bind_result` writes through the
+        // caller's `length` pointers at bind time: 0 for variable-length types,
+        // `pack_len` for fixed-size types (libmariadb/mariadb_stmt.c,
+        // mysql_stmt_bind_result). Oracle's libmysqlclient leaves them
+        // untouched, and MariaDB has acknowledged the write as incorrect and
+        // removed it on its master branch (CONC-821), but every Connector/C
+        // release to date still performs it. Since this rebind happens *after*
+        // the current row's data was fetched into the buffers, it zeroes the
+        // lengths we just populated and every variable-length value in the
+        // first row reads back empty. Preserve the lengths across the rebind.
+        let lengths: Vec<libc::c_ulong> = self.0.data.iter().map(|d| d.length).collect();
+        let result = unsafe { self.with_mysql_binds(|bind_ptr| stmt.bind_result(bind_ptr)) };
+        for (data, length) in self.0.data.iter_mut().zip(lengths) {
+            data.length = length;
+        }
+        result
     }
 
     pub(super) fn update_buffer_lengths(&mut self) {

--- a/diesel/src/mysql/connection/mod.rs
+++ b/diesel/src/mysql/connection/mod.rs
@@ -417,4 +417,47 @@ mod tests {
 
         assert_eq!(output, 1);
     }
+
+    #[diesel_test_helper::test]
+    fn first_row_of_a_result_set_deserializes_variable_length_values() {
+        // Regression test for the first row of every result set coming back
+        // with empty strings when diesel is linked against MariaDB
+        // Connector/C instead of Oracle's libmysqlclient.
+        //
+        // Diesel binds variable-length output columns with tiny buffers, so
+        // the first row of a result set is fetched as `MYSQL_DATA_TRUNCATED`
+        // and refetched column-by-column via `mysql_stmt_fetch_column`,
+        // after which the grown buffers are re-bound with
+        // `mysql_stmt_bind_result`. MariaDB's `mysql_stmt_bind_result`
+        // writes through the caller's `length` pointers at bind time
+        // (0 for variable-length types; acknowledged as incorrect and
+        // removed on MariaDB's master branch in CONC-821, but present in
+        // every released Connector/C), which used to zero the lengths of
+        // the row that had just been fetched — so every variable-length
+        // value in that row deserialized as "". Later rows reuse the grown
+        // buffers and were never affected. The second row here is longer
+        // than the first so it also exercises the buffer-regrow path.
+        #[derive(crate::deserialize::QueryableByName, PartialEq, Eq, Debug)]
+        struct Row {
+            #[diesel(sql_type = crate::sql_types::Text)]
+            s: String,
+        }
+
+        let connection = &mut connection();
+        let rows = crate::sql_query(
+            "SELECT 'alpha' AS s UNION ALL SELECT 'much-longer-second-row-value' ORDER BY s",
+        )
+        .load::<Row>(connection)
+        .unwrap();
+
+        assert_eq!(
+            rows,
+            vec![
+                Row { s: "alpha".into() },
+                Row {
+                    s: "much-longer-second-row-value".into()
+                },
+            ]
+        );
+    }
 }


### PR DESCRIPTION
I suddenly had 26 failing tests for one of my projects after upgrading my local version of the mariadb libs using Diesel+MySQL. The root cause appears to be MariaDB's `mysql_stmt_bind_result` zeroing `*length` at bind time, which destroys the lengths which were just fetched, resulting in empty strings being returned for the first result from my queries. In my research, I found https://jira.mariadb.org/projects/CONC/issues/CONC-821?filter=allopenissues which confirms this is a long-standing issue and was resolved ~3 weeks ago in their master branch.

Fixes #5091 

Note that the existing CI cannot exercise the breaking behavior, since it is only using `libmysqlclient-dev` on Ubuntu using Oracle's code, not the mariadb libraries.

While I understand the discussion about not wanting an interim fix for a MariaDB-specific breakage, the fix seems small and well-contained. Additionally, it would allow versions of Diesel with this fix in place to support several existing versions of the mariadb libs for users who are on slower-releasing distros with older versions of mariadb which don't already carry the fix.


- [x] I checked for similar changes and made sure to reference them
- [x] I included a changelog entry for relevant new features or changes

Disclaimer: AI was used to research this issue, identify the root-cause, and write the change (Fable model). I have run the relevant tests and included a test-case which failed on my local MariaDB libs before the change and was green afterward. All code has been reviewed and verified by a human.