### PR TITLE
add initial type mapping support for sqlite only

### DIFF
--- a/diesel_cli/src/config.rs
+++ b/diesel_cli/src/config.rs
@@ -521,6 +521,17 @@ pub struct PrintSchema {
     pub custom_enum_derives: Option<BTreeSet<String>>,
     #[serde(default)]
     pub generate_rust_enum_definitions: Option<bool>,
+    #[serde(default)]
+    pub type_map: Option<Vec<SchemaTypeMap>>,
+}
+
+#[derive(Default, Deserialize, Clone, Debug)]
+pub struct SchemaTypeMap {
+    pub database_typename: String,
+    pub schema_typename: String,
+    pub table_name: Option<String>,
+    pub schema_name: Option<String>,
+    pub column_name: Option<String>,
 }
 
 impl PrintSchema {

--- a/diesel_cli/src/infer_schema_internals/sqlite.rs
+++ b/diesel_cli/src/infer_schema_internals/sqlite.rs
@@ -367,6 +367,48 @@ pub fn get_primary_keys(
     Ok(collected)
 }
 
+pub fn map_column_type(
+    type_name: &str,
+    table: &TableName,
+    attr: &ColumnInformation,
+    config: &PrintSchema,
+) -> Option<ColumnType> {
+    let Some(type_mappings) = &config.type_map else {
+        return None;
+    };
+
+    let Some(type_map) = type_mappings.iter().find(|map| {
+        map.database_typename.to_lowercase() == type_name
+            && map
+                .table_name
+                .as_deref()
+                .is_none_or(|t| t == table.sql_name)
+            && map
+                .schema_name
+                .as_deref()
+                .is_none_or(|s| Some(s) == table.schema.as_deref())
+            && map
+                .column_name
+                .as_deref()
+                .is_none_or(|c| c == attr.column_name)
+    }) else {
+        return None;
+    };
+
+    let path = type_map.schema_typename.clone();
+    Some(ColumnType {
+        schema: None,
+        rust_name: path.clone(),
+        sql_name: path,
+        is_array: false,
+        is_nullable: attr.nullable,
+        is_unsigned: false,
+        record: None,
+        max_length: attr.max_length,
+        unmodified_type: attr.type_name.to_owned(),
+    })
+}
+
 #[tracing::instrument(skip(conn))]
 pub fn determine_column_type(
     conn: &mut SqliteConnection,
@@ -379,6 +421,10 @@ pub fn determine_column_type(
     let mut type_name = attr.type_name.to_lowercase();
     if type_name == "generated always" {
         type_name.clear();
+    }
+
+    if let Some(type_map) = map_column_type(&type_name, table, attr, config) {
+        return Ok(type_map);
     }
 
     let path = if is_bool(&type_name) {

--- a/diesel_cli/src/print_schema.rs
+++ b/diesel_cli/src/print_schema.rs
@@ -516,6 +516,7 @@ fn mysql_diesel_types() -> HashSet<&'static str> {
 fn sqlite_diesel_types() -> HashSet<&'static str> {
     let mut types = HashSet::new();
     common_diesel_types(&mut types);
+
     types
 }
 

--- a/diesel_cli/tests/print_schema.rs
+++ b/diesel_cli/tests/print_schema.rs
@@ -619,6 +619,60 @@ fn print_schema_rust_injection() {
     )
 }
 
+#[test]
+#[cfg(feature = "sqlite")]
+fn print_schema_type_mapping() {
+    test_print_schema_only_config("print_schema_type_mapping");
+}
+
+/// Runs `print-schema` driven purely by `diesel.toml`, with no CLI flags.
+///
+/// This is a self-contained variant of [`test_print_schema_config`]: it sets up
+/// its own insta `Settings` binding rather than relying on being called from
+/// within [`test_print_schema_with_options`]. Use it for options (such as
+/// `type_map`) that can only be configured through `diesel.toml`.
+#[track_caller]
+fn test_print_schema_only_config(test_name: &str) {
+    let test_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("print_schema")
+        .join(test_name);
+
+    let config = read_file(&test_path.join("diesel.toml"));
+    let schema = read_file(&backend_file_path(test_name, "schema.sql"));
+
+    let mut p = project(&format!("{}_config", test_name)).file("diesel.toml", &config);
+
+    let patch_file = backend_file_path(test_name, "schema.patch");
+    if patch_file.exists() {
+        let patch_contents = read_file(&patch_file);
+        p = p.file("schema.patch", &patch_contents);
+    }
+
+    let p = p.build();
+
+    p.command("setup").run();
+    p.create_migration("12345_create_schema", &schema, None, None);
+    let result = p.command("migration").arg("run").run();
+    assert!(result.is_success(), "Result was unsuccessful {:?}", result);
+
+    let mut setting = insta::Settings::new();
+    setting.set_snapshot_path(backend_file_path(test_name, ""));
+    setting.set_omit_expression(true);
+    setting.set_description(format!("Test: {test_name}"));
+    setting.set_prepend_module_to_snapshot(false);
+
+    setting.bind(|| {
+        let generated = p.file_contents("src/schema.rs").replace("\r\n", "\n");
+        insta::assert_snapshot!("expected", generated);
+
+        let result = p.command("print-schema").run();
+        assert!(result.is_success(), "Result was unsuccessful {:?}", result);
+        let result = result.stdout().replace("\r\n", "\n");
+        insta::assert_snapshot!("expected", result);
+    });
+}
+
 #[cfg(feature = "sqlite")]
 const BACKEND: &str = "sqlite";
 #[cfg(feature = "postgres")]

--- a/diesel_cli/tests/print_schema/print_schema_type_mapping/diesel.toml
+++ b/diesel_cli/tests/print_schema/print_schema_type_mapping/diesel.toml
@@ -1,0 +1,6 @@
+[print_schema]
+file = "src/schema.rs"
+
+[[print_schema.type_map]]
+database_typename = "real"
+schema_typename = "Double"

--- a/diesel_cli/tests/print_schema/print_schema_type_mapping/sqlite/schema.sql
+++ b/diesel_cli/tests/print_schema/print_schema_type_mapping/sqlite/schema.sql
@@ -1,0 +1,4 @@
+CREATE TABLE users (
+    id INTEGER NOT NULL PRIMARY KEY,
+    length REAL NOT NULL
+);


### PR DESCRIPTION
<!-- 
Please provide a short brief summary description of your change here. 
Also make sure that your code passes all tests and style checks. 
Checkout the `CONTRIBUTING.md` file in the root of the repository for running these checks locally.
It's also fine to use the CI setup for running these tests, but in this case please indicate that your PR 
is not ready for review yet by marking it as DRAFT until it is ready.

If you submit a notable change please ensure to include it into the CHANGELOG.md file in
the root of the repository.

Also make sure to follow the projects guide lines about the usage of LLM's and AI agents as outlined
in the CONTRIBUTING.md file in the root of the repository.
-->

- [x] I checked for similar changes and make sure to reference them
- [ ] I included a changelog entry for relevant new features or changes

This adds basic type mapping support to sqlite. This is an implementation of this proposal https://github.com/diesel-rs/diesel/discussions/4113#discussioncomment-10021444. The issue was referenced in these conversations https://github.com/diesel-rs/diesel/discussions/4192.

This only provides support for Sqlite as a starting point because, one I needed it, and two Sqlite is a lot more permissive with "types" so this would be a good starting point. Also wanted to gather feedback before making anymore broader changes to the other backends. This supports configuring output schema type for specific table, column, or schema or combination of them.

One major question I had was if it was worth it to add a CLI flag for this feature? Or if it is a requirement that there is a CLI flag for all configuration options. I opted to only have this work if using `diesel.toml` because it's easier to write the table of fields that way.