### PR TITLE
Add lockfile auto-delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 * The minimal supported Rust version is now 1.88.0
 * Add support for no-std environments using the SQLite backend
 * Improved documentation and added examples for `filter_target` on `IncompleteOnConflict`
+* .diesel_lock_ file now auto deletes after use
 
 ## [2.3.12] 2026-08-07
 

--- a/diesel_cli/src/migrations/lock_file.rs
+++ b/diesel_cli/src/migrations/lock_file.rs
@@ -1,6 +1,5 @@
 use std::{
     fs::{File, remove_file},
-    os::fd::AsFd,
     path::PathBuf,
 };
 
@@ -10,9 +9,17 @@ pub struct LockFile {
     pub file: File,
 }
 
-impl AsFd for LockFile {
-    fn as_fd(&self) -> std::os::unix::prelude::BorrowedFd<'_> {
+#[cfg(unix)]
+impl std::os::fd::AsFd for LockFile {
+    fn as_fd(&self) -> std::os::fd::BorrowedFd<'_> {
         self.file.as_fd()
+    }
+}
+
+#[cfg(windows)]
+impl std::os::windows::io::AsHandle for LockFile {
+    fn as_handle(&self) -> std::os::windows::io::BorrowedHandle<'_> {
+        self.file.as_handle()
     }
 }
 

--- a/diesel_cli/src/migrations/lock_file.rs
+++ b/diesel_cli/src/migrations/lock_file.rs
@@ -1,5 +1,5 @@
 use std::{
-    fs::{remove_file, File},
+    fs::{File, remove_file},
     os::fd::AsFd,
     path::PathBuf,
 };

--- a/diesel_cli/src/migrations/lock_file.rs
+++ b/diesel_cli/src/migrations/lock_file.rs
@@ -1,0 +1,24 @@
+use std::{
+    fs::{remove_file, File},
+    os::fd::AsFd,
+    path::PathBuf,
+};
+
+/// Wrapper around a file and its path, deletes the file on drop
+pub struct LockFile {
+    pub path: PathBuf,
+    pub file: File,
+}
+
+impl AsFd for LockFile {
+    fn as_fd(&self) -> std::os::unix::prelude::BorrowedFd<'_> {
+        self.file.as_fd()
+    }
+}
+
+impl Drop for LockFile {
+    fn drop(&mut self) {
+        // Ignore the error, best not to panic here.
+        let _ = remove_file(&self.path);
+    }
+}

--- a/diesel_cli/src/migrations/mod.rs
+++ b/diesel_cli/src/migrations/mod.rs
@@ -1,3 +1,4 @@
+use crate::migrations::lock_file::LockFile;
 use crate::print_schema::PrintSchemaArgs;
 use chrono::Utc;
 use clap::{ArgAction, Args, Subcommand, ValueEnum};
@@ -18,6 +19,7 @@ use crate::database::InferConnection;
 use crate::{config::Config, regenerate_schema_if_file_specified};
 
 pub mod diff_schema;
+mod lock_file;
 
 #[derive(Debug, Args)]
 pub struct MigrationArgs {
@@ -358,13 +360,16 @@ fn conn_and_migration_dir(
 /// A lock can be acquired on this file to make sure we don't have multiple instances of diesel
 /// doing migration work
 /// See [run_migration_command]::generate for an example
-fn migration_folder_lock(dir: PathBuf) -> Result<File, crate::errors::Error> {
+fn migration_folder_lock(dir: PathBuf) -> Result<LockFile, crate::errors::Error> {
     let path = dir.join(".diesel_lock");
     match File::create_new(&path) {
-        Ok(file) => Ok(file),
+        Ok(file) => Ok(LockFile { path, file }),
         Err(err) => {
             if matches!(err.kind(), io::ErrorKind::AlreadyExists) {
-                File::open(&path).map_err(|err| crate::errors::Error::IoError(err, Some(path)))
+                let file = File::open(&path)
+	                .map_err(|err| crate::errors::Error::IoError(err, Some(path.clone())))?;
+
+                Ok(LockFile { path, file })
             } else {
                 Err(crate::errors::Error::IoError(err, Some(path)))
             }

--- a/diesel_cli/src/migrations/mod.rs
+++ b/diesel_cli/src/migrations/mod.rs
@@ -367,7 +367,7 @@ fn migration_folder_lock(dir: PathBuf) -> Result<LockFile, crate::errors::Error>
         Err(err) => {
             if matches!(err.kind(), io::ErrorKind::AlreadyExists) {
                 let file = File::open(&path)
-	                .map_err(|err| crate::errors::Error::IoError(err, Some(path.clone())))?;
+                    .map_err(|err| crate::errors::Error::IoError(err, Some(path.clone())))?;
 
                 Ok(LockFile { path, file })
             } else {


### PR DESCRIPTION
From #4800

Auto delete `.diesel_lock` file via a `LockFile` wrapper with a `Drop` impl.

- [x] I checked for similar changes and make sure to reference them
- [ ] I included a changelog entry for relevant new features or changes
