### PR TITLE
Allow `diesel_dynamic_schema` runtime columns in `GROUP BY`/ `HAVING`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 * Added support for `RETURNING` to  Mariadb (`UPDATE ... RETURNING` requires Mariadb >= 13)
 * Added support for `VALUES(column)` in Upsert for Mysql and Mariadb
 * Added the `UnsignedTiny`, `UnsignedSmall`, `UnsignedMedium` and `UnsignedBig` variants to `NumericRepresentation` for the MySQL and MariaDB backends
+* `diesel_dynamic_schema` runtime columns can now be used in `GROUP BY` and `HAVING` clauses, including alongside aggregates.
 
 ### Fixed
 

--- a/diesel_dynamic_schema/src/column.rs
+++ b/diesel_dynamic_schema/src/column.rs
@@ -7,8 +7,15 @@ use diesel::query_builder::*;
 use diesel::query_source::ColumnHasTable;
 
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-/// A database table column.
-/// This type is created by the [`column`](crate::Table::column()) function.
+/// A database table column, created by [`Table::column`](crate::Table::column).
+///
+/// # Grouping and aggregate expressions
+///
+/// `ValidGrouping<GB>` holds for any `GB` with `IsAggregate = Never`, so mixing a runtime
+/// column with an aggregate and no `.group_by()` compiles and leaves the verdict to the
+/// server: PostgreSQL rejects it, MySQL rejects it only under
+/// [`ONLY_FULL_GROUP_BY`](https://dev.mysql.com/doc/refman/8.4/en/sql-mode.html#sqlmode_only_full_group_by),
+/// and SQLite answers from an [arbitrary row](https://www.sqlite.org/lang_select.html#bareagg).
 pub struct Column<T, U, ST> {
     table: T,
     name: U,
@@ -51,8 +58,10 @@ where
     type SqlType = ST;
 }
 
-impl<T, U, ST> ValidGrouping<()> for Column<T, U, ST> {
-    type IsAggregate = is_aggregate::No;
+impl<T, U, ST, GB> ValidGrouping<GB> for Column<T, U, ST> {
+    // `Never`, not `No`, because a blanket impl cannot coexist with a narrower
+    // `ValidGrouping<()>`. Costs the mixed-aggregate compile error, see the type docs.
+    type IsAggregate = is_aggregate::Never;
 }
 
 impl<T, U, ST, DB> QueryFragment<DB> for Column<T, U, ST>

--- a/diesel_dynamic_schema/src/dynamic_select.rs
+++ b/diesel_dynamic_schema/src/dynamic_select.rs
@@ -8,7 +8,10 @@ use diesel::query_builder::{AstPass, QueryFragment, QueryId};
 use diesel::sql_types::Untyped;
 use diesel::{AppearsOnTable, Expression, QueryResult, SelectableExpression};
 
-/// Represents a dynamically sized select clause
+/// Represents a dynamically sized select clause.
+///
+/// `ValidGrouping` holds only for the empty group-by clause, so `.group_by()` compiles but
+/// the query will not load. Select [`Column`](crate::Column) values when grouping.
 #[allow(missing_debug_implementations)]
 pub struct DynamicSelectClause<'a, DB, QS> {
     selects: Vec<Box<dyn QueryFragment<DB> + Send + 'a>>,

--- a/diesel_dynamic_schema/tests/lib.rs
+++ b/diesel_dynamic_schema/tests/lib.rs
@@ -93,3 +93,97 @@ fn providing_custom_schema_name() {
     #[cfg(not(feature = "postgres"))]
     assert_eq!("`information_schema`.`users` -- binds: []", sql.to_string());
 }
+
+#[test]
+fn dynamic_group_by_having_filters_groups() {
+    use diesel::dsl::count;
+
+    let conn = &mut establish_connection();
+    create_user_table(conn);
+    sql_query("INSERT INTO users (name) VALUES ('Sean'), ('Sean'), ('Tess')")
+        .execute(conn)
+        .unwrap();
+
+    let users = table("users");
+    let id = users.column::<Integer, _>("id");
+    let name = users.column::<Text, _>("name");
+
+    let counts = users
+        .select((name, count(id)))
+        .group_by(name)
+        .having(count(id).gt(1))
+        .order(name)
+        .load::<(String, i64)>(conn);
+
+    assert_eq!(Ok(vec![("Sean".into(), 2)]), counts);
+}
+
+#[test]
+fn dynamic_group_by_multiple_columns() {
+    use diesel::dsl::count;
+
+    let conn = &mut establish_connection();
+    create_user_table(conn);
+    sql_query(
+        "INSERT INTO users (name, hair_color) VALUES \
+         ('Sean', 'black'), ('Sean', 'black'), ('Sean', 'blonde'), ('Tess', 'red')",
+    )
+    .execute(conn)
+    .unwrap();
+
+    let users = table("users");
+    let id = users.column::<Integer, _>("id");
+    let name = users.column::<Text, _>("name");
+    let hair_color = users.column::<Text, _>("hair_color");
+
+    let counts = users
+        .select((name, hair_color, count(id)))
+        .group_by((name, hair_color))
+        .order((name, hair_color))
+        .load::<(String, String, i64)>(conn);
+
+    assert_eq!(
+        Ok(vec![
+            ("Sean".into(), "black".into(), 2),
+            ("Sean".into(), "blonde".into(), 1),
+            ("Tess".into(), "red".into(), 1),
+        ]),
+        counts
+    );
+}
+
+#[test]
+fn dynamic_group_by_without_aggregate_deduplicates() {
+    let conn = &mut establish_connection();
+    create_user_table(conn);
+    sql_query("INSERT INTO users (name) VALUES ('Sean'), ('Sean'), ('Tess')")
+        .execute(conn)
+        .unwrap();
+
+    let users = table("users");
+    let name = users.column::<Text, _>("name");
+
+    let names = users
+        .select(name)
+        .group_by(name)
+        .order(name)
+        .load::<String>(conn);
+
+    assert_eq!(Ok(vec!["Sean".to_string(), "Tess".to_string()]), names);
+}
+
+#[test]
+fn mixed_aggregate_without_group_by_compiles() {
+    // Used to fail on `No: MixedAggregates<Yes>`, now allowed. See the `Column` docs.
+    use diesel::dsl::count;
+
+    let users = table("users");
+    let id = users.column::<Integer, _>("id");
+    let name = users.column::<Text, _>("name");
+
+    let query = users.select((name, count(id)));
+    // Quoting is backend specific.
+    let sql = diesel::debug_query::<Backend, _>(&query).to_string();
+    assert!(sql.contains("count("), "{}", sql);
+    assert!(!sql.contains("GROUP BY"), "{}", sql);
+}


### PR DESCRIPTION
`diesel_dynamic_schema` runtime columns only implemented `ValidGrouping<()>`, so `.group_by(col)` and `.having(pred)` could not work. This adds a blanket `ValidGrouping<GB>` for `Column` so both clauses work, including grouping by a tuple of runtime columns.

The associated type is `is_aggregate::Never` as a runtime column cannot be checked for membership in the `GROUP BY`.

**I am unsure whether there was any reason for the lack of support, or this was just a missing feature.**