### PR TITLE
Make `diesel-dynamic-schema` `no-std` compatible

### DIFF
--- a/diesel_dynamic_schema/Cargo.toml
+++ b/diesel_dynamic_schema/Cargo.toml
@@ -51,6 +51,7 @@ required-features = ["sqlite"]
 default = []
 postgres = ["diesel/postgres_backend"]
 sqlite = ["diesel/sqlite"]
+sqlite-no-std = ["diesel/sqlite-no-std"]
 mysql = ["diesel/mysql_backend"]
 mariadb = ["diesel/mariadb_backend"]
 

--- a/diesel_dynamic_schema/src/column.rs
+++ b/diesel_dynamic_schema/src/column.rs
@@ -1,10 +1,10 @@
+use core::borrow::Borrow;
+use core::marker::PhantomData;
 use diesel::backend::Backend;
 use diesel::expression::{is_aggregate, TypedExpressionType, ValidGrouping};
 use diesel::prelude::*;
 use diesel::query_builder::*;
 use diesel::query_source::ColumnHasTable;
-use std::borrow::Borrow;
-use std::marker::PhantomData;
 
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 /// A database table column.

--- a/diesel_dynamic_schema/src/dynamic_select.rs
+++ b/diesel_dynamic_schema/src/dynamic_select.rs
@@ -1,10 +1,12 @@
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use core::iter::FromIterator;
+use core::marker::PhantomData;
 use diesel::backend::Backend;
 use diesel::expression::{is_aggregate, NonAggregate, ValidGrouping};
 use diesel::query_builder::{AstPass, QueryFragment, QueryId};
 use diesel::sql_types::Untyped;
 use diesel::{AppearsOnTable, Expression, QueryResult, SelectableExpression};
-use std::iter::FromIterator;
-use std::marker::PhantomData;
 
 /// Represents a dynamically sized select clause
 #[allow(missing_debug_implementations)]
@@ -110,7 +112,7 @@ where
     }
 }
 
-impl<'a, DB, QS, F> std::iter::Extend<F> for DynamicSelectClause<'a, DB, QS>
+impl<'a, DB, QS, F> core::iter::Extend<F> for DynamicSelectClause<'a, DB, QS>
 where
     F: QueryFragment<DB> + SelectableExpression<QS> + NonAggregate + Send + 'a,
     DB: Backend,

--- a/diesel_dynamic_schema/src/dynamic_value.rs
+++ b/diesel_dynamic_schema/src/dynamic_value.rs
@@ -41,7 +41,7 @@
 //! #     }
 //! # }
 //! #
-//! # #[cfg(feature = "sqlite")]
+//! # #[cfg(any(feature = "sqlite", feature = "sqlite-no-std"))]
 //! # impl FromSql<Any, diesel::sqlite::Sqlite> for MyDynamicValue {
 //! #     fn from_sql(value: diesel::sqlite::SqliteValue) -> deserialize::Result<Self> {
 //! #         use diesel::sqlite::{Sqlite, SqliteType};
@@ -163,13 +163,16 @@
 //! }
 //! ```
 
+use alloc::borrow::ToOwned;
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::iter::FromIterator;
+use core::ops::{Index, IndexMut};
 use diesel::backend::Backend;
 use diesel::deserialize::{self, FromSql};
 use diesel::expression::TypedExpressionType;
 use diesel::row::{Field, NamedRow, Row};
 use diesel::QueryableByName;
-use std::iter::FromIterator;
-use std::ops::{Index, IndexMut};
 
 /// A marker type used to indicate that
 /// the provided `FromSql` impl does handle
@@ -186,7 +189,7 @@ impl diesel::expression::QueryMetadata<Any> for diesel::pg::Pg {
     }
 }
 
-#[cfg(feature = "sqlite")]
+#[cfg(any(feature = "sqlite", feature = "sqlite-no-std"))]
 impl diesel::expression::QueryMetadata<Any> for diesel::sqlite::Sqlite {
     fn row_metadata(_lookup: &mut Self::MetadataLookup, out: &mut Vec<Option<Self::TypeMetadata>>) {
         out.push(None)
@@ -405,7 +408,7 @@ where
     }
 }
 
-#[cfg(feature = "sqlite")]
+#[cfg(any(feature = "sqlite", feature = "sqlite-no-std"))]
 impl<I> QueryableByName<diesel::sqlite::Sqlite> for DynamicRow<I>
 where
     I: FromSql<Any, diesel::sqlite::Sqlite>,
@@ -492,7 +495,7 @@ where
     }
 }
 
-#[cfg(feature = "sqlite")]
+#[cfg(any(feature = "sqlite", feature = "sqlite-no-std"))]
 impl<I> QueryableByName<diesel::sqlite::Sqlite> for DynamicRow<NamedField<Option<I>>>
 where
     I: FromSql<Any, diesel::sqlite::Sqlite>,

--- a/diesel_dynamic_schema/src/lib.rs
+++ b/diesel_dynamic_schema/src/lib.rs
@@ -77,6 +77,9 @@
 
 // Built-in Lints
 #![warn(missing_docs)]
+#![no_std]
+
+extern crate alloc;
 
 mod column;
 mod dummy_expression;

--- a/diesel_dynamic_schema/src/schema.rs
+++ b/diesel_dynamic_schema/src/schema.rs
@@ -1,4 +1,5 @@
 use crate::table::Table;
+use alloc::string::String;
 
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 /// A database schema.

--- a/diesel_dynamic_schema/src/table.rs
+++ b/diesel_dynamic_schema/src/table.rs
@@ -1,10 +1,11 @@
+use alloc::string::String;
+use core::borrow::Borrow;
 use diesel::backend::Backend;
 use diesel::expression::expression_types;
 use diesel::internal::table_macro::{FromClause, SelectStatement};
 use diesel::prelude::*;
 use diesel::query_builder::*;
 use diesel::query_source::NamedTable;
-use std::borrow::Borrow;
 
 use crate::column::Column;
 use crate::dummy_expression::*;

--- a/diesel_dynamic_schema/tests/connection_setup.rs
+++ b/diesel_dynamic_schema/tests/connection_setup.rs
@@ -7,7 +7,7 @@ pub fn create_user_table(conn: &mut diesel::PgConnection) {
         .unwrap();
 }
 
-#[cfg(feature = "sqlite")]
+#[cfg(any(feature = "sqlite", feature = "sqlite-no-std"))]
 pub fn create_user_table(conn: &mut diesel::SqliteConnection) {
     use diesel::*;
 
@@ -34,7 +34,7 @@ pub fn create_user_table(conn: &mut diesel::MariadbConnection) {
         .unwrap();
 }
 
-#[cfg(feature = "sqlite")]
+#[cfg(any(feature = "sqlite", feature = "sqlite-no-std"))]
 pub fn establish_connection() -> diesel::SqliteConnection {
     use diesel::*;
 

--- a/diesel_dynamic_schema/tests/dynamic_values.rs
+++ b/diesel_dynamic_schema/tests/dynamic_values.rs
@@ -33,7 +33,7 @@ impl FromSql<Any, diesel::pg::Pg> for MyDynamicValue {
     }
 }
 
-#[cfg(feature = "sqlite")]
+#[cfg(any(feature = "sqlite", feature = "sqlite-no-std"))]
 impl FromSql<Any, diesel::sqlite::Sqlite> for MyDynamicValue {
     fn from_sql(value: diesel::sqlite::SqliteValue) -> Result<Self> {
         use diesel::sqlite::{Sqlite, SqliteType};
@@ -91,7 +91,7 @@ type TestDB = diesel::pg::Pg;
 type TestDB = diesel::mysql::Mysql;
 #[cfg(feature = "mariadb")]
 type TestDB = diesel::mariadb::Mariadb;
-#[cfg(feature = "sqlite")]
+#[cfg(any(feature = "sqlite", feature = "sqlite-no-std"))]
 type TestDB = diesel::sqlite::Sqlite;
 
 #[test]
@@ -99,7 +99,8 @@ type TestDB = diesel::sqlite::Sqlite;
     feature = "postgres",
     feature = "mysql",
     feature = "mariadb",
-    feature = "sqlite"
+    feature = "sqlite",
+    feature = "sqlite-no-std"
 ))]
 fn test_ergonomics() {
     let connection = &mut super::establish_connection();

--- a/diesel_dynamic_schema/tests/lib.rs
+++ b/diesel_dynamic_schema/tests/lib.rs
@@ -17,7 +17,7 @@ type Backend = diesel::pg::Pg;
 type Backend = diesel::mysql::Mysql;
 #[cfg(feature = "mariadb")]
 type Backend = diesel::mariadb::Mariadb;
-#[cfg(feature = "sqlite")]
+#[cfg(any(feature = "sqlite", feature = "sqlite-no-std"))]
 type Backend = diesel::sqlite::Sqlite;
 
 #[test]
@@ -77,7 +77,8 @@ fn columns_used_in_where_clause() {
     feature = "postgres",
     feature = "mysql",
     feature = "mariadb",
-    feature = "sqlite"
+    feature = "sqlite",
+    feature = "sqlite-no-std"
 ))]
 fn providing_custom_schema_name() {
     let table = schema("information_schema").table("users");

--- a/examples/sqlite/embedded/Cargo.toml
+++ b/examples/sqlite/embedded/Cargo.toml
@@ -19,6 +19,7 @@ esp-println = { version = "0.16", features = ["esp32c6"] }
 esp-bootloader-esp-idf = { version = "0.2.0", features = ["esp32c6"] }
 # diesel with the no-std target
 diesel = { version = "2.3.0", path = "../../../diesel/", default-features = false, features = ["sqlite-no-std"] }
+diesel-dynamic-schema = { path = "../../../diesel_dynamic_schema/", default-features = false, features = ["sqlite-no-std"] }
 # libsqlite to have a bundled build for the target
 # This requires additonally
 # * Setting the right config flags LIBSQLITE3_FLAGS="-DSQLITE_SMALL_STACK=1 -DSQLITE_THREADSAFE=0 -DSQLITE_OS_OTHER=1 -DSQLITE_OMIT_LOCALTIME=1 -USQLITE_ENABLE_FTS3 -UQLITE_ENABLE_DBSTAT_VTAB -UDSQLITE_ENABLE_JSON1 -USQLITE_ENABLE_FTS5 -USQLITE_ENABLE_STAT4 -DSQLITE_ENABLE_MEMSYS3=1"

--- a/examples/sqlite/embedded/src/main.rs
+++ b/examples/sqlite/embedded/src/main.rs
@@ -68,15 +68,28 @@ fn main() -> ! {
         .execute(&mut conn)
         .unwrap();
 
+    let users_dynamic = diesel_dynamic_schema::table("users");
+    let dynamic_id = users_dynamic.column::<diesel::sql_types::Integer, _>("id");
+    let dynamic_name = users_dynamic.column::<diesel::sql_types::Text, _>("name");
+
     let delay = Delay::new();
     loop {
         let data = users::table
             .filter(users::name.eq("Jane"))
             .first::<(i32, String)>(&mut conn)
             .unwrap();
+        let dynamic_data = users_dynamic
+            .select((dynamic_id, dynamic_name))
+            .filter(dynamic_name.eq("Jane"))
+            .first::<(i32, String)>(&mut conn)
+            .unwrap();
         println!("----");
         println!("Query data:");
         println!("Loaded user data: {} -> {}", data.0, data.1);
+        println!(
+            "Loaded dynamic user data: {} -> {}",
+            dynamic_data.0, dynamic_data.1
+        );
         println!("---");
         delay.delay_millis(500);
     }


### PR DESCRIPTION
With this PR, also `diesel-dynamic-schema` can has `no_std` SQLite support.

<details>
<img width="500" height="729" alt="image" src="https://github.com/user-attachments/assets/27463e4e-f9aa-4ec1-bd6d-575fbea6c684" />
</details>