### PR TITLE
fix #661

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 * Fixed several panics in the serialization and deserialization code for PostgreSQL and MySQL
 * Tighten requirements for `SqliteConnection::deserialize_readonly_database` to closely match the upstream requirements
 * `diesel print-schema` now generates `joinable!` and `allow_tables_to_appear_in_same_query!` for PostgreSQL foreign keys across multiple configured schemas
+* Fixed several Tests using schema modifications for `mysql` and `mariadb`
 
 ### Changed
 

--- a/diesel_derives/tests/insertable.rs
+++ b/diesel_derives/tests/insertable.rs
@@ -446,7 +446,7 @@ fn insertable_with_slice_of_borrowed() {
     }
 
     let conn = &mut connection();
-    
+
     sql_query("CREATE TEMPORARY TABLE posts (id SERIAL PRIMARY KEY, tags TEXT[] NOT NULL)")
         .execute(conn)
         .unwrap();

--- a/diesel_derives/tests/insertable.rs
+++ b/diesel_derives/tests/insertable.rs
@@ -446,10 +446,8 @@ fn insertable_with_slice_of_borrowed() {
     }
 
     let conn = &mut connection();
-    sql_query("DROP TABLE IF EXISTS posts CASCADE")
-        .execute(conn)
-        .unwrap();
-    sql_query("CREATE TABLE posts (id SERIAL PRIMARY KEY, tags TEXT[] NOT NULL)")
+    
+    sql_query("CREATE TEMPORARY TABLE posts (id SERIAL PRIMARY KEY, tags TEXT[] NOT NULL)")
         .execute(conn)
         .unwrap();
     let new_post = NewPost {

--- a/diesel_tests/tests/associations.rs
+++ b/diesel_tests/tests/associations.rs
@@ -55,9 +55,8 @@ fn eager_loading_associations_for_multiple_ref_records() {
     assert_eq!(expected_data, users_and_posts);
 }
 
-#[cfg(not(any(feature = "mysql", feature = "mariadb")))] // FIXME: Figure out how to handle tests that modify schema
 mod eager_loading_with_string_keys {
-    use crate::schema::{connection, drop_table_cascade};
+    use crate::schema::connection;
     use diesel::connection::SimpleConnection;
     use diesel::*;
 
@@ -80,14 +79,11 @@ mod eager_loading_with_string_keys {
     #[diesel_test_helper::test]
     fn eager_loading_associations_for_multiple_records() {
         let connection = &mut connection();
-        drop_table_cascade(connection, "users");
-        drop_table_cascade(connection, "posts");
-        drop_table_cascade(connection, "fk_doesnt_reference_pk");
         connection
             .batch_execute(
                 r#"
-            CREATE TABLE users (id TEXT PRIMARY KEY NOT NULL);
-            CREATE TABLE posts (id TEXT PRIMARY KEY NOT NULL, user_id TEXT NOT NULL);
+            CREATE TEMPORARY TABLE users (id VARCHAR(50) PRIMARY KEY NOT NULL);
+            CREATE TEMPORARY TABLE posts (id VARCHAR(50) PRIMARY KEY NOT NULL, user_id TEXT NOT NULL);
             INSERT INTO users (id) VALUES ('Sean'), ('Tess');
             INSERT INTO posts (id, user_id) VALUES ('Hello', 'Sean'), ('World', 'Sean'), ('Hello 2', 'Tess');
         "#,
@@ -278,8 +274,6 @@ fn conn_with_test_data() -> (TestConnection, User, User, User) {
 }
 
 #[diesel_test_helper::test]
-// FIXME: Figure out how to handle tests that modify schema
-#[cfg(not(any(feature = "mysql", feature = "mariadb")))]
 // https://github.com/rust-lang/rust/issues/124396
 #[allow(unknown_lints, non_local_definitions)]
 fn custom_foreign_key() {
@@ -324,9 +318,9 @@ fn custom_foreign_key() {
     connection
         .batch_execute(
             r#"
-            CREATE TABLE users1 (id SERIAL PRIMARY KEY,
+            CREATE TEMPORARY TABLE users1 (id SERIAL PRIMARY KEY,
                                 name TEXT NOT NULL);
-            CREATE TABLE posts1 (id SERIAL PRIMARY KEY,
+            CREATE TEMPORARY TABLE posts1 (id SERIAL PRIMARY KEY,
                                 belongs_to_user INTEGER NOT NULL,
                                 title TEXT NOT NULL);
             INSERT INTO users1 (id, name) VALUES (1, 'Sean'), (2, 'Tess');

--- a/diesel_tests/tests/connection.rs
+++ b/diesel_tests/tests/connection.rs
@@ -25,7 +25,7 @@ fn managing_updated_at_for_table() {
 
     // transactions have frozen time, so we can't use them
     let connection = &mut connection_without_transaction();
-    create_table(
+    create_temporary_table(
         "auto_time",
         (
             integer("id").primary_key().auto_increment(),
@@ -35,12 +35,6 @@ fn managing_updated_at_for_table() {
     )
     .execute(connection)
     .unwrap();
-    let mut _drop_conn = connection_without_transaction();
-    let _guard = DropTable {
-        connection: &mut _drop_conn,
-        table_name: "auto_time",
-        can_drop: !cfg!(feature = "sqlite"),
-    };
 
     sql_query("SELECT diesel_manage_updated_at('auto_time')")
         .execute(connection)
@@ -150,7 +144,7 @@ fn use_the_same_connection_multiple_times() {
     // We can extend `schema_dsl` module to accommodate UNIQUE constraint.
     sql_query(
         r#"
-          CREATE TABLE github_issue_3342 (
+          CREATE TEMPORARY TABLE github_issue_3342 (
             id SERIAL PRIMARY KEY,
             uid INTEGER NOT NULL UNIQUE
           )
@@ -158,13 +152,6 @@ fn use_the_same_connection_multiple_times() {
     )
     .execute(connection)
     .unwrap();
-
-    let mut _drop_conn = connection_without_transaction();
-    let _guard = DropTable {
-        connection: &mut _drop_conn,
-        table_name: "github_issue_3342",
-        can_drop: true,
-    };
 
     // helper method to simulate database error.
     fn insert_or_fetch(conn: &mut PgConnection, input: i32) {

--- a/diesel_tests/tests/expressions/date_and_time.rs
+++ b/diesel_tests/tests/expressions/date_and_time.rs
@@ -281,7 +281,6 @@ fn now_executes_sql_function_now() {
     assert_eq!(Ok(vec![2]), after_today);
 }
 #[diesel_test_helper::test]
-#[cfg(not(any(feature = "mysql", feature = "mariadb")))] // FIXME: Figure out how to handle tests that modify schema
 fn date_uses_sql_function_date() {
     use self::has_timestamps::dsl::*;
 
@@ -461,7 +460,7 @@ fn adding_interval_to_nullable_things() {
 fn setup_test_table(conn: &mut TestConnection) {
     use crate::schema_dsl::*;
 
-    create_table(
+    create_temporary_table(
         "has_timestamps",
         (
             integer("id").primary_key().auto_increment(),
@@ -475,7 +474,7 @@ fn setup_test_table(conn: &mut TestConnection) {
     .unwrap();
 
     #[cfg(feature = "postgres")]
-    create_table(
+    create_temporary_table(
         "has_timestamptzs",
         (
             integer("id").primary_key().auto_increment(),
@@ -488,7 +487,7 @@ fn setup_test_table(conn: &mut TestConnection) {
     .execute(conn)
     .unwrap();
 
-    create_table(
+    create_temporary_table(
         "has_time",
         (
             integer("id").primary_key().auto_increment(),
@@ -498,7 +497,7 @@ fn setup_test_table(conn: &mut TestConnection) {
     .execute(conn)
     .unwrap();
 
-    create_table(
+    create_temporary_table(
         "has_date",
         (
             integer("id").primary_key().auto_increment(),
@@ -508,7 +507,7 @@ fn setup_test_table(conn: &mut TestConnection) {
     .execute(conn)
     .unwrap();
 
-    create_table(
+    create_temporary_table(
         "nullable_date_and_time",
         (
             integer("id").primary_key().auto_increment(),

--- a/diesel_tests/tests/filter.rs
+++ b/diesel_tests/tests/filter.rs
@@ -622,7 +622,7 @@ fn filter_subselect_with_nullable_column() {
     }
     let connection = &mut connection();
 
-    create_table(
+    create_temporary_table(
         "home_worlds",
         (
             integer("id").primary_key().auto_increment(),
@@ -632,7 +632,7 @@ fn filter_subselect_with_nullable_column() {
     .execute(connection)
     .unwrap();
 
-    create_table(
+    create_temporary_table(
         "heroes",
         (
             integer("id").primary_key().auto_increment(),

--- a/diesel_tests/tests/insert.rs
+++ b/diesel_tests/tests/insert.rs
@@ -669,19 +669,15 @@ fn insert_in_nullable_with_non_null_default() {
 fn insert_returning_count_returns_number_of_rows_inserted() {
     use crate::schema::users::table as users;
     let connection = &mut connection();
-    #[cfg(any(feature = "mysql", feature = "mariadb"))]
-    let query = "CREATE TEMPORARY TABLE users (
+    diesel::sql_query(
+        "CREATE TEMPORARY TABLE users (
         id SERIAL PRIMARY KEY,
         name VARCHAR(50) NOT NULL,
         hair_color VARCHAR(10) NOT NULL DEFAULT 'Green'
-    )";
-    #[cfg(not(any(feature = "mysql", feature = "mariadb")))]
-    let query = "CREATE TEMPORARY TABLE users (
-        id SERIAL PRIMARY KEY,
-        name VARCHAR NOT NULL,
-        hair_color VARCHAR NOT NULL DEFAULT 'Green'
-    )";
-    diesel::sql_query(query).execute(connection).unwrap();
+    )",
+    )
+    .execute(connection)
+    .unwrap();
     let new_users: &[_] = &[
         BaldUser {
             name: "Sean".to_string(),

--- a/diesel_tests/tests/insert.rs
+++ b/diesel_tests/tests/insert.rs
@@ -548,14 +548,12 @@ fn batch_insert_with_returning_id_sqlite() {
 }
 
 #[diesel_test_helper::test]
-#[cfg(not(any(feature = "mysql", feature = "mariadb")))] // FIXME: Figure out how to handle tests that modify schema
 fn batch_insert_with_defaults() {
     use crate::schema::users::table as users;
     use crate::schema_dsl::*;
 
     let connection = &mut connection();
-    drop_table_cascade(connection, "users");
-    create_table(
+    create_temporary_table(
         "users",
         (
             integer("id").primary_key().auto_increment(),
@@ -593,14 +591,12 @@ fn batch_insert_with_defaults() {
 }
 
 #[diesel_test_helper::test]
-#[cfg(not(any(feature = "mysql", feature = "mariadb")))] // FIXME: Figure out how to handle tests that modify schema
 fn insert_with_defaults() {
     use crate::schema::users::table as users;
     use crate::schema_dsl::*;
 
     let connection = &mut connection();
-    drop_table_cascade(connection, "users");
-    create_table(
+    create_temporary_table(
         "users",
         (
             integer("id").primary_key().auto_increment(),
@@ -626,14 +622,12 @@ fn insert_with_defaults() {
 }
 
 #[diesel_test_helper::test]
-#[cfg(not(any(feature = "mysql", feature = "mariadb")))] // FIXME: Figure out how to handle tests that modify schema
 fn insert_in_nullable_with_non_null_default() {
     use crate::schema::users::table as users;
     use crate::schema_dsl::*;
 
     let connection = &mut connection();
-    drop_table_cascade(connection, "users");
-    create_table(
+    create_temporary_table(
         "users",
         (
             integer("id").primary_key().auto_increment(),
@@ -672,18 +666,22 @@ fn insert_in_nullable_with_non_null_default() {
 }
 
 #[diesel_test_helper::test]
-#[cfg(not(any(feature = "mysql", feature = "mariadb")))] // FIXME: Figure out how to handle tests that modify schema
 fn insert_returning_count_returns_number_of_rows_inserted() {
     use crate::schema::users::table as users;
     let connection = &mut connection();
-    drop_table_cascade(connection, "users");
-    diesel::sql_query(
-        "CREATE TABLE users (
+    #[cfg(any(feature = "mysql", feature = "mariadb"))]
+    let query = "CREATE TEMPORARY TABLE users (
+        id SERIAL PRIMARY KEY,
+        name VARCHAR(50) NOT NULL,
+        hair_color VARCHAR(10) NOT NULL DEFAULT 'Green'
+    )";
+    #[cfg(not(any(feature = "mysql", feature = "mariadb")))]
+    let query = "CREATE TEMPORARY TABLE users (
         id SERIAL PRIMARY KEY,
         name VARCHAR NOT NULL,
         hair_color VARCHAR NOT NULL DEFAULT 'Green'
-    )",
-    )
+    )";
+    diesel::sql_query(query)
     .execute(connection)
     .unwrap();
     let new_users: &[_] = &[
@@ -723,7 +721,7 @@ fn insert_with_generated_column() {
 
     let connection = &mut connection();
     diesel::sql_query(
-        "CREATE TABLE user_with_last_names (
+        "CREATE TEMPORARY TABLE user_with_last_names (
         first_name VARCHAR NOT NULL PRIMARY KEY,
         last_name VARCHAR NOT NULL,
         full_name VARCHAR GENERATED ALWAYS AS (first_name || ' ' || last_name) STORED
@@ -827,8 +825,7 @@ fn insert_only_default_values_with_returning() {
     use crate::schema_dsl::*;
     let connection = &mut connection();
 
-    drop_table_cascade(connection, "users");
-    create_table(
+    create_temporary_table(
         "users",
         (
             integer("id").primary_key().auto_increment(),
@@ -1001,13 +998,11 @@ fn insert_optional_field_with_null() {
 }
 
 #[diesel_test_helper::test]
-#[cfg(not(any(feature = "mysql", feature = "mariadb")))]
 fn insert_optional_field_with_default() {
     use crate::schema::users::dsl::*;
     use crate::schema_dsl::*;
     let connection = &mut connection();
-    drop_table_cascade(connection, "users");
-    create_table(
+    create_temporary_table(
         "users",
         (
             integer("id").primary_key().auto_increment(),
@@ -1036,13 +1031,11 @@ fn insert_optional_field_with_default() {
 }
 
 #[diesel_test_helper::test]
-#[cfg(not(any(feature = "mysql", feature = "mariadb")))]
 fn insert_all_default_fields() {
     use crate::schema::users::dsl::*;
     use crate::schema_dsl::*;
     let connection = &mut connection();
-    drop_table_cascade(connection, "users");
-    create_table(
+    create_temporary_table(
         "users",
         (
             integer("id").primary_key().auto_increment(),

--- a/diesel_tests/tests/insert.rs
+++ b/diesel_tests/tests/insert.rs
@@ -681,9 +681,7 @@ fn insert_returning_count_returns_number_of_rows_inserted() {
         name VARCHAR NOT NULL,
         hair_color VARCHAR NOT NULL DEFAULT 'Green'
     )";
-    diesel::sql_query(query)
-    .execute(connection)
-    .unwrap();
+    diesel::sql_query(query).execute(connection).unwrap();
     let new_users: &[_] = &[
         BaldUser {
             name: "Sean".to_string(),

--- a/diesel_tests/tests/lib.rs
+++ b/diesel_tests/tests/lib.rs
@@ -59,7 +59,6 @@ mod schema_inference;
 mod select;
 mod select_by;
 mod serialize_as;
-#[cfg(not(feature = "mysql"))] // FIXME: Figure out how to handle tests that modify schema
 mod transactions;
 mod types;
 mod types_roundtrip;

--- a/diesel_tests/tests/schema/mod.rs
+++ b/diesel_tests/tests/schema/mod.rs
@@ -326,20 +326,39 @@ pub type TestConnection = MariadbConnection;
 pub type TestBackend = <TestConnection as Connection>::Backend;
 
 //Used to ensure cleanup of one-off tables, e.g. for a table created for a single test
-#[cfg(not(any(feature = "mysql", feature = "mariadb")))]
 pub struct DropTable<'a> {
     pub connection: &'a mut TestConnection,
-    pub table_name: &'static str,
+    pub table_name: &'a str,
     pub can_drop: bool,
 }
 
-#[cfg(not(any(feature = "mysql", feature = "mariadb")))]
 impl Drop for DropTable<'_> {
     fn drop(&mut self) {
         if self.can_drop {
-            diesel::sql_query(format!("DROP TABLE {}", self.table_name))
+            diesel::sql_query(format!("DROP TABLE IF EXISTS {}", self.table_name))
                 .execute(self.connection)
                 .unwrap();
+        }
+    }
+}
+
+//Used to ensure cleanup of one-off tables in order, e.g. for tables created for a single test with fk constraints
+#[cfg(feature = "postgres")]
+pub struct DropTableInOrder<'a, const N:usize> {
+    pub connection: &'a mut TestConnection,
+    pub table_names: [&'a str; N],
+    pub can_drop: bool,
+}
+
+#[cfg(feature = "postgres")]
+impl<const N:usize> Drop for DropTableInOrder<'_, N> {
+    fn drop(&mut self) {
+        if self.can_drop {
+            for table_name in self.table_names {
+                diesel::sql_query(format!("DROP TABLE IF EXISTS {}", table_name))
+                    .execute(self.connection)
+                    .unwrap();
+            }
         }
     }
 }
@@ -449,20 +468,6 @@ pub fn disable_foreign_keys(connection: &mut TestConnection) {
 #[cfg(feature = "sqlite")]
 pub fn disable_foreign_keys(connection: &mut TestConnection) {
     diesel::sql_query("PRAGMA defer_foreign_keys = ON")
-        .execute(connection)
-        .unwrap();
-}
-
-#[cfg(feature = "sqlite")]
-pub fn drop_table_cascade(connection: &mut TestConnection, table: &str) {
-    diesel::sql_query(format!("DROP TABLE {table}"))
-        .execute(connection)
-        .unwrap();
-}
-
-#[cfg(feature = "postgres")]
-pub fn drop_table_cascade(connection: &mut TestConnection, table: &str) {
-    diesel::sql_query(format!("DROP TABLE {table} CASCADE"))
         .execute(connection)
         .unwrap();
 }

--- a/diesel_tests/tests/schema/mod.rs
+++ b/diesel_tests/tests/schema/mod.rs
@@ -326,12 +326,14 @@ pub type TestConnection = MariadbConnection;
 pub type TestBackend = <TestConnection as Connection>::Backend;
 
 //Used to ensure cleanup of one-off tables, e.g. for a table created for a single test
+#[cfg(not(feature = "sqlite"))]
 pub struct DropTable<'a> {
     pub connection: &'a mut TestConnection,
     pub table_name: &'a str,
     pub can_drop: bool,
 }
 
+#[cfg(not(feature = "sqlite"))]
 impl Drop for DropTable<'_> {
     fn drop(&mut self) {
         if self.can_drop {
@@ -344,14 +346,14 @@ impl Drop for DropTable<'_> {
 
 //Used to ensure cleanup of one-off tables in order, e.g. for tables created for a single test with fk constraints
 #[cfg(feature = "postgres")]
-pub struct DropTableInOrder<'a, const N:usize> {
+pub struct DropTableInOrder<'a, const N: usize> {
     pub connection: &'a mut TestConnection,
     pub table_names: [&'a str; N],
     pub can_drop: bool,
 }
 
 #[cfg(feature = "postgres")]
-impl<const N:usize> Drop for DropTableInOrder<'_, N> {
+impl<const N: usize> Drop for DropTableInOrder<'_, N> {
     fn drop(&mut self) {
         if self.can_drop {
             for table_name in self.table_names {

--- a/diesel_tests/tests/schema_dsl/functions.rs
+++ b/diesel_tests/tests/schema_dsl/functions.rs
@@ -2,6 +2,10 @@ use diesel::sql_types;
 
 use super::structures::*;
 
+pub fn create_temporary_table<Cols>(name: &str, columns: Cols) -> Temporary<CreateTable<'_, Cols>> {
+    Temporary(CreateTable::new(name, columns))
+}
+
 pub fn create_table<Cols>(name: &str, columns: Cols) -> CreateTable<'_, Cols> {
     CreateTable::new(name, columns)
 }

--- a/diesel_tests/tests/schema_dsl/structures.rs
+++ b/diesel_tests/tests/schema_dsl/structures.rs
@@ -1,7 +1,7 @@
 use diesel::RunQueryDsl;
 use std::marker::PhantomData;
 
-pub struct Temporary<T>(pub(super)T);
+pub struct Temporary<T>(pub(super) T);
 
 pub struct CreateTable<'a, Cols> {
     name: &'a str,

--- a/diesel_tests/tests/schema_dsl/structures.rs
+++ b/diesel_tests/tests/schema_dsl/structures.rs
@@ -1,6 +1,8 @@
 use diesel::RunQueryDsl;
 use std::marker::PhantomData;
 
+pub struct Temporary<T>(pub(super)T);
+
 pub struct CreateTable<'a, Cols> {
     name: &'a str,
     columns: Cols,
@@ -13,6 +15,7 @@ impl<'a, Cols> CreateTable<'a, Cols> {
 }
 
 impl<Cols, Conn> RunQueryDsl<Conn> for CreateTable<'_, Cols> {}
+impl<Cols, Conn> RunQueryDsl<Conn> for Temporary<CreateTable<'_, Cols>> {}
 
 pub struct Column<'a, T> {
     name: &'a str,
@@ -90,7 +93,7 @@ where
 {
     fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         out.unsafe_to_cache_prepared();
-        out.push_sql("CREATE TABLE IF NOT EXISTS ");
+        out.push_sql("CREATE TABLE ");
         out.push_identifier(self.name)?;
         out.push_sql(" (");
         self.columns.walk_ast(out.reborrow())?;
@@ -100,6 +103,28 @@ where
 }
 
 impl<Cols> QueryId for CreateTable<'_, Cols> {
+    type QueryId = ();
+
+    const HAS_STATIC_QUERY_ID: bool = false;
+}
+
+impl<DB, Cols> QueryFragment<DB> for Temporary<CreateTable<'_, Cols>>
+where
+    DB: Backend,
+    Cols: QueryFragment<DB>,
+{
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
+        out.unsafe_to_cache_prepared();
+        out.push_sql("CREATE TEMPORARY TABLE ");
+        out.push_identifier(self.0.name)?;
+        out.push_sql(" (");
+        self.0.columns.walk_ast(out.reborrow())?;
+        out.push_sql(")");
+        Ok(())
+    }
+}
+
+impl<Cols> QueryId for Temporary<CreateTable<'_, Cols>> {
     type QueryId = ();
 
     const HAS_STATIC_QUERY_ID: bool = false;

--- a/diesel_tests/tests/select.rs
+++ b/diesel_tests/tests/select.rs
@@ -1,5 +1,4 @@
 use super::schema::*;
-#[cfg(not(any(feature = "mysql", feature = "mariadb")))]
 use crate::schema_dsl::*;
 use diesel::*;
 
@@ -112,12 +111,11 @@ table! {
 }
 
 #[diesel_test_helper::test]
-#[cfg(not(any(feature = "mysql", feature = "mariadb")))] // FIXME: Figure out how to handle tests that modify schema
 fn selecting_columns_and_tables_with_reserved_names() {
     use self::select::dsl::*;
 
     let connection = &mut connection();
-    create_table(
+    create_temporary_table(
         "select",
         (
             integer("id").primary_key().auto_increment(),
@@ -126,7 +124,11 @@ fn selecting_columns_and_tables_with_reserved_names() {
     )
     .execute(connection)
     .unwrap();
-    diesel::sql_query("INSERT INTO \"select\" (\"join\") VALUES (1), (2), (3)")
+
+    let records = vec![join.eq(1),join.eq(2),join.eq(3)];
+
+    insert_into(select)
+        .values(&records)
         .execute(connection)
         .unwrap();
 
@@ -140,11 +142,9 @@ fn selecting_columns_and_tables_with_reserved_names() {
 }
 
 #[diesel_test_helper::test]
-#[cfg(not(any(feature = "mysql", feature = "mariadb")))] // FIXME: Figure out how to handle tests that modify schema
 fn selecting_columns_with_different_definition_order() {
     let connection = &mut connection();
-    drop_table_cascade(connection, "users");
-    create_table(
+    create_temporary_table(
         "users",
         (
             integer("id").primary_key().auto_increment(),
@@ -224,7 +224,7 @@ table! {
 }
 
 // the test is somehow broken on some mariadb versions
-#[cfg(not(any(feature = "sqlite", feature = "mysql", feature = "mariadb")))]
+#[cfg(not(any(feature = "sqlite", feature = "mariadb")))]
 #[diesel_test_helper::test]
 fn select_for_update_locks_selected_rows() {
     use self::users_select_for_update::dsl::*;
@@ -234,10 +234,10 @@ fn select_for_update_locks_selected_rows() {
     use std::thread;
     use std::time::Duration;
 
+    let conn_ddl = &mut connection_without_transaction();
+    let _guard = DropTable{connection: conn_ddl, table_name: "users_select_for_update", can_drop: true};
+
     let mut conn_1 = connection_without_transaction();
-    diesel::sql_query("DROP TABLE IF EXISTS users_select_for_update")
-        .execute(&mut conn_1)
-        .unwrap();
     create_table(
         "users_select_for_update",
         (
@@ -248,6 +248,7 @@ fn select_for_update_locks_selected_rows() {
     )
     .execute(&mut conn_1)
     .unwrap();
+
     conn_1
         .batch_execute(
             "
@@ -305,16 +306,15 @@ fn select_for_update_locks_selected_rows() {
 fn select_for_update_modifiers() {
     use self::users_select_for_update_modifiers::dsl::*;
 
+    let conn_ddl = &mut connection_without_transaction();
+    let _guard = DropTable{connection: conn_ddl, table_name: "users_select_for_update_modifiers", can_drop: true};
+
     // We need to actually commit some data for the
     // test
     let conn_1 = &mut connection_without_transaction();
     let conn_2 = &mut connection();
     let conn_3 = &mut connection();
 
-    // Recreate the table
-    diesel::sql_query("DROP TABLE IF EXISTS users_select_for_update_modifiers")
-        .execute(conn_1)
-        .unwrap();
     create_table(
         "users_select_for_update_modifiers",
         (
@@ -380,20 +380,15 @@ fn select_for_no_key_update_modifiers() {
     use self::users_fk_for_no_key_update::dsl::*;
     use self::users_select_for_no_key_update::dsl::*;
 
+    let conn_ddl = &mut connection_without_transaction();
+    let _guard = DropTableInOrder{connection: conn_ddl, table_names: ["users_fk_for_no_key_update","users_select_for_no_key_update"], can_drop: true};
+
     // We need to actually commit some data for the
     // test
     let conn_1 = &mut connection_without_transaction();
     let conn_2 = &mut connection();
     let conn_3 = &mut connection();
     let conn_4 = &mut connection();
-
-    // Recreate the table
-    diesel::sql_query("DROP TABLE IF EXISTS users_fk_for_no_key_update")
-        .execute(conn_1)
-        .unwrap();
-    diesel::sql_query("DROP TABLE IF EXISTS users_select_for_no_key_update")
-        .execute(conn_1)
-        .unwrap();
 
     create_table(
         "users_select_for_no_key_update",
@@ -415,6 +410,7 @@ fn select_for_no_key_update_modifiers() {
     )
     .execute(conn_1)
     .unwrap();
+
 
     // Add a foreign key
     diesel::sql_query(

--- a/diesel_tests/tests/select.rs
+++ b/diesel_tests/tests/select.rs
@@ -125,7 +125,7 @@ fn selecting_columns_and_tables_with_reserved_names() {
     .execute(connection)
     .unwrap();
 
-    let records = vec![join.eq(1),join.eq(2),join.eq(3)];
+    let records = vec![join.eq(1), join.eq(2), join.eq(3)];
 
     insert_into(select)
         .values(&records)
@@ -235,7 +235,11 @@ fn select_for_update_locks_selected_rows() {
     use std::time::Duration;
 
     let conn_ddl = &mut connection_without_transaction();
-    let _guard = DropTable{connection: conn_ddl, table_name: "users_select_for_update", can_drop: true};
+    let _guard = DropTable {
+        connection: conn_ddl,
+        table_name: "users_select_for_update",
+        can_drop: true,
+    };
 
     let mut conn_1 = connection_without_transaction();
     create_table(
@@ -307,7 +311,11 @@ fn select_for_update_modifiers() {
     use self::users_select_for_update_modifiers::dsl::*;
 
     let conn_ddl = &mut connection_without_transaction();
-    let _guard = DropTable{connection: conn_ddl, table_name: "users_select_for_update_modifiers", can_drop: true};
+    let _guard = DropTable {
+        connection: conn_ddl,
+        table_name: "users_select_for_update_modifiers",
+        can_drop: true,
+    };
 
     // We need to actually commit some data for the
     // test
@@ -381,7 +389,14 @@ fn select_for_no_key_update_modifiers() {
     use self::users_select_for_no_key_update::dsl::*;
 
     let conn_ddl = &mut connection_without_transaction();
-    let _guard = DropTableInOrder{connection: conn_ddl, table_names: ["users_fk_for_no_key_update","users_select_for_no_key_update"], can_drop: true};
+    let _guard = DropTableInOrder {
+        connection: conn_ddl,
+        table_names: [
+            "users_fk_for_no_key_update",
+            "users_select_for_no_key_update",
+        ],
+        can_drop: true,
+    };
 
     // We need to actually commit some data for the
     // test
@@ -410,7 +425,6 @@ fn select_for_no_key_update_modifiers() {
     )
     .execute(conn_1)
     .unwrap();
-
 
     // Add a foreign key
     diesel::sql_query(

--- a/diesel_tests/tests/select_by.rs
+++ b/diesel_tests/tests/select_by.rs
@@ -50,11 +50,10 @@ table! {
 }
 
 #[diesel_test_helper::test]
-#[cfg(not(any(feature = "mysql", feature = "mariadb")))] // FIXME: Figure out how to handle tests that modify schema
 fn selecting_columns_and_tables_with_reserved_names() {
     use crate::schema_dsl::*;
     let connection = &mut connection();
-    create_table(
+    create_temporary_table(
         "select",
         (
             integer("id").primary_key().auto_increment(),
@@ -63,7 +62,11 @@ fn selecting_columns_and_tables_with_reserved_names() {
     )
     .execute(connection)
     .unwrap();
-    diesel::sql_query("INSERT INTO \"select\" (\"join\") VALUES (1), (2), (3)")
+
+    let records = vec![select::columns::join.eq(1),select::columns::join.eq(2),select::columns::join.eq(3)];
+
+    insert_into(select::table)
+        .values(&records)
         .execute(connection)
         .unwrap();
 
@@ -85,12 +88,10 @@ fn selecting_columns_and_tables_with_reserved_names() {
 }
 
 #[diesel_test_helper::test]
-#[cfg(not(any(feature = "mysql", feature = "mariadb")))] // FIXME: Figure out how to handle tests that modify schema
 fn selecting_columns_with_different_definition_order() {
     use crate::schema_dsl::*;
     let connection = &mut connection();
-    drop_table_cascade(connection, "users");
-    create_table(
+    create_temporary_table(
         "users",
         (
             integer("id").primary_key().auto_increment(),

--- a/diesel_tests/tests/select_by.rs
+++ b/diesel_tests/tests/select_by.rs
@@ -63,7 +63,11 @@ fn selecting_columns_and_tables_with_reserved_names() {
     .execute(connection)
     .unwrap();
 
-    let records = vec![select::columns::join.eq(1),select::columns::join.eq(2),select::columns::join.eq(3)];
+    let records = vec![
+        select::columns::join.eq(1),
+        select::columns::join.eq(2),
+        select::columns::join.eq(3),
+    ];
 
     insert_into(select::table)
         .values(&records)

--- a/diesel_tests/tests/transactions.rs
+++ b/diesel_tests/tests/transactions.rs
@@ -6,9 +6,10 @@ use diesel::*;
 #[cfg(not(feature = "sqlite"))] // FIXME: This test is only valid when operating on a file and not :memory:
 fn transaction_executes_fn_in_a_sql_transaction() {
     const TEST_NAME: &str = "transaction_executes_fn_in_a_sql_transaction";
+    let conn_ddl = &mut connection_without_transaction();
+    let _guard = setup_test_table(conn_ddl, TEST_NAME);
     let conn1 = &mut connection_without_transaction();
     let conn2 = &mut connection_without_transaction();
-    setup_test_table(conn1, TEST_NAME);
 
     fn get_count(conn: &mut TestConnection) -> i64 {
         count_test_table(conn, TEST_NAME)
@@ -18,9 +19,9 @@ fn transaction_executes_fn_in_a_sql_transaction() {
         .transaction::<_, Error, _>(|conn1| {
             assert_eq!(0, get_count(conn1));
             assert_eq!(0, get_count(conn2));
-            #[cfg(not(feature = "mariadb"))]
+            #[cfg(not(any(feature="mysql", feature = "mariadb")))]
             diesel::sql_query(format!("INSERT INTO {TEST_NAME} DEFAULT VALUES")).execute(conn1)?;
-            #[cfg(feature = "mariadb")]
+            #[cfg(any(feature="mysql", feature = "mariadb"))]
             diesel::sql_query(format!("INSERT INTO {TEST_NAME} VALUES (DEFAULT)"))
                 .execute(conn1)?;
             assert_eq!(1, get_count(conn1));
@@ -31,8 +32,6 @@ fn transaction_executes_fn_in_a_sql_transaction() {
 
     assert_eq!(1, get_count(conn1));
     assert_eq!(1, get_count(conn2));
-
-    drop_test_table(conn1, TEST_NAME);
 }
 
 #[diesel_test_helper::test]
@@ -46,22 +45,20 @@ fn transaction_returns_the_returned_value() {
 fn transaction_is_rolled_back_when_returned_an_error() {
     let connection = &mut connection_without_transaction();
     let test_name = "transaction_is_rolled_back_when_returned_an_error";
-    setup_test_table(connection, test_name);
+    setup_temporary_test_table(connection, test_name);
 
     let _ = connection.transaction::<(), _, _>(|connection| {
-        #[cfg(not(feature = "mariadb"))]
+        #[cfg(not(any(feature="mysql", feature = "mariadb")))]
         diesel::sql_query(format!("INSERT INTO {test_name} DEFAULT VALUES"))
             .execute(connection)
             .unwrap();
-        #[cfg(feature = "mariadb")]
+        #[cfg(any(feature="mysql", feature = "mariadb"))]
         diesel::sql_query(format!("INSERT INTO {test_name} VALUES (DEFAULT)"))
             .execute(connection)
             .unwrap();
         Err(Error::RollbackTransaction)
     });
     assert_eq!(0, count_test_table(connection, test_name));
-
-    drop_test_table(connection, test_name);
 }
 
 // This test uses a SQLite3 fact to generate a rollback error,
@@ -80,7 +77,7 @@ fn transaction_is_rolled_back_when_returned_an_error() {
 fn transaction_rollback_returns_error() {
     let connection = &mut connection_without_transaction();
     let test_name = "transaction_rollback_returns_error";
-    setup_test_table(connection, test_name);
+    setup_temporary_test_table(connection, test_name);
 
     // Create a transaction that will fail to rollback.
     let r = connection.transaction::<usize, _, _>(|connection| {
@@ -100,34 +97,33 @@ fn transaction_rollback_returns_error() {
     assert!(matches!(r.unwrap_err(), Error::DatabaseError(_, _)));
 
     assert_eq!(0, count_test_table(connection, test_name));
-    drop_test_table(connection, test_name);
 }
 
 #[diesel_test_helper::test]
 fn transactions_can_be_nested() {
     let connection = &mut connection_without_transaction();
     const TEST_NAME: &str = "transactions_can_be_nested";
-    setup_test_table(connection, TEST_NAME);
+    setup_temporary_test_table(connection, TEST_NAME);
     fn get_count(connection: &mut TestConnection) -> i64 {
         count_test_table(connection, TEST_NAME)
     }
 
     let _ = connection.transaction::<(), _, _>(|connection| {
-        #[cfg(not(feature = "mariadb"))]
+        #[cfg(not(any(feature="mysql", feature = "mariadb")))]
         diesel::sql_query(format!("INSERT INTO {TEST_NAME} DEFAULT VALUES"))
             .execute(connection)
             .unwrap();
-        #[cfg(feature = "mariadb")]
+        #[cfg(any(feature = "mariadb", feature = "mysql"))]
         diesel::sql_query(format!("INSERT INTO {TEST_NAME} VALUES (DEFAULT)"))
             .execute(connection)
             .unwrap();
         assert_eq!(1, get_count(connection));
         let _ = connection.transaction::<(), _, _>(|connection| {
-            #[cfg(not(feature = "mariadb"))]
+            #[cfg(not(any(feature = "mariadb", feature = "mysql")))]
             diesel::sql_query(format!("INSERT INTO {TEST_NAME} DEFAULT VALUES"))
                 .execute(connection)
                 .unwrap();
-            #[cfg(feature = "mariadb")]
+            #[cfg(any(feature = "mariadb", feature = "mysql"))]
             diesel::sql_query(format!("INSERT INTO {TEST_NAME} VALUES (DEFAULT)"))
                 .execute(connection)
                 .unwrap();
@@ -136,11 +132,11 @@ fn transactions_can_be_nested() {
         });
         assert_eq!(1, get_count(connection));
         let _ = connection.transaction::<(), Error, _>(|connection| {
-            #[cfg(not(feature = "mariadb"))]
+            #[cfg(not(any(feature = "mariadb", feature = "mysql")))]
             diesel::sql_query(format!("INSERT INTO {TEST_NAME} DEFAULT VALUES"))
                 .execute(connection)
                 .unwrap();
-            #[cfg(feature = "mariadb")]
+            #[cfg(any(feature = "mariadb", feature = "mysql"))]
             diesel::sql_query(format!("INSERT INTO {TEST_NAME} VALUES (DEFAULT)"))
                 .execute(connection)
                 .unwrap();
@@ -151,20 +147,18 @@ fn transactions_can_be_nested() {
         Err(Error::RollbackTransaction)
     });
     assert_eq!(0, get_count(connection));
-
-    drop_test_table(connection, TEST_NAME);
 }
 
 #[diesel_test_helper::test]
 fn test_transaction_always_rolls_back() {
     let connection = &mut connection_without_transaction();
     let test_name = "test_transaction_always_rolls_back";
-    setup_test_table(connection, test_name);
+    setup_temporary_test_table(connection, test_name);
 
     let result = connection.test_transaction::<_, Error, _>(|connection| {
-        #[cfg(not(feature = "mariadb"))]
+        #[cfg(not(any(feature = "mariadb", feature = "mysql")))]
         diesel::sql_query(format!("INSERT INTO {test_name} DEFAULT VALUES")).execute(connection)?;
-        #[cfg(feature = "mariadb")]
+        #[cfg(any(feature = "mariadb", feature = "mysql"))]
         diesel::sql_query(format!("INSERT INTO {test_name} VALUES (DEFAULT)"))
             .execute(connection)?;
         assert_eq!(1, count_test_table(connection, test_name));
@@ -172,8 +166,6 @@ fn test_transaction_always_rolls_back() {
     });
     assert_eq!(0, count_test_table(connection, test_name));
     assert_eq!("success", result);
-
-    drop_test_table(connection, test_name);
 }
 
 #[diesel_test_helper::test]
@@ -183,17 +175,20 @@ fn test_transaction_panics_on_error() {
     connection.test_transaction::<(), _, _>(|_| Err(()));
 }
 
-fn setup_test_table(connection: &mut TestConnection, table_name: &str) {
+fn setup_temporary_test_table(connection: &mut TestConnection, table_name: &str) {
     use crate::schema_dsl::*;
-    create_table(table_name, (integer("id").primary_key().auto_increment(),))
+    create_temporary_table(table_name, (integer("id").primary_key().auto_increment(),))
         .execute(connection)
         .unwrap();
 }
 
-fn drop_test_table(connection: &mut TestConnection, table_name: &str) {
-    diesel::sql_query(format!("DROP TABLE {table_name}"))
+#[must_use]
+fn setup_test_table<'a>(connection: &'a mut TestConnection, table_name: &'a str) -> DropTable<'a> {
+    use crate::schema_dsl::*;
+    create_table(table_name, (integer("id").primary_key().auto_increment(),))
         .execute(connection)
         .unwrap();
+    DropTable { connection, table_name, can_drop: true }
 }
 
 fn count_test_table(connection: &mut TestConnection, table_name: &str) -> i64 {

--- a/diesel_tests/tests/transactions.rs
+++ b/diesel_tests/tests/transactions.rs
@@ -19,9 +19,9 @@ fn transaction_executes_fn_in_a_sql_transaction() {
         .transaction::<_, Error, _>(|conn1| {
             assert_eq!(0, get_count(conn1));
             assert_eq!(0, get_count(conn2));
-            #[cfg(not(any(feature="mysql", feature = "mariadb")))]
+            #[cfg(not(any(feature = "mysql", feature = "mariadb")))]
             diesel::sql_query(format!("INSERT INTO {TEST_NAME} DEFAULT VALUES")).execute(conn1)?;
-            #[cfg(any(feature="mysql", feature = "mariadb"))]
+            #[cfg(any(feature = "mysql", feature = "mariadb"))]
             diesel::sql_query(format!("INSERT INTO {TEST_NAME} VALUES (DEFAULT)"))
                 .execute(conn1)?;
             assert_eq!(1, get_count(conn1));
@@ -48,11 +48,11 @@ fn transaction_is_rolled_back_when_returned_an_error() {
     setup_temporary_test_table(connection, test_name);
 
     let _ = connection.transaction::<(), _, _>(|connection| {
-        #[cfg(not(any(feature="mysql", feature = "mariadb")))]
+        #[cfg(not(any(feature = "mysql", feature = "mariadb")))]
         diesel::sql_query(format!("INSERT INTO {test_name} DEFAULT VALUES"))
             .execute(connection)
             .unwrap();
-        #[cfg(any(feature="mysql", feature = "mariadb"))]
+        #[cfg(any(feature = "mysql", feature = "mariadb"))]
         diesel::sql_query(format!("INSERT INTO {test_name} VALUES (DEFAULT)"))
             .execute(connection)
             .unwrap();
@@ -109,7 +109,7 @@ fn transactions_can_be_nested() {
     }
 
     let _ = connection.transaction::<(), _, _>(|connection| {
-        #[cfg(not(any(feature="mysql", feature = "mariadb")))]
+        #[cfg(not(any(feature = "mysql", feature = "mariadb")))]
         diesel::sql_query(format!("INSERT INTO {TEST_NAME} DEFAULT VALUES"))
             .execute(connection)
             .unwrap();
@@ -183,12 +183,17 @@ fn setup_temporary_test_table(connection: &mut TestConnection, table_name: &str)
 }
 
 #[must_use]
+#[cfg(not(feature = "sqlite"))]
 fn setup_test_table<'a>(connection: &'a mut TestConnection, table_name: &'a str) -> DropTable<'a> {
     use crate::schema_dsl::*;
     create_table(table_name, (integer("id").primary_key().auto_increment(),))
         .execute(connection)
         .unwrap();
-    DropTable { connection, table_name, can_drop: true }
+    DropTable {
+        connection,
+        table_name,
+        can_drop: true,
+    }
 }
 
 fn count_test_table(connection: &mut TestConnection, table_name: &str) -> i64 {


### PR DESCRIPTION
<!-- 
Please provide a short brief summary description of your change here. 
Also make sure that your code passes all tests and style checks. 
Checkout the `CONTRIBUTING.md` file in the root of the repository for running these checks locally.
It's also fine to use the CI setup for running these tests, but in this case please indicate that your PR 
is not ready for review yet by marking it as DRAFT until it is ready.

If you submit a notable change please ensure to include it into the CHANGELOG.md file in
the root of the repository.

Also make sure to follow the projects guide lines about the usage of LLM's and AI agents as outlined
in the CONTRIBUTING.md file in the root of the repository.
-->

This fixes #661 and enables tests for `mysql` and `mariadb` which where blocked by it.

- [x] I checked for similar changes and make sure to reference them
- [x] I included a changelog entry for relevant new features or changes
