### PR TITLE
Add `SqliteConnection::wal_checkpoint`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 * Added `SqliteConnection::incremental_vacuum` to return freelist pages to the filesystem on a database in incremental `auto_vacuum` mode, accepting an optional schema name and an optional bound on how many pages to reclaim.
 * Added `SqliteConnection::vacuum` and `SqliteConnection::vacuum_into` to rebuild a database or write a vacuumed copy of it to a new file, each accepting an optional schema name to target an attached database, with the destination path passed as a bind parameter.
 * Added `BoxedCloneQuery` type. This is a boxed query that uses `Arc` to allow the query to be cloned.
+* Added `SqliteConnection::wal_checkpoint` to checkpoint the write-ahead log through the typed `WalCheckpointMode` enum, returning a `WalCheckpointOutcome` with the busy flag and frame counts, and accepting an optional schema name where `None` checkpoints every attached database.
 
 ### Fixed
 

--- a/diesel/src/sqlite/connection/hooks.rs
+++ b/diesel/src/sqlite/connection/hooks.rs
@@ -292,13 +292,14 @@ impl SqliteConnection {
     /// # use diesel::prelude::*;
     /// # use diesel::connection::SimpleConnection;
     /// # use diesel::sqlite::SqliteConnection;
+    /// # use diesel::sqlite::WalCheckpointMode;
     /// # let conn = &mut SqliteConnection::establish("test.db").unwrap();
     /// # conn.batch_execute("PRAGMA journal_mode = WAL;").unwrap();
     /// conn.on_wal(|conn, db_name, n_pages| {
     ///     println!("WAL for {db_name}: {n_pages} pages");
     ///     if n_pages > 1000 {
     ///         // The connection may be used here, e.g. to force a checkpoint.
-    ///         let _ = conn.batch_execute("PRAGMA wal_checkpoint(TRUNCATE);");
+    ///         let _ = conn.wal_checkpoint(None, WalCheckpointMode::Truncate);
     ///     }
     /// });
     /// ```

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -166,6 +166,7 @@ use core::num::NonZeroI64;
 /// # fn run_test() -> QueryResult<()> {
 /// #     use schema::users;
 /// use diesel::connection::SimpleConnection;
+/// use diesel::sqlite::WalCheckpointMode;
 /// let conn = &mut establish_connection();
 /// // see https://fractaledmind.github.io/2023/09/07/enhancing-rails-sqlite-fine-tuning/
 /// // sleep if the database is busy, this corresponds to up to 2 seconds sleeping time.
@@ -178,7 +179,7 @@ use core::num::NonZeroI64;
 /// // May affect readers if number is increased
 /// conn.batch_execute("PRAGMA wal_autocheckpoint = 1000;")?;
 /// // free some space by truncating possibly massive WAL files from the last run
-/// conn.batch_execute("PRAGMA wal_checkpoint(TRUNCATE);")?;
+/// conn.wal_checkpoint(None, WalCheckpointMode::Truncate)?;
 /// #   Ok(())
 /// # }
 /// ```
@@ -403,6 +404,49 @@ pub enum AutoVacuumMode {
     /// Freelist bookkeeping is kept, pages are reclaimed only when
     /// `incremental_vacuum` runs.
     Incremental = 2,
+}
+
+/// The mode of a [`wal_checkpoint`](SqliteConnection::wal_checkpoint) run,
+/// matching the modes of
+/// [`sqlite3_wal_checkpoint_v2`](https://www.sqlite.org/c3ref/wal_checkpoint_v2.html).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum WalCheckpointMode {
+    /// Checkpoint what is possible without waiting on readers or writers.
+    Passive,
+    /// Wait until there is no writer and every reader reads from the most
+    /// recent snapshot, then checkpoint every frame.
+    Full,
+    /// Like [`Full`](Self::Full), then wait until no reader uses the WAL, so
+    /// the next writer restarts the log.
+    Restart,
+    /// Like [`Restart`](Self::Restart), then truncate the WAL file to zero
+    /// bytes.
+    Truncate,
+    /// Report the WAL state without checkpointing anything.
+    ///
+    /// Requires SQLite 3.51.0 or later. Older versions do not know this
+    /// mode and silently run a [`Passive`](Self::Passive) checkpoint
+    /// instead.
+    Noop,
+}
+
+/// The result of a [`wal_checkpoint`](SqliteConnection::wal_checkpoint) run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct WalCheckpointOutcome {
+    /// Whether a busy reader or writer stopped the checkpoint early. Only
+    /// the blocking modes set it: [`Passive`](WalCheckpointMode::Passive)
+    /// reports `false` even when it left frames behind.
+    pub busy: bool,
+    /// Frames in the WAL after the checkpoint, `None` when the database is
+    /// not in WAL mode.
+    pub log_frames: Option<i64>,
+    /// Frames of the WAL moved into the database file, `None` when the
+    /// database is not in WAL mode. Counted within the current log, so a
+    /// [`Truncate`](WalCheckpointMode::Truncate) run reports `Some(0)`
+    /// because the log was emptied, not because nothing was moved.
+    pub checkpointed_frames: Option<i64>,
 }
 
 impl SqliteConnection {
@@ -1616,6 +1660,69 @@ impl SqliteConnection {
         .map(|_| ())
     }
 
+    /// Checkpoint the [write-ahead log](https://www.sqlite.org/wal.html),
+    /// moving committed frames from the WAL file into the database file.
+    ///
+    /// `schema` selects one attached database by name. Unlike the other
+    /// maintenance helpers, `None` does not mean `main`: SQLite defines the
+    /// unqualified pragma to checkpoint every attached database. With
+    /// `None` and several attached databases the C API leaves the frame
+    /// counts undefined.
+    ///
+    /// A checkpoint stopped early by a reader or writer on another
+    /// connection is not an error: it sets
+    /// [`busy`](WalCheckpointOutcome::busy). On a database that is not in
+    /// WAL mode the call succeeds with both frame counts `None`, so it is
+    /// safe to issue unconditionally. Inside a transaction on its own
+    /// connection it fails with `SQLITE_LOCKED`.
+    ///
+    /// The mode argument requires SQLite 3.7.6 or later,
+    /// [`Truncate`](WalCheckpointMode::Truncate) requires 3.8.8 or later,
+    /// and [`Noop`](WalCheckpointMode::Noop) requires 3.51.0 or later.
+    /// Older versions do not report an error and treat an unrecognized
+    /// mode as [`Passive`](WalCheckpointMode::Passive).
+    ///
+    /// ```rust
+    /// # include!("../../doctest_setup.rs");
+    /// #
+    /// # fn main() {
+    /// #     run_test().unwrap();
+    /// # }
+    /// #
+    /// # fn run_test() -> QueryResult<()> {
+    /// use diesel::connection::SimpleConnection;
+    /// use diesel::sqlite::WalCheckpointMode;
+    /// # let dir = tempfile::tempdir().unwrap();
+    /// # let path = dir.path().join("app.db");
+    /// let conn = &mut SqliteConnection::establish(path.to_str().unwrap()).unwrap();
+    /// conn.batch_execute("PRAGMA journal_mode = WAL")?;
+    /// conn.batch_execute("CREATE TABLE logs (line TEXT NOT NULL)")?;
+    ///
+    /// let outcome = conn.wal_checkpoint(None, WalCheckpointMode::Truncate)?;
+    /// assert!(!outcome.busy);
+    /// // The whole WAL was moved into the database file and the log truncated.
+    /// assert_eq!(outcome.log_frames, Some(0));
+    /// assert_eq!(outcome.checkpointed_frames, Some(0));
+    /// #     Ok(())
+    /// # }
+    /// ```
+    pub fn wal_checkpoint(
+        &mut self,
+        schema: Option<&str>,
+        mode: WalCheckpointMode,
+    ) -> QueryResult<WalCheckpointOutcome> {
+        use crate::query_dsl::RunQueryDsl;
+
+        let (busy, log_frames, checkpointed_frames) =
+            WalCheckpoint { schema, mode }.get_result::<(i32, i64, i64)>(self)?;
+        Ok(WalCheckpointOutcome {
+            busy: busy != 0,
+            // On a database not in WAL mode both counts come back as -1.
+            log_frames: (log_frames >= 0).then_some(log_frames),
+            checkpointed_frames: (checkpointed_frames >= 0).then_some(checkpointed_frames),
+        })
+    }
+
     fn register_diesel_sql_functions(&self) -> QueryResult<()> {
         use crate::sql_types::{Integer, Text};
 
@@ -1788,6 +1895,52 @@ impl QueryId for Vacuum<'_> {
 }
 
 impl RunQueryDslSupport for Vacuum<'_> {}
+
+// Like `Pragma`, no operand can be a bind parameter. Unlike `Pragma`, a
+// `None` schema stays unqualified on purpose: the unqualified pragma
+// checkpoints every attached database, while a qualified one targets a
+// single schema. The whole checkpoint runs on the first step of the
+// statement and yields exactly one row, so a prepared statement works here
+// (unlike `incremental_vacuum`).
+struct WalCheckpoint<'a> {
+    schema: Option<&'a str>,
+    mode: WalCheckpointMode,
+}
+
+impl QueryFragment<Sqlite> for WalCheckpoint<'_> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Sqlite>) -> QueryResult<()> {
+        out.push_sql("PRAGMA ");
+        if let Some(schema) = self.schema {
+            out.push_identifier(schema)?;
+            out.push_sql(".");
+        }
+        out.push_sql(match self.mode {
+            WalCheckpointMode::Passive => "wal_checkpoint(PASSIVE)",
+            WalCheckpointMode::Full => "wal_checkpoint(FULL)",
+            WalCheckpointMode::Restart => "wal_checkpoint(RESTART)",
+            WalCheckpointMode::Truncate => "wal_checkpoint(TRUNCATE)",
+            WalCheckpointMode::Noop => "wal_checkpoint(NOOP)",
+        });
+        Ok(())
+    }
+}
+
+// The schema name and mode are runtime data, so the rendered SQL is not determined by the type.
+impl QueryId for WalCheckpoint<'_> {
+    type QueryId = ();
+
+    const HAS_STATIC_QUERY_ID: bool = false;
+}
+
+impl Query for WalCheckpoint<'_> {
+    type SqlType = (
+        crate::sql_types::Integer,
+        crate::sql_types::BigInt,
+        crate::sql_types::BigInt,
+    );
+}
+
+impl RunQueryDslSupport for WalCheckpoint<'_> {}
 
 #[cfg(test)]
 mod tests {
@@ -4493,5 +4646,290 @@ mod tests {
             conn.page_count(Some("aux")).unwrap() < aux_before,
             "aux was rebuilt too, not main a second time"
         );
+    }
+
+    // WAL requires a real file.
+    #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+    fn wal_connection(path: &std::path::Path) -> SqliteConnection {
+        let mut conn = SqliteConnection::establish(path.to_str().unwrap()).unwrap();
+        conn.batch_execute("PRAGMA journal_mode = WAL").unwrap();
+        conn
+    }
+
+    #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+    #[diesel_test_helper::test]
+    fn wal_checkpoint_truncate_reports_an_emptied_wal() {
+        let dir = tempfile::tempdir().unwrap();
+        let conn = &mut wal_connection(&dir.path().join("wal.db"));
+        conn.batch_execute(PROBE_TABLE).unwrap();
+        insert_overflowing_row(conn);
+
+        let outcome = conn
+            .wal_checkpoint(None, WalCheckpointMode::Truncate)
+            .unwrap();
+
+        assert!(!outcome.busy);
+        assert_eq!(Some(0), outcome.log_frames, "the WAL file was truncated");
+        assert_eq!(Some(0), outcome.checkpointed_frames);
+    }
+
+    #[diesel_test_helper::test]
+    fn wal_checkpoint_outside_wal_mode_reports_no_frames() {
+        let conn = &mut connection();
+
+        let outcome = conn
+            .wal_checkpoint(None, WalCheckpointMode::Truncate)
+            .unwrap();
+
+        assert!(!outcome.busy);
+        assert_eq!(None, outcome.log_frames);
+        assert_eq!(None, outcome.checkpointed_frames);
+    }
+
+    #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+    #[diesel_test_helper::test]
+    fn wal_checkpoint_accepts_every_mode() {
+        let dir = tempfile::tempdir().unwrap();
+        let conn = &mut wal_connection(&dir.path().join("modes.db"));
+        conn.batch_execute(PROBE_TABLE).unwrap();
+
+        for (row, mode) in [
+            WalCheckpointMode::Passive,
+            WalCheckpointMode::Full,
+            WalCheckpointMode::Restart,
+            WalCheckpointMode::Truncate,
+            WalCheckpointMode::Noop,
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            // A fresh row per round gives every mode frames to move.
+            crate::insert_into(pragma_probe::table)
+                .values((
+                    pragma_probe::id.eq(i32::try_from(row).unwrap() + 1),
+                    pragma_probe::payload.eq("row"),
+                ))
+                .execute(conn)
+                .unwrap();
+
+            let outcome = conn.wal_checkpoint(None, mode).unwrap();
+            assert!(!outcome.busy, "{mode:?} had no competing readers");
+            assert!(
+                outcome.log_frames.is_some(),
+                "{mode:?} ran on a WAL database"
+            );
+            assert!(outcome.checkpointed_frames.is_some());
+            assert!(
+                outcome.checkpointed_frames <= outcome.log_frames,
+                "{mode:?}: checkpointed frames cannot exceed the log size"
+            );
+        }
+    }
+
+    #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+    #[diesel_test_helper::test]
+    fn wal_checkpoint_noop_reports_state_without_moving_frames() {
+        let dir = tempfile::tempdir().unwrap();
+        let conn = &mut wal_connection(&dir.path().join("noop.db"));
+
+        // NOOP exists since SQLite 3.51.0, older versions run PASSIVE instead.
+        let version = crate::select(sql::<Text>("sqlite_version()"))
+            .get_result::<String>(conn)
+            .unwrap();
+        let mut parts = version.split('.').map(|part| part.parse::<u32>().unwrap());
+        if (parts.next().unwrap(), parts.next().unwrap()) < (3, 51) {
+            return;
+        }
+
+        conn.batch_execute(PROBE_TABLE).unwrap();
+        conn.wal_checkpoint(None, WalCheckpointMode::Truncate)
+            .unwrap();
+        crate::insert_into(pragma_probe::table)
+            .values((pragma_probe::id.eq(1), pragma_probe::payload.eq("noop")))
+            .execute(conn)
+            .unwrap();
+
+        let first = conn.wal_checkpoint(None, WalCheckpointMode::Noop).unwrap();
+        let second = conn.wal_checkpoint(None, WalCheckpointMode::Noop).unwrap();
+
+        assert!(!first.busy, "NOOP never blocks");
+        assert!(first.log_frames > Some(0), "the insert sits in the WAL");
+        assert_eq!(Some(0), first.checkpointed_frames, "nothing was moved");
+        assert_eq!(first, second, "a second NOOP reports the same state");
+    }
+
+    #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+    #[diesel_test_helper::test]
+    fn wal_checkpoint_reports_busy_while_a_reader_holds_an_old_snapshot() {
+        use crate::connection::Connection;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("busy.db");
+        let writer = &mut wal_connection(&path);
+        writer.batch_execute(PROBE_TABLE).unwrap();
+        insert_overflowing_row(writer);
+
+        let reader = &mut SqliteConnection::establish(path.to_str().unwrap()).unwrap();
+        reader
+            .transaction::<_, crate::result::Error, _>(|reader| {
+                // Take the read snapshot, BEGIN alone defers it to the first read.
+                let _ = pragma_probe::table.count().get_result::<i64>(reader)?;
+
+                // Grow the WAL past the reader's snapshot, so a blocking
+                // checkpoint cannot complete.
+                crate::insert_into(pragma_probe::table)
+                    .values((pragma_probe::id.eq(2), pragma_probe::payload.eq("late")))
+                    .execute(writer)?;
+
+                // Passive is never reported busy, it checkpoints up to the
+                // reader's snapshot and leaves the rest.
+                let outcome = writer.wal_checkpoint(None, WalCheckpointMode::Passive)?;
+                assert!(!outcome.busy, "PASSIVE never reports busy");
+                assert!(
+                    outcome.checkpointed_frames < outcome.log_frames,
+                    "the frames past the reader's snapshot stay in the WAL"
+                );
+
+                for mode in [
+                    WalCheckpointMode::Full,
+                    WalCheckpointMode::Restart,
+                    WalCheckpointMode::Truncate,
+                ] {
+                    let outcome = writer.wal_checkpoint(None, mode)?;
+                    assert!(outcome.busy, "the open reader blocks a {mode:?} checkpoint");
+                }
+                Ok(())
+            })
+            .unwrap();
+
+        let outcome = writer
+            .wal_checkpoint(None, WalCheckpointMode::Truncate)
+            .unwrap();
+        assert!(
+            !outcome.busy,
+            "the checkpoint completes once the reader is done"
+        );
+        assert_eq!(Some(0), outcome.log_frames);
+    }
+
+    #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+    #[diesel_test_helper::test]
+    fn wal_checkpoint_targets_the_named_attached_database() {
+        let dir = tempfile::tempdir().unwrap();
+        let conn = &mut connection();
+        conn.attach_database(dir.path().join("aux.db").to_str().unwrap(), "aux")
+            .unwrap();
+        conn.batch_execute("PRAGMA aux.journal_mode = WAL").unwrap();
+        conn.batch_execute(AUX_PROBE_TABLE).unwrap();
+        crate::insert_into(aux_pragma_probe::table)
+            .values((
+                aux_pragma_probe::id.eq(1),
+                aux_pragma_probe::payload.eq("row"),
+            ))
+            .execute(conn)
+            .unwrap();
+
+        let outcome = conn
+            .wal_checkpoint(Some("aux"), WalCheckpointMode::Truncate)
+            .unwrap();
+        assert!(!outcome.busy);
+        assert_eq!(
+            Some(0),
+            outcome.log_frames,
+            "the attached database was checkpointed"
+        );
+
+        // `main` is not in WAL mode, so a checkpoint naming it reports no frames.
+        let outcome = conn
+            .wal_checkpoint(Some("main"), WalCheckpointMode::Truncate)
+            .unwrap();
+        assert_eq!(None, outcome.log_frames);
+    }
+
+    #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+    #[diesel_test_helper::test]
+    fn wal_checkpoint_unqualified_covers_every_attached_database() {
+        let dir = tempfile::tempdir().unwrap();
+        let conn = &mut wal_connection(&dir.path().join("main.db"));
+        conn.batch_execute(PROBE_TABLE).unwrap();
+        insert_overflowing_row(conn);
+        conn.attach_database(dir.path().join("aux.db").to_str().unwrap(), "aux")
+            .unwrap();
+        conn.batch_execute("PRAGMA aux.journal_mode = WAL").unwrap();
+        conn.batch_execute(AUX_PROBE_TABLE).unwrap();
+        crate::insert_into(aux_pragma_probe::table)
+            .values((
+                aux_pragma_probe::id.eq(1),
+                aux_pragma_probe::payload.eq("row"),
+            ))
+            .execute(conn)
+            .unwrap();
+
+        conn.wal_checkpoint(None, WalCheckpointMode::Truncate)
+            .unwrap();
+
+        // Both WALs are empty afterwards, which a qualified passive
+        // checkpoint reports without moving anything.
+        let main_after = conn
+            .wal_checkpoint(Some("main"), WalCheckpointMode::Passive)
+            .unwrap();
+        assert_eq!(Some(0), main_after.log_frames, "main was checkpointed");
+        let aux_after = conn
+            .wal_checkpoint(Some("aux"), WalCheckpointMode::Passive)
+            .unwrap();
+        assert_eq!(Some(0), aux_after.log_frames, "aux was checkpointed too");
+    }
+
+    #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+    #[diesel_test_helper::test]
+    fn wal_checkpoint_escapes_a_double_quote_in_the_schema_name() {
+        // An unquoted identifier would be a syntax error, and the wrong quoting
+        // would address a different database.
+        let dir = tempfile::tempdir().unwrap();
+        let conn = &mut connection();
+        let schema = r#"we"ird"#;
+        let quoted = schema.replace('"', "\"\"");
+        conn.attach_database(dir.path().join("weird.db").to_str().unwrap(), schema)
+            .unwrap();
+        conn.batch_execute(&alloc::format!(r#"PRAGMA "{quoted}".journal_mode = WAL"#))
+            .unwrap();
+        conn.batch_execute(&alloc::format!(
+            r#"CREATE TABLE "{quoted}".t (id INTEGER PRIMARY KEY)"#
+        ))
+        .unwrap();
+
+        let outcome = conn
+            .wal_checkpoint(Some(schema), WalCheckpointMode::Truncate)
+            .unwrap();
+        assert_eq!(Some(0), outcome.log_frames, "the quoted schema was reached");
+    }
+
+    #[diesel_test_helper::test]
+    fn wal_checkpoint_of_an_unknown_schema_is_an_error() {
+        let conn = &mut connection();
+
+        assert!(
+            conn.wal_checkpoint(Some("nope"), WalCheckpointMode::Passive)
+                .is_err()
+        );
+    }
+
+    #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+    #[diesel_test_helper::test]
+    fn wal_checkpoint_inside_a_transaction_is_an_error() {
+        use crate::connection::Connection;
+
+        let dir = tempfile::tempdir().unwrap();
+        let conn = &mut wal_connection(&dir.path().join("txn.db"));
+        conn.batch_execute(PROBE_TABLE).unwrap();
+
+        let result: QueryResult<WalCheckpointOutcome> = conn.transaction(|conn| {
+            crate::insert_into(pragma_probe::table)
+                .values((pragma_probe::id.eq(1), pragma_probe::payload.eq("txn")))
+                .execute(conn)?;
+            conn.wal_checkpoint(None, WalCheckpointMode::Truncate)
+        });
+
+        assert!(result.is_err(), "SQLite reports SQLITE_LOCKED");
     }
 }

--- a/diesel/src/sqlite/mod.rs
+++ b/diesel/src/sqlite/mod.rs
@@ -29,6 +29,8 @@ pub use self::connection::SqliteLimit;
 pub use self::connection::SqliteTraceEvent;
 pub use self::connection::SqliteTraceFlags;
 pub use self::connection::SqliteValue;
+pub use self::connection::WalCheckpointMode;
+pub use self::connection::WalCheckpointOutcome;
 pub use self::connection::authorizer;
 pub use self::connection::sqlite_blob::SqliteReadOnlyBlob;
 pub use self::connection::{AuthorizerContext, AuthorizerDecision};


### PR DESCRIPTION
Diesel's own SQLite examples run WAL checkpoints as strings, which throws away the pragma's result, i.e. whether a busy reader blocked the checkpoint and how many log frames were moved back into the database file. Those two values are the difference between a WAL that stays bounded and one that silently grows because a long-lived reader pins it, and reading them today needs a hand-rolled `sql_query` row type.

This adds `SqliteConnection::wal_checkpoint(schema, mode)` with a `WalCheckpointMode` enum and a `WalCheckpointOutcome` result. Frame counts come back as `None` on a database not in WAL mode (SQLite reports `-1` there), so the call is safe to issue unconditionally.

A `None` schema **does not** fall back to main, because SQLite defines the unqualified pragma to checkpoint every attached database.

I went for `PRAGMA` instead of `sqlite3_wal_checkpoint_v2`, I could not find any reason to go for either option in particular so I just picked the one I have been using most often for these use cases, but if you have any particular opinion on the matter let me know.

In SQLite 3.51.0 (November 2025) added a fifth checkpoint mode, `NOOP`, which reports the WAL state without checkpointing anything. It seemed way too recent, so I left it out for now.