### PR TITLE
Adjust interactions between `DISTINCT ON` and `ORDER BY` clauses

### DIFF
--- a/diesel/src/query_builder/select_statement/dsl_impls.rs
+++ b/diesel/src/query_builder/select_statement/dsl_impls.rs
@@ -355,6 +355,7 @@ where
     S::Selection: ValidGrouping<()>,
     <S::Selection as ValidGrouping<()>>::IsAggregate:
         MixedAggregates<<Expr as ValidGrouping<()>>::IsAggregate>,
+    OrderClause<(O, Expr)>: ValidOrderingForDistinct<D>,
 {
     type Output = SelectStatement<
         FromClause<F>,
@@ -393,6 +394,7 @@ where
     SelectStatement<FromClause<F>, S, D, W, OrderClause<(O, Expr)>, LOf, GroupByClause<GB>, H, LC>:
         SelectQuery<SqlType = ST>,
     (O, Expr): ValidGrouping<GB>,
+    OrderClause<(O, Expr)>: ValidOrderingForDistinct<D>,
 {
     type Output = SelectStatement<
         FromClause<F>,

--- a/diesel/src/query_dsl/mod.rs
+++ b/diesel/src/query_dsl/mod.rs
@@ -128,6 +128,15 @@ pub trait QueryDsl: Sized {
 
     /// Adds the `DISTINCT ON` clause to a query.
     ///
+    /// Diesel performs compile time checks to verify that your `DISTINCT ON`
+    /// clause is compatible to any `ORDER BY` clause used by your query. It
+    /// requires that the first elements for both clauses are the same up to
+    /// the length of the shorter list.
+    /// By default this check allows only up to 5 columns in your `DISTINCT ON`
+    /// or `ORDER BY` clause. You can side step this limitation by wrapping
+    /// your columns same shaped tuples up to the size of 5 elements.
+    ///
+    ///
     /// # Example
     ///
     /// ```rust
@@ -164,6 +173,9 @@ pub trait QueryDsl: Sized {
     ///     .execute(connection)
     ///     .unwrap();
     /// let all_animals = animals.select((species, name, legs)).load(connection);
+    ///
+    /// // requires that `distinct_on` and `order_by` both start with the
+    /// // same column
     /// let distinct_animals = animals
     ///     .select((species, name, legs))
     ///     .order_by((species, legs))
@@ -773,6 +785,14 @@ pub trait QueryDsl: Sized {
     /// To construct an order clause of an unknown number of columns,
     /// see [`QueryDsl::then_order_by`](QueryDsl::then_order_by())
     ///
+    /// If you combine a `ORDER BY` clause with a [`DISTINCT ON`](QueryDsl::distinct_on())
+    /// clause you need to make sure that the columns used in both clauses are
+    /// the same up to the number of elements in the shorter of both clauses.
+    /// Diesel imposes a limit of 5 columns for this check. If you need to
+    /// have more order by expressions make sure to use `.order_by`
+    /// for the columns used by the `DISTINCT ON` clause and add additional
+    /// columns via  [`QueryDsl::then_order_by`](QueryDsl::then_order_by())
+    ///
     /// # Examples
     ///
     /// ```rust
@@ -784,6 +804,7 @@ pub trait QueryDsl: Sized {
     /// #
     /// # fn run_test() -> QueryResult<()> {
     /// #     use schema::users::dsl::*;
+    /// #     use schema::{comments, posts};
     /// #     let connection = &mut establish_connection();
     /// #     diesel::sql_query("DELETE FROM users").execute(connection)?;
     /// diesel::insert_into(users)
@@ -811,6 +832,23 @@ pub trait QueryDsl: Sized {
     ///     (String::from("Steve"), 4),
     /// ];
     /// assert_eq!(expected_data, data);
+    ///
+    /// # #[cfg(feature = "postgres")]
+    /// let data = users
+    ///     .inner_join(posts::table.inner_join(comments::table.on(comments::post_id.eq(posts::id))))
+    /// #    .select((name, id))
+    ///     .distinct_on(id)
+    ///     .order_by(id)
+    ///     .then_order_by((
+    ///         posts::id,
+    ///         posts::user_id,
+    ///         posts::title,
+    ///         comments::id,
+    ///         comments::body,
+    ///         comments::post_id,
+    ///     ))
+    ///     .load(connection)?;
+    /// # let _: Vec<(String, i32)> = data;
     /// #    Ok(())
     /// # }
     /// ```
@@ -838,7 +876,6 @@ pub trait QueryDsl: Sized {
     /// `.order_by(foo).order_by(bar)` is equivalent to `.order_by(bar)`.
     /// In contrast,
     /// `.order_by(foo).then_order_by(bar)` is equivalent to `.order((foo, bar))`.
-    /// This method is only present on boxed queries.
     ///
     /// # Examples
     ///

--- a/diesel_compile_tests/tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.stderr
+++ b/diesel_compile_tests/tests/fail/cannot_mix_aggregate_and_non_aggregate_in_order_by.stderr
@@ -587,18 +587,18 @@ LL | |     for SelectStatement<FromClause<F>, S, D, W, OrderClause<O>, LOf, NoGr
 LL | | where
 LL | |     F: QuerySource,
 ...   |
-LL | |     <S::Selection as ValidGrouping<()>>::IsAggregate:
 LL | |         MixedAggregates<<Expr as ValidGrouping<()>>::IsAggregate>,
-    | |__________________________________________________________________^ `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
+LL | |     OrderClause<(O, Expr)>: ValidOrderingForDistinct<D>,
+    | |________________________________________________________^ `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
 ...
 LL | / impl<ST, F, S, D, W, O, LOf, GB, H, LC, Expr> ThenOrderDsl<Expr>
 LL | |     for SelectStatement<FromClause<F>, S, D, W, OrderClause<O>, LOf, GroupByClause<GB>, H...
 LL | | where
 LL | |     F: QuerySource,
 ...   |
-LL | |         SelectQuery<SqlType = ST>,
 LL | |     (O, Expr): ValidGrouping<GB>,
-    | |_________________________________^ `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
+LL | |     OrderClause<(O, Expr)>: ValidOrderingForDistinct<D>,
+    | |________________________________________________________^ `SelectStatement<..., ..., ..., ..., ..., ..., ..., ..., ...>`
 ...
 LL | / impl<F, S, D, W, LOf, G, LC, Expr> ThenOrderDsl<Expr>
 LL | |     for SelectStatement<F, S, D, W, NoOrderClause, LOf, G, LC>

--- a/diesel_compile_tests/tests/fail/distinct_on_requires_matching_order_clause.rs
+++ b/diesel_compile_tests/tests/fail/distinct_on_requires_matching_order_clause.rs
@@ -10,6 +10,18 @@ table! {
     }
 }
 
+table! {
+    posts {
+        id -> Integer,
+        title -> Text,
+        user_id -> Integer,
+        body -> Text,
+    }
+}
+
+allow_tables_to_appear_in_same_query!(users, posts);
+joinable!(posts -> users(user_id));
+
 fn main() {
     // verify that we could use distinct on without order clause
     let _ = users::table.distinct_on(users::name);
@@ -185,4 +197,81 @@ fn main() {
         .order_by(users::id)
         //~^ ERROR: invalid order of elements in your `DISTINCT ON` clause in relation to your `ORDER BY` clause
         .into_boxed();
+
+    // verify that we cannot use `then_order_by` to
+    // add a not matching element later
+    // verify that we could use multiple columns for both order by and distinct on and distinct on has more columns than order by
+    //
+    // that works
+    let _ = users::table
+        .order_by(users::name)
+        .distinct_on((users::name, users::id));
+    // this should fail
+    let _ = users::table
+        .order_by(users::name)
+        .distinct_on((users::name, users::id))
+        .then_order_by(users::hair_color);
+    //~^ ERROR: invalid order of elements in your `DISTINCT ON` clause in relation to your `ORDER BY` clause
+
+    // using joins works, also with more than 5 columns
+    users::table.inner_join(posts::table).order_by((
+        users::id,
+        posts::id,
+        users::name,
+        posts::title,
+        users::hair_color,
+        posts::body,
+    ));
+    // the distinct check continues to work
+    users::table
+        .inner_join(posts::table)
+        .distinct_on(users::id)
+        .order_by(posts::id);
+    //~^ ERROR: invalid order of elements in your `DISTINCT ON` clause in relation to your `ORDER BY` clause
+
+    // we reject ordering by more than 5 columns
+    // (If we change the number, it's fine to update this example)
+    users::table
+        .inner_join(posts::table)
+        .distinct_on(users::id)
+        .order_by((
+            //~^ ERROR: invalid order of elements in your `DISTINCT ON` clause in relation to your `ORDER BY` clause
+            users::id,
+            posts::id,
+            users::hair_color,
+            users::name,
+            posts::title,
+            posts::body,
+        ));
+    // using then_order_by doesn't allow to workaround that
+    users::table
+        .inner_join(posts::table)
+        .distinct_on((users::id, posts::id))
+        .order_by(users::id)
+        .then_order_by((
+            //~^ ERROR: invalid order of elements in your `DISTINCT ON` clause in relation to your `ORDER BY` clause
+            posts::id,
+            users::hair_color,
+            users::name,
+            posts::title,
+            posts::body,
+            posts::user_id,
+        ));
+
+    // working around the limitation with tuples works
+    // same example as the plain tuple example above
+    // with just an extra tuple
+    users::table
+        .inner_join(posts::table)
+        .distinct_on(users::id)
+        .order_by((
+            users::id,
+            (
+                posts::id,
+                users::hair_color,
+                users::name,
+                posts::title,
+                posts::body,
+            ),
+        ));
 }

--- a/diesel_compile_tests/tests/fail/distinct_on_requires_matching_order_clause.stderr
+++ b/diesel_compile_tests/tests/fail/distinct_on_requires_matching_order_clause.stderr
@@ -1,12 +1,12 @@
 error[E0277]: invalid order of elements in your `DISTINCT ON` clause in relation to your `ORDER BY` clause
-   --> tests/fail/distinct_on_requires_matching_order_clause.rs:120:58
+   --> tests/fail/distinct_on_requires_matching_order_clause.rs:132:58
     |
 LL |     let _ = users::table.order_by(users::id).distinct_on(users::name);
     |                                              ----------- ^^^^^^^^^^^ unsatisfied trait bound
     |                                              |
     |                                              required by a bound introduced by this call
     |
-    = help: the trait `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<columns::name>>` is not implemented for `diesel::query_builder::order_clause::OrderClause<columns::id>`
+    = help: the trait `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<users::columns::name>>` is not implemented for `OrderClause<id>`
     = note: the elements in your `DISTINCT ON` clause needs to match the elements in your `ORDER BY` clause up to which clause contains less elements
 help: the following other types implement trait `query_dsl::order_dsl::ValidOrderingForDistinct<D>`
    --> DIESEL/diesel/diesel/src/pg/query_builder/distinct_on.rs
@@ -29,7 +29,7 @@ help: the following other types implement trait `query_dsl::order_dsl::ValidOrde
  LL | |     T: crate::Expression,
  LL | |     T::SqlType: SingleValue,
     | |____________________________^ `OrderClause<Desc<T>>`
-    = note: required for `SelectStatement<..., ..., ..., ..., ...>` to implement `DistinctOnDsl<columns::name>`
+    = note: required for `SelectStatement<..., ..., ..., ..., ...>` to implement `DistinctOnDsl<users::columns::name>`
 note: required by a bound in `diesel::QueryDsl::distinct_on`
    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
     |
@@ -41,14 +41,14 @@ LL |         Self: methods::DistinctOnDsl<Expr>,
  
     
 error[E0277]: invalid order of elements in your `DISTINCT ON` clause in relation to your `ORDER BY` clause
-   --> tests/fail/distinct_on_requires_matching_order_clause.rs:127:22
+   --> tests/fail/distinct_on_requires_matching_order_clause.rs:139:22
     |
 LL |         .distinct_on(users::name);
     |          ----------- ^^^^^^^^^^^ unsatisfied trait bound
     |          |
     |          required by a bound introduced by this call
     |
-    = help: the trait `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<columns::name>>` is not implemented for `OrderClause<(id, name)>`
+    = help: the trait `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<users::columns::name>>` is not implemented for `OrderClause<(id, name)>`
     = note: the elements in your `DISTINCT ON` clause needs to match the elements in your `ORDER BY` clause up to which clause contains less elements
 help: the following other types implement trait `query_dsl::order_dsl::ValidOrderingForDistinct<D>`
    --> DIESEL/diesel/diesel/src/pg/query_builder/distinct_on.rs
@@ -71,7 +71,7 @@ help: the following other types implement trait `query_dsl::order_dsl::ValidOrde
  LL | |     T: crate::Expression,
  LL | |     T::SqlType: SingleValue,
     | |____________________________^ `OrderClause<Desc<T>>`
-    = note: required for `SelectStatement<..., ..., ..., ..., ...>` to implement `DistinctOnDsl<columns::name>`
+    = note: required for `SelectStatement<..., ..., ..., ..., ...>` to implement `DistinctOnDsl<users::columns::name>`
 note: required by a bound in `diesel::QueryDsl::distinct_on`
    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
     |
@@ -83,14 +83,14 @@ LL |         Self: methods::DistinctOnDsl<Expr>,
  
     
 error[E0277]: invalid order of elements in your `DISTINCT ON` clause in relation to your `ORDER BY` clause
-   --> tests/fail/distinct_on_requires_matching_order_clause.rs:134:22
+   --> tests/fail/distinct_on_requires_matching_order_clause.rs:146:22
     |
 LL |         .distinct_on(users::name);
     |          ----------- ^^^^^^^^^^^ unsatisfied trait bound
     |          |
     |          required by a bound introduced by this call
     |
-    = help: the trait `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<columns::name>>` is not implemented for `OrderClause<(id, name)>`
+    = help: the trait `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<users::columns::name>>` is not implemented for `OrderClause<(id, name)>`
     = note: the elements in your `DISTINCT ON` clause needs to match the elements in your `ORDER BY` clause up to which clause contains less elements
 help: the following other types implement trait `query_dsl::order_dsl::ValidOrderingForDistinct<D>`
    --> DIESEL/diesel/diesel/src/pg/query_builder/distinct_on.rs
@@ -113,7 +113,7 @@ help: the following other types implement trait `query_dsl::order_dsl::ValidOrde
  LL | |     T: crate::Expression,
  LL | |     T::SqlType: SingleValue,
     | |____________________________^ `OrderClause<Desc<T>>`
-    = note: required for `SelectStatement<..., ..., ..., ..., ...>` to implement `DistinctOnDsl<columns::name>`
+    = note: required for `SelectStatement<..., ..., ..., ..., ...>` to implement `DistinctOnDsl<users::columns::name>`
 note: required by a bound in `diesel::QueryDsl::distinct_on`
    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
     |
@@ -125,14 +125,14 @@ LL |         Self: methods::DistinctOnDsl<Expr>,
  
     
 error[E0277]: invalid order of elements in your `DISTINCT ON` clause in relation to your `ORDER BY` clause
-   --> tests/fail/distinct_on_requires_matching_order_clause.rs:139:60
+   --> tests/fail/distinct_on_requires_matching_order_clause.rs:151:60
     |
 LL |     let _ = users::table.distinct_on(users::name).order_by(users::id);
     |                                                   -------- ^^^^^^^^^ unsatisfied trait bound
     |                                                   |
     |                                                   required by a bound introduced by this call
     |
-    = help: the trait `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<columns::name>>` is not implemented for `diesel::query_builder::order_clause::OrderClause<columns::id>`
+    = help: the trait `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<users::columns::name>>` is not implemented for `OrderClause<id>`
     = note: the elements in your `DISTINCT ON` clause needs to match the elements in your `ORDER BY` clause up to which clause contains less elements
 help: the following other types implement trait `query_dsl::order_dsl::ValidOrderingForDistinct<D>`
    --> DIESEL/diesel/diesel/src/pg/query_builder/distinct_on.rs
@@ -155,7 +155,7 @@ help: the following other types implement trait `query_dsl::order_dsl::ValidOrde
  LL | |     T: crate::Expression,
  LL | |     T::SqlType: SingleValue,
     | |____________________________^ `OrderClause<Desc<T>>`
-    = note: required for `SelectStatement<FromClause<table>, ..., ...>` to implement `OrderDsl<columns::id>`
+    = note: required for `SelectStatement<FromClause<table>, ..., ...>` to implement `OrderDsl<users::columns::id>`
 note: required by a bound in `order_by`
    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
     |
@@ -167,14 +167,14 @@ LL |         Self: methods::OrderDsl<Expr>,
  
     
 error[E0277]: invalid order of elements in your `DISTINCT ON` clause in relation to your `ORDER BY` clause
-   --> tests/fail/distinct_on_requires_matching_order_clause.rs:145:22
+   --> tests/fail/distinct_on_requires_matching_order_clause.rs:157:22
     |
 LL |         .distinct_on(users::name)
     |          ----------- ^^^^^^^^^^^ unsatisfied trait bound
     |          |
     |          required by a bound introduced by this call
     |
-    = help: the trait `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<columns::name>>` is not implemented for `diesel::query_builder::order_clause::OrderClause<columns::id>`
+    = help: the trait `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<users::columns::name>>` is not implemented for `OrderClause<id>`
     = note: the elements in your `DISTINCT ON` clause needs to match the elements in your `ORDER BY` clause up to which clause contains less elements
 help: the following other types implement trait `query_dsl::order_dsl::ValidOrderingForDistinct<D>`
    --> DIESEL/diesel/diesel/src/pg/query_builder/distinct_on.rs
@@ -197,7 +197,7 @@ help: the following other types implement trait `query_dsl::order_dsl::ValidOrde
  LL | |     T: crate::Expression,
  LL | |     T::SqlType: SingleValue,
     | |____________________________^ `OrderClause<Desc<T>>`
-    = note: required for `SelectStatement<..., ..., ..., ..., ...>` to implement `DistinctOnDsl<columns::name>`
+    = note: required for `SelectStatement<..., ..., ..., ..., ...>` to implement `DistinctOnDsl<users::columns::name>`
 note: required by a bound in `diesel::QueryDsl::distinct_on`
    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
     |
@@ -209,14 +209,14 @@ LL |         Self: methods::DistinctOnDsl<Expr>,
  
     
 error[E0277]: invalid order of elements in your `DISTINCT ON` clause in relation to your `ORDER BY` clause
-   --> tests/fail/distinct_on_requires_matching_order_clause.rs:153:22
+   --> tests/fail/distinct_on_requires_matching_order_clause.rs:165:22
     |
 LL |         .distinct_on(users::name)
     |          ----------- ^^^^^^^^^^^ unsatisfied trait bound
     |          |
     |          required by a bound introduced by this call
     |
-    = help: the trait `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<columns::name>>` is not implemented for `OrderClause<(id, name)>`
+    = help: the trait `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<users::columns::name>>` is not implemented for `OrderClause<(id, name)>`
     = note: the elements in your `DISTINCT ON` clause needs to match the elements in your `ORDER BY` clause up to which clause contains less elements
 help: the following other types implement trait `query_dsl::order_dsl::ValidOrderingForDistinct<D>`
    --> DIESEL/diesel/diesel/src/pg/query_builder/distinct_on.rs
@@ -239,7 +239,7 @@ help: the following other types implement trait `query_dsl::order_dsl::ValidOrde
  LL | |     T: crate::Expression,
  LL | |     T::SqlType: SingleValue,
     | |____________________________^ `OrderClause<Desc<T>>`
-    = note: required for `SelectStatement<..., ..., ..., ..., ...>` to implement `DistinctOnDsl<columns::name>`
+    = note: required for `SelectStatement<..., ..., ..., ..., ...>` to implement `DistinctOnDsl<users::columns::name>`
 note: required by a bound in `diesel::QueryDsl::distinct_on`
    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
     |
@@ -251,14 +251,14 @@ LL |         Self: methods::DistinctOnDsl<Expr>,
  
     
 error[E0277]: invalid order of elements in your `DISTINCT ON` clause in relation to your `ORDER BY` clause
-   --> tests/fail/distinct_on_requires_matching_order_clause.rs:161:22
+   --> tests/fail/distinct_on_requires_matching_order_clause.rs:173:22
     |
 LL |         .distinct_on((users::name, users::id))
     |          ----------- ^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
     |          |
     |          required by a bound introduced by this call
     |
-    = help: the trait `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(columns::name, columns::id)>>` is not implemented for `OrderClause<(id, name)>`
+    = help: the trait `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(users::columns::name, users::columns::id)>>` is not implemented for `OrderClause<(id, name)>`
     = note: the elements in your `DISTINCT ON` clause needs to match the elements in your `ORDER BY` clause up to which clause contains less elements
 help: the following other types implement trait `query_dsl::order_dsl::ValidOrderingForDistinct<D>`
    --> DIESEL/diesel/diesel/src/pg/query_builder/distinct_on.rs
@@ -281,7 +281,7 @@ help: the following other types implement trait `query_dsl::order_dsl::ValidOrde
  LL | |     T: crate::Expression,
  LL | |     T::SqlType: SingleValue,
     | |____________________________^ `OrderClause<Desc<T>>`
-    = note: required for `SelectStatement<..., ..., ..., ..., ...>` to implement `DistinctOnDsl<(columns::name, columns::id)>`
+    = note: required for `SelectStatement<..., ..., ..., ..., ...>` to implement `DistinctOnDsl<(users::columns::name, users::columns::id)>`
 note: required by a bound in `diesel::QueryDsl::distinct_on`
    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
     |
@@ -293,14 +293,14 @@ LL |         Self: methods::DistinctOnDsl<Expr>,
  
     
 error[E0277]: invalid order of elements in your `DISTINCT ON` clause in relation to your `ORDER BY` clause
-   --> tests/fail/distinct_on_requires_matching_order_clause.rs:169:22
+   --> tests/fail/distinct_on_requires_matching_order_clause.rs:181:22
     |
 LL |         .distinct_on((users::name, users::id))
     |          ----------- ^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
     |          |
     |          required by a bound introduced by this call
     |
-    = help: the trait `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(columns::name, columns::id)>>` is not implemented for `diesel::query_builder::order_clause::OrderClause<columns::id>`
+    = help: the trait `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(users::columns::name, users::columns::id)>>` is not implemented for `OrderClause<id>`
     = note: the elements in your `DISTINCT ON` clause needs to match the elements in your `ORDER BY` clause up to which clause contains less elements
 help: the following other types implement trait `query_dsl::order_dsl::ValidOrderingForDistinct<D>`
    --> DIESEL/diesel/diesel/src/pg/query_builder/distinct_on.rs
@@ -323,7 +323,7 @@ help: the following other types implement trait `query_dsl::order_dsl::ValidOrde
  LL | |     T: crate::Expression,
  LL | |     T::SqlType: SingleValue,
     | |____________________________^ `OrderClause<Desc<T>>`
-    = note: required for `SelectStatement<..., ..., ..., ..., ...>` to implement `DistinctOnDsl<(columns::name, columns::id)>`
+    = note: required for `SelectStatement<..., ..., ..., ..., ...>` to implement `DistinctOnDsl<(users::columns::name, users::columns::id)>`
 note: required by a bound in `diesel::QueryDsl::distinct_on`
    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
     |
@@ -335,14 +335,14 @@ LL |         Self: methods::DistinctOnDsl<Expr>,
  
     
 error[E0277]: invalid order of elements in your `DISTINCT ON` clause in relation to your `ORDER BY` clause
-   --> tests/fail/distinct_on_requires_matching_order_clause.rs:177:22
+   --> tests/fail/distinct_on_requires_matching_order_clause.rs:189:22
     |
 LL |         .distinct_on(users::name)
     |          ----------- ^^^^^^^^^^^ unsatisfied trait bound
     |          |
     |          required by a bound introduced by this call
     |
-    = help: the trait `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<columns::name>>` is not implemented for `OrderClause<(id, name)>`
+    = help: the trait `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<users::columns::name>>` is not implemented for `OrderClause<(id, name)>`
     = note: the elements in your `DISTINCT ON` clause needs to match the elements in your `ORDER BY` clause up to which clause contains less elements
 help: the following other types implement trait `query_dsl::order_dsl::ValidOrderingForDistinct<D>`
    --> DIESEL/diesel/diesel/src/pg/query_builder/distinct_on.rs
@@ -365,7 +365,7 @@ help: the following other types implement trait `query_dsl::order_dsl::ValidOrde
  LL | |     T: crate::Expression,
  LL | |     T::SqlType: SingleValue,
     | |____________________________^ `OrderClause<Desc<T>>`
-    = note: required for `SelectStatement<..., ..., ..., ..., ...>` to implement `DistinctOnDsl<columns::name>`
+    = note: required for `SelectStatement<..., ..., ..., ..., ...>` to implement `DistinctOnDsl<users::columns::name>`
 note: required by a bound in `diesel::QueryDsl::distinct_on`
    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
     |
@@ -377,14 +377,14 @@ LL |         Self: methods::DistinctOnDsl<Expr>,
  
     
 error[E0277]: invalid order of elements in your `DISTINCT ON` clause in relation to your `ORDER BY` clause
-   --> tests/fail/distinct_on_requires_matching_order_clause.rs:185:19
+   --> tests/fail/distinct_on_requires_matching_order_clause.rs:197:19
     |
 LL |         .order_by(users::id)
     |          -------- ^^^^^^^^^ unsatisfied trait bound
     |          |
     |          required by a bound introduced by this call
     |
-    = help: the trait `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<columns::name>>` is not implemented for `diesel::query_builder::order_clause::OrderClause<columns::id>`
+    = help: the trait `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<users::columns::name>>` is not implemented for `OrderClause<id>`
     = note: the elements in your `DISTINCT ON` clause needs to match the elements in your `ORDER BY` clause up to which clause contains less elements
 help: the following other types implement trait `query_dsl::order_dsl::ValidOrderingForDistinct<D>`
    --> DIESEL/diesel/diesel/src/pg/query_builder/distinct_on.rs
@@ -407,7 +407,7 @@ help: the following other types implement trait `query_dsl::order_dsl::ValidOrde
  LL | |     T: crate::Expression,
  LL | |     T::SqlType: SingleValue,
     | |____________________________^ `OrderClause<Desc<T>>`
-    = note: required for `SelectStatement<FromClause<table>, ..., ...>` to implement `OrderDsl<columns::id>`
+    = note: required for `SelectStatement<FromClause<table>, ..., ...>` to implement `OrderDsl<users::columns::id>`
 note: required by a bound in `order_by`
    --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
     |
@@ -416,5 +416,187 @@ LL |     fn order_by<Expr>(self, expr: Expr) -> OrderBy<Self, Expr>
 ...
 LL |         Self: methods::OrderDsl<Expr>,
     |               ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::order_by`
+ 
+    
+error[E0277]: invalid order of elements in your `DISTINCT ON` clause in relation to your `ORDER BY` clause
+   --> tests/fail/distinct_on_requires_matching_order_clause.rs:213:24
+    |
+LL |         .then_order_by(users::hair_color);
+    |          ------------- ^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+    |          |
+    |          required by a bound introduced by this call
+    |
+    = help: the trait `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(users::columns::name, users::columns::id)>>` is not implemented for `OrderClause<(name, hair_color)>`
+    = note: the elements in your `DISTINCT ON` clause needs to match the elements in your `ORDER BY` clause up to which clause contains less elements
+help: the following other types implement trait `query_dsl::order_dsl::ValidOrderingForDistinct<D>`
+   --> DIESEL/diesel/diesel/src/pg/query_builder/distinct_on.rs
+    |
+ LL |   impl<T> ValidOrderingForDistinct<DistinctOnClause<T>> for OrderClause<(T,)> {}
+    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `diesel::query_builder::order_clause::OrderClause<(T,)>`
+ LL |   impl<T> ValidOrderingForDistinct<DistinctOnClause<T>> for OrderClause<T> where T: crate::Expression {}
+    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `diesel::query_builder::order_clause::OrderClause<T>`
+...
+ LL | / impl<T> ValidOrderingForDistinct<DistinctOnClause<T>>
+ LL | |     for OrderClause<crate::expression::operators::Asc<T>>
+ LL | | where
+ LL | |     T: crate::Expression,
+ LL | |     T::SqlType: SingleValue,
+    | |____________________________^ `OrderClause<Asc<T>>`
+...
+ LL | / impl<T> ValidOrderingForDistinct<DistinctOnClause<T>>
+ LL | |     for OrderClause<crate::expression::operators::Desc<T>>
+ LL | | where
+ LL | |     T: crate::Expression,
+ LL | |     T::SqlType: SingleValue,
+    | |____________________________^ `OrderClause<Desc<T>>`
+    = note: required for `SelectStatement<..., ..., ..., ..., ...>` to implement `ThenOrderDsl<users::columns::hair_color>`
+note: required by a bound in `diesel::QueryDsl::then_order_by`
+   --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+    |
+LL |     fn then_order_by<Order>(self, order: Order) -> ThenOrderBy<Self, Order>
+    |        ------------- required by a bound in this associated function
+LL |     where
+LL |         Self: methods::ThenOrderDsl<Order>,
+    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::then_order_by`
+ 
+    
+error[E0277]: invalid order of elements in your `DISTINCT ON` clause in relation to your `ORDER BY` clause
+   --> tests/fail/distinct_on_requires_matching_order_clause.rs:229:19
+    |
+LL |         .order_by(posts::id);
+    |          -------- ^^^^^^^^^ unsatisfied trait bound
+    |          |
+    |          required by a bound introduced by this call
+    |
+    = help: the trait `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<users::columns::id>>` is not implemented for `OrderClause<id>`
+    = note: the elements in your `DISTINCT ON` clause needs to match the elements in your `ORDER BY` clause up to which clause contains less elements
+help: the following other types implement trait `query_dsl::order_dsl::ValidOrderingForDistinct<D>`
+   --> DIESEL/diesel/diesel/src/pg/query_builder/distinct_on.rs
+    |
+ LL |   impl<T> ValidOrderingForDistinct<DistinctOnClause<T>> for OrderClause<(T,)> {}
+    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `diesel::query_builder::order_clause::OrderClause<(T,)>`
+ LL |   impl<T> ValidOrderingForDistinct<DistinctOnClause<T>> for OrderClause<T> where T: crate::Expression {}
+    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `diesel::query_builder::order_clause::OrderClause<T>`
+...
+ LL | / impl<T> ValidOrderingForDistinct<DistinctOnClause<T>>
+ LL | |     for OrderClause<crate::expression::operators::Asc<T>>
+ LL | | where
+ LL | |     T: crate::Expression,
+ LL | |     T::SqlType: SingleValue,
+    | |____________________________^ `OrderClause<Asc<T>>`
+...
+ LL | / impl<T> ValidOrderingForDistinct<DistinctOnClause<T>>
+ LL | |     for OrderClause<crate::expression::operators::Desc<T>>
+ LL | | where
+ LL | |     T: crate::Expression,
+ LL | |     T::SqlType: SingleValue,
+    | |____________________________^ `OrderClause<Desc<T>>`
+    = note: required for `SelectStatement<FromClause<...>, ..., ...>` to implement `OrderDsl<posts::columns::id>`
+note: required by a bound in `order_by`
+   --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+    |
+LL |     fn order_by<Expr>(self, expr: Expr) -> OrderBy<Self, Expr>
+    |        -------- required by a bound in this associated function
+...
+LL |         Self: methods::OrderDsl<Expr>,
+    |               ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::order_by`
+ 
+    
+error[E0277]: invalid order of elements in your `DISTINCT ON` clause in relation to your `ORDER BY` clause
+   --> tests/fail/distinct_on_requires_matching_order_clause.rs:237:19
+    |
+LL |   ...   .order_by((
+    |  ________--------_^
+    | |        |
+    | |        required by a bound introduced by this call
+LL | | ...
+LL | | ...       users::id,
+LL | | ...       posts::id,
+...   |
+LL | | ...       posts::body,
+LL | | ...   ));
+    | |_______^ unsatisfied trait bound
+    |
+    = help: the trait `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<users::columns::id>>` is not implemented for `OrderClause<(id, id, hair_color, name, ..., ...)>`
+    = note: the elements in your `DISTINCT ON` clause needs to match the elements in your `ORDER BY` clause up to which clause contains less elements
+help: the following other types implement trait `query_dsl::order_dsl::ValidOrderingForDistinct<D>`
+   --> DIESEL/diesel/diesel/src/pg/query_builder/distinct_on.rs
+    |
+ LL |   impl<T> ValidOrderingForDistinct<DistinctOnClause<T>> for OrderClause<(T,)> {}
+    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `diesel::query_builder::order_clause::OrderClause<(T,)>`
+ LL |   impl<T> ValidOrderingForDistinct<DistinctOnClause<T>> for OrderClause<T> where T: crate::Expression {}
+    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `diesel::query_builder::order_clause::OrderClause<T>`
+...
+ LL | / impl<T> ValidOrderingForDistinct<DistinctOnClause<T>>
+ LL | |     for OrderClause<crate::expression::operators::Asc<T>>
+ LL | | where
+ LL | |     T: crate::Expression,
+ LL | |     T::SqlType: SingleValue,
+    | |____________________________^ `OrderClause<Asc<T>>`
+...
+ LL | / impl<T> ValidOrderingForDistinct<DistinctOnClause<T>>
+ LL | |     for OrderClause<crate::expression::operators::Desc<T>>
+ LL | | where
+ LL | |     T: crate::Expression,
+ LL | |     T::SqlType: SingleValue,
+    | |____________________________^ `OrderClause<Desc<T>>`
+    = note: required for `SelectStatement<FromClause<...>, ..., ...>` to implement `OrderDsl<(id, id, hair_color, name, title, body)>`
+note: required by a bound in `order_by`
+   --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+    |
+LL |     fn order_by<Expr>(self, expr: Expr) -> OrderBy<Self, Expr>
+    |        -------- required by a bound in this associated function
+...
+LL |         Self: methods::OrderDsl<Expr>,
+    |               ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::order_by`
+ 
+    
+error[E0277]: invalid order of elements in your `DISTINCT ON` clause in relation to your `ORDER BY` clause
+   --> tests/fail/distinct_on_requires_matching_order_clause.rs:251:24
+    |
+LL |   ...   .then_order_by((
+    |  ________-------------_^
+    | |        |
+    | |        required by a bound introduced by this call
+LL | | ...
+LL | | ...       posts::id,
+LL | | ...       users::hair_color,
+...   |
+LL | | ...       posts::user_id,
+LL | | ...   ));
+    | |_______^ unsatisfied trait bound
+    |
+    = help: the trait `query_dsl::order_dsl::ValidOrderingForDistinct<DistinctOnClause<(users::columns::id, posts::columns::id)>>` is not implemented for `OrderClause<(id, (id, ..., ..., ..., ..., ...))>`
+    = note: the elements in your `DISTINCT ON` clause needs to match the elements in your `ORDER BY` clause up to which clause contains less elements
+help: the following other types implement trait `query_dsl::order_dsl::ValidOrderingForDistinct<D>`
+   --> DIESEL/diesel/diesel/src/pg/query_builder/distinct_on.rs
+    |
+ LL |   impl<T> ValidOrderingForDistinct<DistinctOnClause<T>> for OrderClause<(T,)> {}
+    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `diesel::query_builder::order_clause::OrderClause<(T,)>`
+ LL |   impl<T> ValidOrderingForDistinct<DistinctOnClause<T>> for OrderClause<T> where T: crate::Expression {}
+    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `diesel::query_builder::order_clause::OrderClause<T>`
+...
+ LL | / impl<T> ValidOrderingForDistinct<DistinctOnClause<T>>
+ LL | |     for OrderClause<crate::expression::operators::Asc<T>>
+ LL | | where
+ LL | |     T: crate::Expression,
+ LL | |     T::SqlType: SingleValue,
+    | |____________________________^ `OrderClause<Asc<T>>`
+...
+ LL | / impl<T> ValidOrderingForDistinct<DistinctOnClause<T>>
+ LL | |     for OrderClause<crate::expression::operators::Desc<T>>
+ LL | | where
+ LL | |     T: crate::Expression,
+ LL | |     T::SqlType: SingleValue,
+    | |____________________________^ `OrderClause<Desc<T>>`
+    = note: required for `SelectStatement<..., ..., ..., ..., ...>` to implement `ThenOrderDsl<(id, hair_color, ..., ..., ..., ...)>`
+note: required by a bound in `diesel::QueryDsl::then_order_by`
+   --> DIESEL/diesel/diesel/src/query_dsl/mod.rs
+    |
+LL |     fn then_order_by<Order>(self, order: Order) -> ThenOrderBy<Self, Order>
+    |        ------------- required by a bound in this associated function
+LL |     where
+LL |         Self: methods::ThenOrderDsl<Order>,
+    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `QueryDsl::then_order_by`
  
     For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
This PR fixes a loophole that allowed to construct queries having a mismatch between `DISTINCT ON` and `ORDER BY` clauses via `then_order_by`. We add some additional compile fail test cases for this.

Additionally we adjust the documentation to mention the 5 column limit for this query combinations explicitly for `order_by` and `disticnt_on`.  We also add some hints how to workaround that limitation and add some test cases for these workarounds.

Finally we adjust the documentation of `then_order_by` to not state anymore that it only exists for boxed queries. That is long not correct anymore.

Close #5156

<!-- 
Please provide a short brief summary description of your change here. 
Also make sure that your code passes all tests and style checks. 
Checkout the `CONTRIBUTING.md` file in the root of the repository for running these checks locally.
It's also fine to use the CI setup for running these tests, but in this case please indicate that your PR 
is not ready for review yet by marking it as DRAFT until it is ready.

If you submit a notable change please ensure to include it into the CHANGELOG.md file in
the root of the repository.

Also make sure to follow the projects guide lines about the usage of LLM's and AI agents as outlined
in the CONTRIBUTING.md file in the root of the repository.
-->

- [x] I checked for similar changes and make sure to reference them
- [x] I included a changelog entry for relevant new features or changes
