### PR TITLE
Fix clippy lint for `#[derive(QueryableByName)]`

### DIFF
--- a/diesel_derives/build.rs
+++ b/diesel_derives/build.rs
@@ -297,9 +297,16 @@ fn main() {
         ),
         (
             "queryable_by_name",
-            vec![Example::new(
-                "diesel_derives__tests__queryable_by_name_1.snap",
-            )],
+            vec![
+                Example::with_heading(
+                    "diesel_derives__tests__queryable_by_name_1.snap",
+                    "Without attributes",
+                ),
+                Example::with_heading(
+                    "diesel_derives__tests__queryable_by_name_1.snap",
+                    "With `#[diesel(sql_type)]` on field",
+                ),
+            ],
         ),
         (
             "query_id",

--- a/diesel_derives/src/queryable_by_name.rs
+++ b/diesel_derives/src/queryable_by_name.rs
@@ -1,7 +1,7 @@
 use diesel_attribute_parser::AttributeSpanWrapper;
 use diesel_attribute_parser::CheckForBackend;
 use proc_macro2::{Span, TokenStream};
-use quote::quote;
+use quote::{quote, quote_spanned};
 use syn::spanned::Spanned;
 use syn::{DeriveInput, Ident, LitStr, Result, Type, parse_quote, parse_quote_spanned};
 
@@ -14,7 +14,6 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
 
     let struct_name = &item.ident;
     let fields = &model.fields().iter().map(get_ident).collect::<Vec<_>>();
-    let field_names = model.fields().iter().map(|f| &f.name);
 
     let initial_field_expr = model
         .fields()
@@ -88,6 +87,14 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
     };
 
     let (impl_generics, _, where_clause) = generics.split_for_impl();
+    let field_constructor = model.fields().iter().zip(fields).map(|(f, f_n)| {
+        let s = f.span;
+        let field_name = &f.name;
+        match field_name {
+            FieldName::Named(_) => quote_spanned! {s=> #f_n},
+            FieldName::Unnamed(_) => quote_spanned! {s=> #field_name: #f_n},
+        }
+    });
 
     Ok(wrap_in_dummy_mod(quote! {
 
@@ -101,9 +108,7 @@ pub fn derive(item: DeriveInput) -> Result<TokenStream> {
                     let mut #fields = #initial_field_expr;
                 )*
                 diesel::deserialize::Result::Ok(Self {
-                    #(
-                        #field_names: #fields,
-                    )*
+                    #(#field_constructor,)*
                 })
             }
         }

--- a/diesel_derives/src/tests/queryable_by_name.rs
+++ b/diesel_derives/src/tests/queryable_by_name.rs
@@ -18,3 +18,20 @@ pub(crate) fn queryable_by_name_1() {
         "queryable_by_name_1",
     );
 }
+
+#[test]
+pub(crate) fn queryable_by_name_2() {
+    let input = quote::quote! {
+        pub struct UserCount {
+            #[diesel(sql_type = diesel::sql_types::BigInt)]
+            pub value: i16,
+        }
+    };
+
+    expand_with(
+        &crate::derive_queryable_by_name_inner as &dyn Fn(_) -> _,
+        input,
+        derive(syn::parse_quote!(#[derive(QueryableByName)])),
+        "queryable_by_name_2",
+    );
+}

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__queryable_by_name_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__queryable_by_name_1.snap
@@ -32,7 +32,7 @@ const _: () = {
                 >(row, "name")?;
                 <String as ::core::convert::Into<String>>::into(field)
             };
-            diesel::deserialize::Result::Ok(Self { id: id, name: name })
+            diesel::deserialize::Result::Ok(Self { id, name })
         }
     }
 };

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__queryable_by_name_2.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__queryable_by_name_2.snap
@@ -1,0 +1,27 @@
+---
+source: diesel_derives/src/tests/mod.rs
+expression: out
+info:
+  input: "#[derive(QueryableByName)]\npub struct UserCount {\n    #[diesel(sql_type = diesel::sql_types::BigInt)]\n    pub value: i16,\n}\n"
+---
+const _: () = {
+    use diesel;
+    impl<__DB: diesel::backend::Backend> diesel::deserialize::QueryableByName<__DB>
+    for UserCount
+    where
+        i16: diesel::deserialize::FromSql<diesel::sql_types::BigInt, __DB>,
+    {
+        fn build<'__a>(
+            row: &impl diesel::row::NamedRow<'__a, __DB>,
+        ) -> diesel::deserialize::Result<Self> {
+            let mut value = {
+                let field = diesel::row::NamedRow::get::<
+                    diesel::sql_types::BigInt,
+                    i16,
+                >(row, "value")?;
+                <i16 as ::core::convert::Into<i16>>::into(field)
+            };
+            diesel::deserialize::Result::Ok(Self { value })
+        }
+    }
+};


### PR DESCRIPTION
this commit fixes a new nightly clippy lint against the code generated by `#[derive(QueryableByName)]`. We did generate the old `field: field` struct construction there for longer than the short hand syntax exists. It seems like clippy now started to lint against that, so we should stop with that. This PR just checks if that's the case and emits the shorthand syntax instead. 
I also added the example out of the issue as expanded snapshot test.

Fix #5152

<!-- 
Please provide a short brief summary description of your change here. 
Also make sure that your code passes all tests and style checks. 
Checkout the `CONTRIBUTING.md` file in the root of the repository for running these checks locally.
It's also fine to use the CI setup for running these tests, but in this case please indicate that your PR 
is not ready for review yet by marking it as DRAFT until it is ready.

If you submit a notable change please ensure to include it into the CHANGELOG.md file in
the root of the repository.

Also make sure to follow the projects guide lines about the usage of LLM's and AI agents as outlined
in the CONTRIBUTING.md file in the root of the repository.
-->

- [x] I checked for similar changes and make sure to reference them
- [x] I included a changelog entry for relevant new features or changes
