### PR TITLE
Validate `diesel_dynamic_schema` columns against query sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 * Added support for `RETURNING` to  Mariadb (`UPDATE ... RETURNING` requires Mariadb >= 13)
 * Added the `UnsignedTiny`, `UnsignedSmall`, `UnsignedMedium` and `UnsignedBig` variants to `NumericRepresentation` for the MySQL and MariaDB backends
 * Added `DynamicValue` as a default `FromSql<Any, DB>` decoder for runtime-shaped rows on PostgreSQL, SQLite, MySQL, and MariaDB, with optional features for rich scalar types.
+* `diesel_dynamic_schema` runtime columns can now be used in `GROUP BY` and `HAVING` clauses, including alongside aggregates.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 * Added the `UnsignedTiny`, `UnsignedSmall`, `UnsignedMedium` and `UnsignedBig` variants to `NumericRepresentation` for the MySQL and MariaDB backends
 * Added `DynamicValue` as a default `FromSql<Any, DB>` decoder for runtime-shaped rows on PostgreSQL, SQLite, MySQL, and MariaDB, with optional features for rich scalar types.
 * `diesel_dynamic_schema` runtime columns can now be used in `GROUP BY` and `HAVING` clauses, including alongside aggregates.
+* `diesel_dynamic_schema` now rejects runtime columns whose table is absent from the query.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 * Added `SqliteConnection::wal_checkpoint` to checkpoint the write-ahead log through the typed `WalCheckpointMode` enum, returning a `WalCheckpointOutcome` with the busy flag and frame counts, and accepting an optional schema name where `None` checkpoints every attached database.
 * Added support for `RETURNING` to  Mariadb (`UPDATE ... RETURNING` requires Mariadb >= 13)
 * Added the `UnsignedTiny`, `UnsignedSmall`, `UnsignedMedium` and `UnsignedBig` variants to `NumericRepresentation` for the MySQL and MariaDB backends
+* Added `DynamicValue` as a default `FromSql<Any, DB>` decoder for runtime-shaped rows on PostgreSQL, SQLite, MySQL, and MariaDB, with optional features for rich scalar types.
 
 ### Fixed
 

--- a/diesel/src/internal/derives.rs
+++ b/diesel/src/internal/derives.rs
@@ -72,6 +72,9 @@ pub mod multiconnection {
     pub use crate::query_builder::offset_clause::{NoOffsetClause, OffsetClause};
 
     #[doc(hidden)]
+    pub use crate::query_builder::from_clause::FromClauseMembership;
+
+    #[doc(hidden)]
     pub use crate::query_builder::select_statement::boxed::BoxedQueryHelper;
 
     #[doc(hidden)]

--- a/diesel/src/query_builder/ast_pass.rs
+++ b/diesel/src/query_builder/ast_pass.rs
@@ -1,5 +1,6 @@
 use crate::backend::Backend;
 use crate::query_builder::{BindCollector, MoveableBindCollector, QueryBuilder};
+use crate::query_source::DynQuerySource;
 use crate::result::QueryResult;
 use crate::serialize::ToSql;
 use crate::sql_types::HasSqlType;
@@ -31,6 +32,7 @@ where
 {
     internals: AstPassInternals<'a, 'b, DB>,
     backend: &'b DB,
+    query_source: StatementContext<'a>,
 }
 
 impl<'a, 'b, DB> AstPass<'a, 'b, DB>
@@ -46,6 +48,7 @@ where
         AstPass {
             internals: AstPassInternals::ToSql(query_builder, options),
             backend,
+            query_source: StatementContext::None,
         }
     }
 
@@ -60,6 +63,7 @@ where
                 metadata_lookup,
             },
             backend,
+            query_source: StatementContext::None,
         }
     }
 
@@ -67,6 +71,7 @@ where
         AstPass {
             internals: AstPassInternals::IsSafeToCachePrepared(result),
             backend,
+            query_source: StatementContext::None,
         }
     }
 
@@ -77,6 +82,7 @@ where
         AstPass {
             internals: AstPassInternals::DebugBinds(formatter),
             backend,
+            query_source: StatementContext::None,
         }
     }
 
@@ -88,6 +94,7 @@ where
         AstPass {
             internals: AstPassInternals::IsNoop(result),
             backend,
+            query_source: StatementContext::None,
         }
     }
 
@@ -137,7 +144,54 @@ where
         AstPass {
             internals,
             backend: self.backend,
+            query_source: self.query_source,
         }
+    }
+
+    pub(crate) fn query_source_frame(
+        &self,
+        source: &'a dyn DynQuerySource,
+        correlatable: bool,
+    ) -> QuerySourceFrame<'a> {
+        QuerySourceFrame {
+            source,
+            correlatable,
+            parent: self.query_source,
+        }
+    }
+
+    pub(crate) fn push_query_source<'c>(
+        &'c mut self,
+        frame: &'c QuerySourceFrame<'c>,
+    ) -> AstPass<'c, 'b, DB> {
+        let mut pass = self.reborrow();
+        pass.query_source = StatementContext::Active(frame);
+        pass
+    }
+
+    /// Reports membership in the current statement or a correlatable outer statement.
+    #[doc(hidden)]
+    pub fn dynamic_table_membership(
+        &self,
+        schema: Option<&str>,
+        table: &str,
+    ) -> DynamicTableMembership {
+        let head = match self.query_source {
+            StatementContext::None => return DynamicTableMembership::NoStatementContext,
+            StatementContext::Active(frame) => frame,
+        };
+        if head.source.contains_runtime_table(schema, table) {
+            return DynamicTableMembership::Present;
+        }
+        let mut context = head.parent;
+        while let StatementContext::Active(frame) = context {
+            // Non-correlatable frames do not match or stop traversal.
+            if frame.correlatable && frame.source.contains_runtime_table(schema, table) {
+                return DynamicTableMembership::Present;
+            }
+            context = frame.parent;
+        }
+        DynamicTableMembership::Absent
     }
 
     /// Mark the current query being constructed as unsafe to store in the
@@ -343,6 +397,28 @@ where
     IsNoop(&'a mut bool),
 }
 
+#[derive(Clone, Copy)]
+enum StatementContext<'a> {
+    None,
+    Active(&'a QuerySourceFrame<'a>),
+}
+
+/// Linked frame that keeps nested statements allocation-free.
+pub(crate) struct QuerySourceFrame<'a> {
+    source: &'a dyn DynQuerySource,
+    /// Insert targets are not visible to nested selects.
+    correlatable: bool,
+    parent: StatementContext<'a>,
+}
+
+#[doc(hidden)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DynamicTableMembership {
+    NoStatementContext,
+    Present,
+    Absent,
+}
+
 #[diesel_derives::__diesel_public_if(
     feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
 )]
@@ -438,6 +514,7 @@ where
         AstPass {
             internals: casted_pass,
             backend: convert_backend(self.backend),
+            query_source: self.query_source,
         }
     }
 

--- a/diesel/src/query_builder/delete_statement/mod.rs
+++ b/diesel/src/query_builder/delete_statement/mod.rs
@@ -1,6 +1,7 @@
 use crate::backend::DieselReserveSpecialization;
 use crate::dsl::{Filter, IntoBoxed, IntoBoxedClone, OrFilter};
 use crate::expression::{AppearsOnTable, Expression, SelectableExpression};
+use crate::query_builder::from_clause::AsQuerySource;
 use crate::query_builder::returning::{
     DeleteStmt, NoReturningClause, ReturningClause, ReturningQuerySource,
 };
@@ -331,6 +332,8 @@ where
     Ret: QueryFragment<DB>,
 {
     fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
+        let frame = out.query_source_frame(self.from_clause.as_query_source(), true);
+        let mut out = out.push_query_source(&frame);
         out.push_sql("DELETE");
         self.from_clause.walk_ast(out.reborrow())?;
         self.where_clause.walk_ast(out.reborrow())?;

--- a/diesel/src/query_builder/from_clause.rs
+++ b/diesel/src/query_builder/from_clause.rs
@@ -1,6 +1,6 @@
 use super::{AstPass, QueryFragment, QueryId};
 use crate::backend::Backend;
-use crate::query_source::AppearsInFromClause;
+use crate::query_source::{AppearsInFromClause, DynQuerySource};
 use crate::{QueryResult, QuerySource};
 
 /// This type represents a not existing from clause
@@ -138,4 +138,33 @@ where
     QS2: AppearsInFromClause<QS1>,
 {
     type Count = <QS2 as AppearsInFromClause<QS1>>::Count;
+}
+
+/// Exposes the runtime-membership source for a select's from clause.
+#[doc(hidden)]
+pub trait FromClauseMembership {
+    fn dyn_query_source(&self) -> &dyn DynQuerySource;
+}
+
+impl<F: QuerySource> FromClauseMembership for FromClause<F> {
+    fn dyn_query_source(&self) -> &dyn DynQuerySource {
+        &self.source
+    }
+}
+
+/// Rejects dynamic columns in a root `NoFromClause`.
+struct NullQuerySource;
+
+impl DynQuerySource for NullQuerySource {
+    fn contains_runtime_table(&self, _schema: Option<&str>, _table: &str) -> bool {
+        false
+    }
+}
+
+static NULL_QUERY_SOURCE: NullQuerySource = NullQuerySource;
+
+impl FromClauseMembership for NoFromClause {
+    fn dyn_query_source(&self) -> &dyn DynQuerySource {
+        &NULL_QUERY_SOURCE
+    }
 }

--- a/diesel/src/query_builder/insert_statement/insert_with_default_for_sqlite.rs
+++ b/diesel/src/query_builder/insert_statement/insert_with_default_for_sqlite.rs
@@ -115,7 +115,7 @@ where
         // explicit destruct to make sure we use all  the fields
         let InsertStatement {
             operator,
-            target: _,
+            target,
             records,
             returning,
             into_clause,
@@ -136,6 +136,7 @@ where
         let ast_pass = AstPass::debug_binds(&mut buffer, &Sqlite);
         super::insert_statement::walk_ast_intern::<T, _, _, _, Sqlite>(
             ast_pass,
+            target,
             records,
             into_clause,
             operator,
@@ -147,6 +148,7 @@ where
         let sql_pass = AstPass::to_sql(&mut query_builder, &mut ast_pass_to_sql_options, &Sqlite);
         super::insert_statement::walk_ast_intern::<T, _, _, _, Sqlite>(
             sql_pass,
+            target,
             records,
             into_clause,
             operator,

--- a/diesel/src/query_builder/insert_statement/mod.rs
+++ b/diesel/src/query_builder/insert_statement/mod.rs
@@ -235,6 +235,7 @@ impl<T: QuerySource, U, C, Op, Ret> InsertStatement<T, InsertFromSelect<U, C>, O
 // slightly adjusted types
 pub(super) fn walk_ast_intern<'b, T, U, Op, Ret, DB>(
     mut out: AstPass<'_, 'b, DB>,
+    target: &'b T,
     records: &'b U,
     into_clause: &'b T::FromClause,
     operator: &'b Op,
@@ -248,6 +249,9 @@ where
     Op: QueryFragment<DB>,
     Ret: QueryFragment<DB>,
 {
+    // Insert targets are not visible to nested selects.
+    let frame = out.query_source_frame(target, false);
+    let mut out = out.push_query_source(&frame);
     if records.rows_to_insert() == Some(0) {
         out.push_sql("SELECT 1 FROM ");
         into_clause.walk_ast(out.reborrow())?;
@@ -276,6 +280,7 @@ where
     fn walk_ast<'b>(&'b self, out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         walk_ast_intern::<T, U, Op, Ret, DB>(
             out,
+            &self.target,
             &self.records,
             &self.into_clause,
             &self.operator,

--- a/diesel/src/query_builder/mod.rs
+++ b/diesel/src/query_builder/mod.rs
@@ -36,6 +36,8 @@ pub(crate) mod where_clause;
 
 #[doc(inline)]
 pub use self::ast_pass::AstPass;
+#[doc(hidden)]
+pub use self::ast_pass::DynamicTableMembership;
 #[doc(inline)]
 pub use self::bind_collector::{BindCollector, MoveableBindCollector};
 #[doc(inline)]

--- a/diesel/src/query_builder/select_statement/boxed.rs
+++ b/diesel/src/query_builder/select_statement/boxed.rs
@@ -7,6 +7,7 @@ use crate::expression::*;
 use crate::insertable::Insertable;
 use crate::query_builder::combination_clause::*;
 use crate::query_builder::distinct_clause::DistinctClause;
+use crate::query_builder::from_clause::FromClauseMembership;
 use crate::query_builder::group_by_clause::ValidGroupByClause;
 use crate::query_builder::having_clause::HavingClause;
 use crate::query_builder::insert_statement::InsertFromSelect;
@@ -144,7 +145,7 @@ pub trait BoxedQueryHelper<'a, QS, DB> {
     ) -> QueryResult<()>
     where
         DB: Backend,
-        QS: QueryFragment<DB>,
+        QS: QueryFragment<DB> + FromClauseMembership,
         BoxedLimitOffsetClause<'a, DB>: QueryFragment<DB>,
         'b: 'c;
 }
@@ -160,10 +161,12 @@ impl<'a, ST, QS, DB, GB> BoxedQueryHelper<'a, QS, DB> for BoxedSelectStatement<'
     ) -> QueryResult<()>
     where
         DB: Backend,
-        QS: QueryFragment<DB>,
+        QS: QueryFragment<DB> + FromClauseMembership,
         BoxedLimitOffsetClause<'a, DB>: QueryFragment<DB>,
         'b: 'c,
     {
+        let frame = out.query_source_frame(self.from.dyn_query_source(), true);
+        let mut out = out.push_query_source(&frame);
         out.push_sql("SELECT ");
         self.distinct.walk_ast(out.reborrow())?;
         self.select.walk_ast(out.reborrow())?;
@@ -217,7 +220,7 @@ where
     DB: Backend<
             SelectStatementSyntax = sql_dialect::select_statement_syntax::AnsiSqlSelectStatement,
         > + DieselReserveSpecialization,
-    QS: QueryFragment<DB>,
+    QS: QueryFragment<DB> + FromClauseMembership,
     BoxedLimitOffsetClause<'a, DB>: QueryFragment<DB>,
 {
     fn walk_ast<'b>(&'b self, out: AstPass<'_, 'b, DB>) -> QueryResult<()> {

--- a/diesel/src/query_builder/select_statement/boxed_clone.rs
+++ b/diesel/src/query_builder/select_statement/boxed_clone.rs
@@ -7,6 +7,7 @@ use crate::expression::*;
 use crate::insertable::Insertable;
 use crate::query_builder::combination_clause::*;
 use crate::query_builder::distinct_clause::DistinctClause;
+use crate::query_builder::from_clause::FromClauseMembership;
 use crate::query_builder::group_by_clause::ValidGroupByClause;
 use crate::query_builder::having_clause::HavingClause;
 use crate::query_builder::insert_statement::InsertFromSelect;
@@ -163,7 +164,7 @@ pub trait BoxedCloneQueryHelper<'a, QS, DB> {
     ) -> QueryResult<()>
     where
         DB: Backend,
-        QS: QueryFragment<DB>,
+        QS: QueryFragment<DB> + FromClauseMembership,
         BoxedCloneLimitOffsetClause<'a, DB>: QueryFragment<DB>,
         'b: 'c;
 }
@@ -181,10 +182,12 @@ impl<'a, ST, QS, DB, GB> BoxedCloneQueryHelper<'a, QS, DB>
     ) -> QueryResult<()>
     where
         DB: Backend,
-        QS: QueryFragment<DB>,
+        QS: QueryFragment<DB> + FromClauseMembership,
         BoxedCloneLimitOffsetClause<'a, DB>: QueryFragment<DB>,
         'b: 'c,
     {
+        let frame = out.query_source_frame(self.from.dyn_query_source(), true);
+        let mut out = out.push_query_source(&frame);
         out.push_sql("SELECT ");
         self.distinct.walk_ast(out.reborrow())?;
         self.select.walk_ast(out.reborrow())?;
@@ -238,7 +241,7 @@ where
     DB: Backend<
             SelectStatementSyntax = sql_dialect::select_statement_syntax::AnsiSqlSelectStatement,
         > + DieselReserveSpecialization,
-    QS: QueryFragment<DB>,
+    QS: QueryFragment<DB> + FromClauseMembership,
     BoxedCloneLimitOffsetClause<'a, DB>: QueryFragment<DB>,
 {
     fn walk_ast<'b>(&'b self, out: AstPass<'_, 'b, DB>) -> QueryResult<()> {

--- a/diesel/src/query_builder/select_statement/mod.rs
+++ b/diesel/src/query_builder/select_statement/mod.rs
@@ -26,7 +26,7 @@ pub(crate) use self::boxed_clone::BoxedCloneSelectStatement;
 use super::NoFromClause;
 use super::distinct_clause::NoDistinctClause;
 use super::from_clause::AsQuerySource;
-use super::from_clause::FromClause;
+use super::from_clause::{FromClause, FromClauseMembership};
 use super::group_by_clause::*;
 use super::limit_clause::NoLimitClause;
 use super::locking_clause::NoLockingClause;
@@ -277,7 +277,7 @@ where
         SelectStatementSyntax = sql_dialect::select_statement_syntax::AnsiSqlSelectStatement,
     >,
     S: QueryFragment<DB>,
-    F: QueryFragment<DB>,
+    F: QueryFragment<DB> + FromClauseMembership,
     D: QueryFragment<DB>,
     W: QueryFragment<DB>,
     O: QueryFragment<DB>,
@@ -287,6 +287,8 @@ where
     LC: QueryFragment<DB>,
 {
     fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
+        let frame = out.query_source_frame(self.from.dyn_query_source(), true);
+        let mut out = out.push_query_source(&frame);
         out.push_sql("SELECT ");
         self.distinct.walk_ast(out.reborrow())?;
         self.select.walk_ast(out.reborrow())?;

--- a/diesel/src/query_builder/update_statement/mod.rs
+++ b/diesel/src/query_builder/update_statement/mod.rs
@@ -10,6 +10,7 @@ use crate::dsl::{Filter, IntoBoxed, IntoBoxedClone};
 use crate::expression::{
     AppearsOnTable, Expression, MixedAggregates, SelectableExpression, ValidGrouping, is_aggregate,
 };
+use crate::query_builder::from_clause::AsQuerySource;
 use crate::query_builder::returning::{
     NoReturningClause, ReturningClause, ReturningQuerySource, UpdateStmt,
 };
@@ -26,7 +27,7 @@ pub(crate) use self::private::SetAutoTypeHelper;
 impl<T: QuerySource, U> UpdateStatement<T, U, SetNotCalled> {
     pub(crate) fn new(target: UpdateTarget<T, U>) -> Self {
         UpdateStatement {
-            from_clause: target.table.from_clause(),
+            from_clause: FromClause::new(target.table),
             where_clause: target.where_clause,
             set_clause: SetClause::Immediate,
             values: SetNotCalled,
@@ -55,7 +56,6 @@ impl<T: QuerySource, U> UpdateStatement<T, U, SetNotCalled> {
     }
 }
 
-#[derive(Clone, Debug)]
 #[must_use = "Queries are only executed when calling `load`, `get_result` or similar."]
 /// Represents a complete `UPDATE` statement.
 ///
@@ -63,11 +63,49 @@ impl<T: QuerySource, U> UpdateStatement<T, U, SetNotCalled> {
 /// guide](https://diesel.rs/guides/all-about-updates/) for a more exhaustive
 /// set of examples.
 pub struct UpdateStatement<T: QuerySource, U, V = SetNotCalled, Ret = NoReturningClause> {
-    from_clause: T::FromClause,
+    from_clause: FromClause<T>,
     where_clause: U,
     set_clause: SetClause,
     values: V,
     returning: Ret,
+}
+
+impl<T, U, V, Ret> Clone for UpdateStatement<T, U, V, Ret>
+where
+    T: QuerySource + Clone,
+    T::FromClause: Clone,
+    U: Clone,
+    V: Clone,
+    Ret: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            from_clause: self.from_clause.clone(),
+            where_clause: self.where_clause.clone(),
+            set_clause: self.set_clause,
+            values: self.values.clone(),
+            returning: self.returning.clone(),
+        }
+    }
+}
+
+impl<T, U, V, Ret> core::fmt::Debug for UpdateStatement<T, U, V, Ret>
+where
+    T: QuerySource,
+    T::FromClause: core::fmt::Debug,
+    U: core::fmt::Debug,
+    V: core::fmt::Debug,
+    Ret: core::fmt::Debug,
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("UpdateStatement")
+            .field("from_clause", &self.from_clause.from_clause)
+            .field("where_clause", &self.where_clause)
+            .field("set_clause", &self.set_clause)
+            .field("values", &self.values)
+            .field("returning", &self.returning)
+            .finish()
+    }
 }
 
 /// An `UPDATE` statement with a boxed `WHERE` clause.
@@ -284,9 +322,11 @@ where
             return Err(QueryBuilderError(Box::new(EmptyChangeset)));
         }
 
+        let frame = out.query_source_frame(self.from_clause.as_query_source(), true);
+        let mut out = out.push_query_source(&frame);
         out.unsafe_to_cache_prepared();
         out.push_sql("UPDATE ");
-        self.from_clause.walk_ast(out.reborrow())?;
+        self.from_clause.from_clause.walk_ast(out.reborrow())?;
         self.set_clause.walk_ast(out.reborrow())?;
         self.values.walk_ast(out.reborrow())?;
         self.where_clause.walk_ast(out.reborrow())?;

--- a/diesel/src/query_source/joins.rs
+++ b/diesel/src/query_source/joins.rs
@@ -128,6 +128,11 @@ where
                 .append_selection(self.right.source.default_selection()),
         )
     }
+
+    fn contains_runtime_table(&self, schema: Option<&str>, table: &str) -> bool {
+        self.left.source.contains_runtime_table(schema, table)
+            || self.right.source.contains_runtime_table(schema, table)
+    }
 }
 
 impl<Left, Right> QuerySource for Join<Left, Right, LeftOuter>
@@ -157,6 +162,11 @@ where
                 .source
                 .append_selection(self.right.source.default_selection().nullable()),
         )
+    }
+
+    fn contains_runtime_table(&self, schema: Option<&str>, table: &str) -> bool {
+        self.left.source.contains_runtime_table(schema, table)
+            || self.right.source.contains_runtime_table(schema, table)
     }
 }
 
@@ -189,6 +199,10 @@ where
 
     fn default_selection(&self) -> Self::DefaultSelection {
         self.join.default_selection()
+    }
+
+    fn contains_runtime_table(&self, schema: Option<&str>, table: &str) -> bool {
+        self.join.contains_runtime_table(schema, table)
     }
 }
 

--- a/diesel/src/query_source/mod.rs
+++ b/diesel/src/query_source/mod.rs
@@ -40,6 +40,26 @@ pub trait QuerySource {
     /// select clause was explicitly specified. This should always be a tuple of
     /// all the desired columns, not `star`
     fn default_selection(&self) -> Self::DefaultSelection;
+
+    /// Static query sources return `false`, while dynamic sources override this.
+    #[doc(hidden)]
+    fn contains_runtime_table(&self, schema: Option<&str>, table: &str) -> bool {
+        let _ = (schema, table);
+        false
+    }
+}
+
+/// Object-safe [`QuerySource::contains_runtime_table`] for the
+/// [`AstPass`](crate::query_builder::AstPass) query-source stack.
+#[doc(hidden)]
+pub trait DynQuerySource {
+    fn contains_runtime_table(&self, schema: Option<&str>, table: &str) -> bool;
+}
+
+impl<QS: QuerySource> DynQuerySource for QS {
+    fn contains_runtime_table(&self, schema: Option<&str>, table: &str) -> bool {
+        <QS as QuerySource>::contains_runtime_table(self, schema, table)
+    }
 }
 
 /// A column on a database table. Types which implement this trait should have

--- a/diesel/src/sqlite/query_builder/query_fragment_impls.rs
+++ b/diesel/src/sqlite/query_builder/query_fragment_impls.rs
@@ -28,7 +28,8 @@ impl<'a, ST, QS, GB> QueryFragment<crate::sqlite::Sqlite>
 where
     BoxedSelectStatement<'a, ST, QS, crate::sqlite::Sqlite, GB>:
         QueryFragment<crate::sqlite::Sqlite>,
-    QS: QueryFragment<crate::sqlite::Sqlite>,
+    QS: QueryFragment<crate::sqlite::Sqlite>
+        + crate::query_builder::from_clause::FromClauseMembership,
 {
     fn walk_ast<'b>(&'b self, pass: AstPass<'_, 'b, crate::sqlite::Sqlite>) -> QueryResult<()> {
         // https://www.sqlite.org/lang_UPSERT.html (Parsing Ambiguity)

--- a/diesel_compile_tests/tests/fail/insert_from_select_with_on_conflict_without_where_clause_not_supported_on_sqlite.stderr
+++ b/diesel_compile_tests/tests/fail/insert_from_select_with_on_conflict_without_where_clause_not_supported_on_sqlite.stderr
@@ -22,8 +22,9 @@ help: the following other types implement trait `QueryFragment<DB, SP>`
   LL | | where
   LL | |     BoxedSelectStatement<'a, ST, QS, crate::sqlite::Sqlite, GB>:
   LL | |         QueryFragment<crate::sqlite::Sqlite>,
-  LL | |     QS: QueryFragment<crate::sqlite::Sqlite>,
-     | |_____________________________________________^ `OnConflictSelectWrapper<...>`
+  LL | |     QS: QueryFragment<crate::sqlite::Sqlite>
+  LL | |         + crate::query_builder::from_clause::FromClauseMembership,
+     | |__________________________________________________________________^ `OnConflictSelectWrapper<...>`
      = note: required for `InsertFromSelect<..., ...>` to implement `QueryFragment<Sqlite>`
      = note: 3 redundant requirements hidden
      = note: required for `InsertStatement<table, ...>` to implement `QueryFragment<Sqlite>`

--- a/diesel_compile_tests/tests/fail/only_only_on_table.stderr
+++ b/diesel_compile_tests/tests/fail/only_only_on_table.stderr
@@ -49,29 +49,29 @@ LL | | )]
 
    
 error[E0599]: the method `only` exists for struct `columns::id`, but its trait bounds were not satisfied
-  --> tests/fail/only_only_on_table.rs:17:31
-   |
- LL |         id -> Int8,
-   |         -- method `only` not found for this struct because it doesn't satisfy `columns::id: Table` or `columns::id: diesel::dsl::OnlyDsl`
+   --> tests/fail/only_only_on_table.rs:17:31
+    |
+  LL |         id -> Int8,
+    |         -- method `only` not found for this struct because it doesn't satisfy `columns::id: Table` or `columns::id: diesel::dsl::OnlyDsl`
 ...
-LL |     foo::table.select(foo::id.only());
-   |                               ^^^^ method cannot be called on `columns::id` due to unsatisfied trait bounds
-   |
-   = note: the following trait bounds were not satisfied:
-           `columns::id: Table`
-           which is required by `columns::id: diesel::dsl::OnlyDsl`
-           `&columns::id: Table`
-           which is required by `&columns::id: diesel::dsl::OnlyDsl`
-           `&mut columns::id: Table`
-           which is required by `&mut columns::id: diesel::dsl::OnlyDsl`
+ LL |     foo::table.select(foo::id.only());
+    |                               ^^^^ method cannot be called on `columns::id` due to unsatisfied trait bounds
+    |
+    = note: the following trait bounds were not satisfied:
+            `columns::id: Table`
+            which is required by `columns::id: diesel::dsl::OnlyDsl`
+            `&columns::id: Table`
+            which is required by `&columns::id: diesel::dsl::OnlyDsl`
+            `&mut columns::id: Table`
+            which is required by `&mut columns::id: diesel::dsl::OnlyDsl`
 note: the trait `Table` must be implemented
-  --> DIESEL/diesel/diesel/src/query_source/mod.rs
-   |
+   --> DIESEL/diesel/diesel/src/query_source/mod.rs
+    |
 LL | pub trait Table: QuerySource + AsQuery + Sized {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = help: items from traits can only be used if the trait is implemented and in scope
-   = note: the following trait defines an item `only`, perhaps you need to implement it:
-           candidate #1: `diesel::dsl::OnlyDsl`
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    = help: items from traits can only be used if the trait is implemented and in scope
+    = note: the following trait defines an item `only`, perhaps you need to implement it:
+            candidate #1: `diesel::dsl::OnlyDsl`
 
 error[E0277]: the trait bound `Only<foo::table>: LoadQuery<'_, diesel::SqliteConnection, _>` is not satisfied
     --> tests/fail/only_only_on_table.rs:22:28

--- a/diesel_derives/src/multiconnection.rs
+++ b/diesel_derives/src/multiconnection.rs
@@ -1718,6 +1718,7 @@ fn generate_querybuilder(
             >
         where
             QS: diesel::query_builder::QueryFragment<super::backend::MultiBackend>
+                + diesel::internal::derives::multiconnection::FromClauseMembership
         {
             fn walk_ast<'b>(
                 &'b self,
@@ -1813,6 +1814,7 @@ fn generate_querybuilder(
             >
         where
             QS: diesel::query_builder::QueryFragment<super::backend::MultiBackend>
+                + diesel::internal::derives::multiconnection::FromClauseMembership
         {
             fn walk_ast<'b>(
                 &'b self,

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__multiconnection_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__multiconnection_1.snap
@@ -708,7 +708,8 @@ mod multi_connection_impl {
             GB,
         >
         where
-            QS: diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
+            QS: diesel::query_builder::QueryFragment<super::backend::MultiBackend>
+                + diesel::internal::derives::multiconnection::FromClauseMembership,
         {
             fn walk_ast<'b>(
                 &'b self,
@@ -863,7 +864,8 @@ mod multi_connection_impl {
             GB,
         >
         where
-            QS: diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
+            QS: diesel::query_builder::QueryFragment<super::backend::MultiBackend>
+                + diesel::internal::derives::multiconnection::FromClauseMembership,
         {
             fn walk_ast<'b>(
                 &'b self,

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__multiconnection_2.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__multiconnection_2.snap
@@ -710,7 +710,8 @@ mod multi_connection_impl {
             GB,
         >
         where
-            QS: diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
+            QS: diesel::query_builder::QueryFragment<super::backend::MultiBackend>
+                + diesel::internal::derives::multiconnection::FromClauseMembership,
         {
             fn walk_ast<'b>(
                 &'b self,
@@ -865,7 +866,8 @@ mod multi_connection_impl {
             GB,
         >
         where
-            QS: diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
+            QS: diesel::query_builder::QueryFragment<super::backend::MultiBackend>
+                + diesel::internal::derives::multiconnection::FromClauseMembership,
         {
             fn walk_ast<'b>(
                 &'b self,

--- a/diesel_dynamic_schema/Cargo.toml
+++ b/diesel_dynamic_schema/Cargo.toml
@@ -18,6 +18,13 @@ version = "~2.3.0"
 path = "../diesel/"
 default-features = false
 
+[dependencies]
+thiserror = { version = "2.0.0", default-features = false }
+chrono = { version = "0.4.20", optional = true, default-features = false }
+bigdecimal = { version = ">=0.0.13, < 0.5.0", optional = true }
+uuid = { version = ">=0.7.0, <2.0.0", optional = true }
+serde_json = { version = ">=0.8.0, <2.0", optional = true, default-features = false, features = ["alloc"] }
+
 [dev-dependencies]
 dotenvy = "0.15"
 
@@ -54,6 +61,10 @@ sqlite = ["diesel/sqlite"]
 sqlite-no-std = ["diesel/sqlite-no-std"]
 mysql = ["diesel/mysql_backend"]
 mariadb = ["diesel/mariadb_backend"]
+chrono = ["dep:chrono", "diesel/chrono"]
+numeric = ["dep:bigdecimal", "diesel/numeric"]
+uuid = ["dep:uuid", "diesel/uuid"]
+serde_json = ["dep:serde_json", "diesel/serde_json"]
 
 [lints]
 workspace = true

--- a/diesel_dynamic_schema/src/column.rs
+++ b/diesel_dynamic_schema/src/column.rs
@@ -59,11 +59,21 @@ impl<T, U, ST, GB> ValidGrouping<GB> for Column<T, U, ST> {
 impl<T, U, ST, DB> QueryFragment<DB> for Column<T, U, ST>
 where
     DB: Backend,
-    T: QueryFragment<DB>,
+    T: QueryFragment<DB> + diesel::query_source::NamedTable,
     U: Borrow<str>,
 {
     fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
         out.unsafe_to_cache_prepared();
+        let schema = diesel::query_source::NamedTable::schema(&self.table);
+        let table = diesel::query_source::NamedTable::table(&self.table);
+        if out.dynamic_table_membership(schema, table) == DynamicTableMembership::Absent {
+            return Err(diesel::result::Error::QueryBuilderError(
+                alloc::boxed::Box::new(crate::DynamicSchemaError::ForeignTable {
+                    schema: schema.map(Into::into),
+                    table: table.into(),
+                }),
+            ));
+        }
         self.table.walk_ast(out.reborrow())?;
         out.push_sql(".");
         out.push_identifier(self.name.borrow())?;

--- a/diesel_dynamic_schema/src/column.rs
+++ b/diesel_dynamic_schema/src/column.rs
@@ -51,8 +51,9 @@ where
     type SqlType = ST;
 }
 
-impl<T, U, ST> ValidGrouping<()> for Column<T, U, ST> {
-    type IsAggregate = is_aggregate::No;
+impl<T, U, ST, GB> ValidGrouping<GB> for Column<T, U, ST> {
+    // `Never` opts runtime columns out of grouping checks so they mix with aggregates.
+    type IsAggregate = is_aggregate::Never;
 }
 
 impl<T, U, ST, DB> QueryFragment<DB> for Column<T, U, ST>

--- a/diesel_dynamic_schema/src/dynamic_value.rs
+++ b/diesel_dynamic_schema/src/dynamic_value.rs
@@ -163,7 +163,11 @@
 //! }
 //! ```
 
+#[cfg(any(feature = "postgres", feature = "mysql", feature = "mariadb"))]
+use crate::error::DynamicSchemaError;
 use alloc::borrow::ToOwned;
+#[cfg(any(feature = "postgres", feature = "mysql", feature = "mariadb"))]
+use alloc::format;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::iter::FromIterator;
@@ -594,4 +598,442 @@ impl<'a, V> IntoIterator for &'a mut DynamicRow<V> {
     fn into_iter(self) -> Self::IntoIter {
         self.values.iter_mut()
     }
+}
+
+/// A runtime database value decoded from [`Any`] without custom backend dispatch.
+///
+/// ```rust
+/// # mod connection_setup {
+/// #     include!("../tests/connection_setup.rs");
+/// # }
+/// # use diesel::prelude::*;
+/// # use diesel::sql_query;
+/// # use diesel::sql_types::Untyped;
+/// # use diesel_dynamic_schema::{table, DynamicSelectClause};
+/// # use diesel_dynamic_schema::dynamic_value::{DynamicRow, DynamicValue};
+/// # fn run() -> QueryResult<()> {
+/// # let conn = &mut connection_setup::establish_connection();
+/// # connection_setup::create_user_table(conn);
+/// # sql_query("INSERT INTO users (name) VALUES ('Sean')").execute(conn)?;
+/// let users = table("users");
+/// let name = users.column::<Untyped, _>("name");
+///
+/// let mut select = DynamicSelectClause::new();
+/// select.add_field(name);
+///
+/// let rows: Vec<DynamicRow<DynamicValue>> = users.select(select).load(conn)?;
+/// assert_eq!(rows[0][0], DynamicValue::Text("Sean".into()));
+/// # Ok(())
+/// # }
+/// # run().unwrap();
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum DynamicValue {
+    /// SQL `NULL`. `Option<DynamicValue>` decodes it as `Some(Null)`.
+    Null,
+    /// A boolean, produced for PostgreSQL `BOOL`.
+    Bool(bool),
+    /// A signed integer, also used for SQLite, MySQL, and MariaDB booleans.
+    Int(i64),
+    /// An unsigned MySQL or MariaDB integer.
+    UInt(u64),
+    /// A floating-point number, widened to double precision.
+    Float(f64),
+    /// Text.
+    Text(String),
+    /// Raw bytes.
+    Bytes(Vec<u8>),
+    /// A timestamp without a time zone.
+    #[cfg(feature = "chrono")]
+    Timestamp(chrono::NaiveDateTime),
+    /// A UTC timestamp.
+    #[cfg(feature = "chrono")]
+    TimestampTz(chrono::DateTime<chrono::Utc>),
+    /// A calendar date.
+    #[cfg(feature = "chrono")]
+    Date(chrono::NaiveDate),
+    /// A PostgreSQL time of day.
+    #[cfg(feature = "chrono")]
+    Time(chrono::NaiveTime),
+    /// A MySQL or MariaDB `TIME` duration.
+    #[cfg(feature = "chrono")]
+    Duration(chrono::Duration),
+    /// An exact decimal.
+    #[cfg(feature = "numeric")]
+    Numeric(bigdecimal::BigDecimal),
+    /// A UUID.
+    #[cfg(feature = "uuid")]
+    Uuid(uuid::Uuid),
+    /// A JSON document.
+    #[cfg(feature = "serde_json")]
+    Json(serde_json::Value),
+    /// A binary JSON document.
+    #[cfg(feature = "serde_json")]
+    Jsonb(serde_json::Value),
+}
+
+#[cfg(feature = "postgres")]
+impl FromSql<Any, diesel::pg::Pg> for DynamicValue {
+    fn from_sql(value: diesel::pg::PgValue<'_>) -> deserialize::Result<Self> {
+        pg_dynamic_value(value)
+    }
+
+    fn from_nullable_sql(value: Option<diesel::pg::PgValue<'_>>) -> deserialize::Result<Self> {
+        match value {
+            Some(value) => pg_dynamic_value(value),
+            None => Ok(DynamicValue::Null),
+        }
+    }
+}
+
+#[cfg(feature = "postgres")]
+fn pg_dynamic_value(value: diesel::pg::PgValue<'_>) -> deserialize::Result<DynamicValue> {
+    use diesel::pg::Pg;
+    use diesel::sql_types as st;
+
+    const BOOL: u32 = 16;
+    const BYTEA: u32 = 17;
+    const NAME: u32 = 19;
+    const INT8: u32 = 20;
+    const INT2: u32 = 21;
+    const INT4: u32 = 23;
+    const TEXT: u32 = 25;
+    const JSON: u32 = 114;
+    const FLOAT4: u32 = 700;
+    const FLOAT8: u32 = 701;
+    const BPCHAR: u32 = 1042;
+    const VARCHAR: u32 = 1043;
+    const DATE: u32 = 1082;
+    const TIME: u32 = 1083;
+    const TIMESTAMP: u32 = 1114;
+    const TIMESTAMPTZ: u32 = 1184;
+    const NUMERIC: u32 = 1700;
+    const UUID: u32 = 2950;
+    const JSONB: u32 = 3802;
+
+    // Diesel's `FromSql` decodes each value. This function owns only dispatch.
+    let oid = value.get_oid().get();
+    Ok(match oid {
+        BOOL => DynamicValue::Bool(<bool as FromSql<st::Bool, Pg>>::from_sql(value)?),
+        INT2 => DynamicValue::Int(i64::from(<i16 as FromSql<st::SmallInt, Pg>>::from_sql(
+            value,
+        )?)),
+        INT4 => DynamicValue::Int(i64::from(<i32 as FromSql<st::Integer, Pg>>::from_sql(
+            value,
+        )?)),
+        INT8 => DynamicValue::Int(<i64 as FromSql<st::BigInt, Pg>>::from_sql(value)?),
+        FLOAT4 => DynamicValue::Float(f64::from(<f32 as FromSql<st::Float, Pg>>::from_sql(value)?)),
+        FLOAT8 => DynamicValue::Float(<f64 as FromSql<st::Double, Pg>>::from_sql(value)?),
+        TEXT | VARCHAR | BPCHAR | NAME => {
+            DynamicValue::Text(<String as FromSql<st::Text, Pg>>::from_sql(value)?)
+        }
+        BYTEA => DynamicValue::Bytes(<Vec<u8> as FromSql<st::Binary, Pg>>::from_sql(value)?),
+        #[cfg(feature = "uuid")]
+        UUID => DynamicValue::Uuid(<uuid::Uuid as FromSql<st::Uuid, Pg>>::from_sql(value)?),
+        #[cfg(not(feature = "uuid"))]
+        UUID => {
+            return Err(DynamicSchemaError::FeatureDisabled {
+                feature: "uuid",
+                sql_type: "UUID",
+            }
+            .into())
+        }
+        #[cfg(feature = "numeric")]
+        NUMERIC => DynamicValue::Numeric(
+            <bigdecimal::BigDecimal as FromSql<st::Numeric, Pg>>::from_sql(value)?,
+        ),
+        #[cfg(not(feature = "numeric"))]
+        NUMERIC => {
+            return Err(DynamicSchemaError::FeatureDisabled {
+                feature: "numeric",
+                sql_type: "NUMERIC",
+            }
+            .into())
+        }
+        #[cfg(feature = "chrono")]
+        TIMESTAMP => DynamicValue::Timestamp(<chrono::NaiveDateTime as FromSql<
+            st::Timestamp,
+            Pg,
+        >>::from_sql(value)?),
+        #[cfg(feature = "chrono")]
+        TIMESTAMPTZ => DynamicValue::TimestampTz(<chrono::DateTime<chrono::Utc> as FromSql<
+            st::Timestamptz,
+            Pg,
+        >>::from_sql(value)?),
+        #[cfg(feature = "chrono")]
+        DATE => DynamicValue::Date(<chrono::NaiveDate as FromSql<st::Date, Pg>>::from_sql(
+            value,
+        )?),
+        #[cfg(feature = "chrono")]
+        TIME => DynamicValue::Time(<chrono::NaiveTime as FromSql<st::Time, Pg>>::from_sql(
+            value,
+        )?),
+        #[cfg(not(feature = "chrono"))]
+        TIMESTAMP => {
+            return Err(DynamicSchemaError::FeatureDisabled {
+                feature: "chrono",
+                sql_type: "TIMESTAMP",
+            }
+            .into())
+        }
+        #[cfg(not(feature = "chrono"))]
+        TIMESTAMPTZ => {
+            return Err(DynamicSchemaError::FeatureDisabled {
+                feature: "chrono",
+                sql_type: "TIMESTAMPTZ",
+            }
+            .into())
+        }
+        #[cfg(not(feature = "chrono"))]
+        DATE => {
+            return Err(DynamicSchemaError::FeatureDisabled {
+                feature: "chrono",
+                sql_type: "DATE",
+            }
+            .into())
+        }
+        #[cfg(not(feature = "chrono"))]
+        TIME => {
+            return Err(DynamicSchemaError::FeatureDisabled {
+                feature: "chrono",
+                sql_type: "TIME",
+            }
+            .into())
+        }
+        #[cfg(feature = "serde_json")]
+        JSON => DynamicValue::Json(<serde_json::Value as FromSql<st::Json, Pg>>::from_sql(
+            value,
+        )?),
+        #[cfg(feature = "serde_json")]
+        JSONB => DynamicValue::Jsonb(<serde_json::Value as FromSql<st::Jsonb, Pg>>::from_sql(
+            value,
+        )?),
+        #[cfg(not(feature = "serde_json"))]
+        JSON => {
+            return Err(DynamicSchemaError::FeatureDisabled {
+                feature: "serde_json",
+                sql_type: "JSON",
+            }
+            .into())
+        }
+        #[cfg(not(feature = "serde_json"))]
+        JSONB => {
+            return Err(DynamicSchemaError::FeatureDisabled {
+                feature: "serde_json",
+                sql_type: "JSONB",
+            }
+            .into())
+        }
+        other => {
+            return Err(DynamicSchemaError::UnsupportedType {
+                backend: "PostgreSQL",
+                sql_type: format!("OID {other}"),
+            }
+            .into())
+        }
+    })
+}
+
+#[cfg(feature = "sqlite")]
+impl FromSql<Any, diesel::sqlite::Sqlite> for DynamicValue {
+    fn from_sql(value: diesel::sqlite::SqliteValue<'_, '_, '_>) -> deserialize::Result<Self> {
+        sqlite_dynamic_value(value)
+    }
+
+    fn from_nullable_sql(
+        value: Option<diesel::sqlite::SqliteValue<'_, '_, '_>>,
+    ) -> deserialize::Result<Self> {
+        match value {
+            Some(value) => sqlite_dynamic_value(value),
+            None => Ok(DynamicValue::Null),
+        }
+    }
+}
+
+#[cfg(feature = "sqlite")]
+fn sqlite_dynamic_value(
+    mut value: diesel::sqlite::SqliteValue<'_, '_, '_>,
+) -> deserialize::Result<DynamicValue> {
+    use diesel::sqlite::SqliteType;
+
+    // SQLite reports storage classes, not declared types.
+    // `SmallInt`, `Integer`, and `Float` are bind-only and matched for exhaustiveness.
+    Ok(match value.value_type() {
+        None => DynamicValue::Null,
+        Some(SqliteType::SmallInt | SqliteType::Integer | SqliteType::Long) => {
+            DynamicValue::Int(value.read_long())
+        }
+        Some(SqliteType::Float | SqliteType::Double) => DynamicValue::Float(value.read_double()),
+        Some(SqliteType::Text) => DynamicValue::Text(value.read_text().to_owned()),
+        Some(SqliteType::Binary) => DynamicValue::Bytes(value.read_blob().to_owned()),
+    })
+}
+
+#[cfg(feature = "mysql")]
+impl FromSql<Any, diesel::mysql::Mysql> for DynamicValue {
+    fn from_sql(value: diesel::mysql::MysqlValue<'_>) -> deserialize::Result<Self> {
+        mysql_like_dynamic_value::<diesel::mysql::Mysql>(value, "MySQL")
+    }
+
+    fn from_nullable_sql(
+        value: Option<diesel::mysql::MysqlValue<'_>>,
+    ) -> deserialize::Result<Self> {
+        match value {
+            Some(value) => mysql_like_dynamic_value::<diesel::mysql::Mysql>(value, "MySQL"),
+            None => Ok(DynamicValue::Null),
+        }
+    }
+}
+
+#[cfg(feature = "mariadb")]
+impl FromSql<Any, diesel::mariadb::Mariadb> for DynamicValue {
+    fn from_sql(value: diesel::mariadb::MariadbValue<'_>) -> deserialize::Result<Self> {
+        mysql_like_dynamic_value::<diesel::mariadb::Mariadb>(value, "MariaDB")
+    }
+
+    fn from_nullable_sql(
+        value: Option<diesel::mariadb::MariadbValue<'_>>,
+    ) -> deserialize::Result<Self> {
+        match value {
+            Some(value) => mysql_like_dynamic_value::<diesel::mariadb::Mariadb>(value, "MariaDB"),
+            None => Ok(DynamicValue::Null),
+        }
+    }
+}
+
+#[cfg(any(feature = "mysql", feature = "mariadb"))]
+fn mysql_like_dynamic_value<DB>(
+    value: diesel::mysql_like::MysqlValue<'_>,
+    backend: &'static str,
+) -> deserialize::Result<DynamicValue>
+where
+    DB: diesel::mysql_like::MysqlLikeBackend,
+{
+    use diesel::mysql_like::MysqlType as T;
+    use diesel::sql_types as st;
+
+    let ty = value.value_type();
+    Ok(match ty {
+        T::Tiny => DynamicValue::Int(i64::from(<i8 as FromSql<st::TinyInt, DB>>::from_sql(
+            value,
+        )?)),
+        T::Short => DynamicValue::Int(i64::from(<i16 as FromSql<st::SmallInt, DB>>::from_sql(
+            value,
+        )?)),
+        T::Long => DynamicValue::Int(i64::from(<i32 as FromSql<st::Integer, DB>>::from_sql(
+            value,
+        )?)),
+        T::LongLong => DynamicValue::Int(<i64 as FromSql<st::BigInt, DB>>::from_sql(value)?),
+        T::UnsignedTiny => DynamicValue::UInt(u64::from(<u8 as FromSql<
+            st::Unsigned<st::TinyInt>,
+            DB,
+        >>::from_sql(value)?)),
+        T::UnsignedShort => DynamicValue::UInt(u64::from(<u16 as FromSql<
+            st::Unsigned<st::SmallInt>,
+            DB,
+        >>::from_sql(value)?)),
+        T::UnsignedLong => DynamicValue::UInt(u64::from(<u32 as FromSql<
+            st::Unsigned<st::Integer>,
+            DB,
+        >>::from_sql(value)?)),
+        T::UnsignedLongLong => DynamicValue::UInt(<u64 as FromSql<
+            st::Unsigned<st::BigInt>,
+            DB,
+        >>::from_sql(value)?),
+        T::Float => {
+            DynamicValue::Float(f64::from(<f32 as FromSql<st::Float, DB>>::from_sql(value)?))
+        }
+        T::Double => DynamicValue::Float(<f64 as FromSql<st::Double, DB>>::from_sql(value)?),
+        // MySQL reports JSON as `String`. MariaDB reports it as `Blob`.
+        T::String | T::Enum | T::Set => {
+            DynamicValue::Text(<String as FromSql<st::Text, DB>>::from_sql(value)?)
+        }
+        T::Blob => DynamicValue::Bytes(<Vec<u8> as FromSql<st::Binary, DB>>::from_sql(value)?),
+        #[cfg(feature = "numeric")]
+        T::Numeric => DynamicValue::Numeric(<bigdecimal::BigDecimal as FromSql<
+            st::Numeric,
+            DB,
+        >>::from_sql(value)?),
+        #[cfg(not(feature = "numeric"))]
+        T::Numeric => {
+            return Err(DynamicSchemaError::FeatureDisabled {
+                feature: "numeric",
+                sql_type: "NUMERIC",
+            }
+            .into())
+        }
+        #[cfg(feature = "chrono")]
+        T::Date => DynamicValue::Date(<chrono::NaiveDate as FromSql<st::Date, DB>>::from_sql(
+            value,
+        )?),
+        #[cfg(feature = "chrono")]
+        T::DateTime => DynamicValue::Timestamp(<chrono::NaiveDateTime as FromSql<
+            st::Datetime,
+            DB,
+        >>::from_sql(value)?),
+        #[cfg(feature = "chrono")]
+        T::Timestamp => DynamicValue::Timestamp(<chrono::NaiveDateTime as FromSql<
+            st::Timestamp,
+            DB,
+        >>::from_sql(value)?),
+        #[cfg(feature = "chrono")]
+        T::Time => DynamicValue::Duration(mysql_time_to_duration(
+            <diesel::mysql_like::data_types::MysqlTime as FromSql<st::Time, DB>>::from_sql(value)?,
+        )?),
+        #[cfg(not(feature = "chrono"))]
+        T::Date => {
+            return Err(DynamicSchemaError::FeatureDisabled {
+                feature: "chrono",
+                sql_type: "DATE",
+            }
+            .into())
+        }
+        #[cfg(not(feature = "chrono"))]
+        T::DateTime => {
+            return Err(DynamicSchemaError::FeatureDisabled {
+                feature: "chrono",
+                sql_type: "DATETIME",
+            }
+            .into())
+        }
+        #[cfg(not(feature = "chrono"))]
+        T::Timestamp => {
+            return Err(DynamicSchemaError::FeatureDisabled {
+                feature: "chrono",
+                sql_type: "TIMESTAMP",
+            }
+            .into())
+        }
+        #[cfg(not(feature = "chrono"))]
+        T::Time => {
+            return Err(DynamicSchemaError::FeatureDisabled {
+                feature: "chrono",
+                sql_type: "TIME",
+            }
+            .into())
+        }
+        // `MysqlType` is non-exhaustive, so unknown tags fail rather than guess.
+        other => {
+            return Err(DynamicSchemaError::UnsupportedType {
+                backend,
+                sql_type: format!("{other:?}"),
+            }
+            .into())
+        }
+    })
+}
+
+#[cfg(all(feature = "chrono", any(feature = "mysql", feature = "mariadb")))]
+fn mysql_time_to_duration(
+    time: diesel::mysql_like::data_types::MysqlTime,
+) -> deserialize::Result<chrono::Duration> {
+    use core::convert::TryFrom;
+
+    let micros = i64::from(time.hour) * 3_600_000_000
+        + i64::from(time.minute) * 60_000_000
+        + i64::from(time.second) * 1_000_000
+        + i64::try_from(time.second_part)?;
+    let micros = if time.neg { -micros } else { micros };
+    Ok(chrono::Duration::microseconds(micros))
 }

--- a/diesel_dynamic_schema/src/error.rs
+++ b/diesel_dynamic_schema/src/error.rs
@@ -1,0 +1,25 @@
+use alloc::string::String;
+
+/// Errors produced by `diesel-dynamic-schema`.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum DynamicSchemaError {
+    /// A runtime type has no [`DynamicValue`](crate::dynamic_value::DynamicValue) representation.
+    #[error("no `DynamicValue` representation for the {backend} runtime type {sql_type}")]
+    UnsupportedType {
+        /// The backend that reported the value.
+        backend: &'static str,
+        /// The runtime type as the backend describes it.
+        sql_type: String,
+    },
+    /// The required rich-type feature is disabled.
+    #[error(
+        "decoding a {sql_type} value into a `DynamicValue` requires the `{feature}` feature of `diesel-dynamic-schema`"
+    )]
+    FeatureDisabled {
+        /// The crate feature that must be enabled.
+        feature: &'static str,
+        /// The runtime type that needs the feature.
+        sql_type: &'static str,
+    },
+}

--- a/diesel_dynamic_schema/src/error.rs
+++ b/diesel_dynamic_schema/src/error.rs
@@ -1,5 +1,7 @@
 use alloc::string::String;
 
+use crate::table::runtime_table_display;
+
 /// Errors produced by `diesel-dynamic-schema`.
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
@@ -21,5 +23,13 @@ pub enum DynamicSchemaError {
         feature: &'static str,
         /// The runtime type that needs the feature.
         sql_type: &'static str,
+    },
+    /// Reported during SQL rendering, before execution.
+    #[error("dynamic column references table {} which is not part of the query", runtime_table_display(.schema.as_deref(), .table))]
+    ForeignTable {
+        /// The schema of the referenced table, if the column carried one.
+        schema: Option<String>,
+        /// The name of the referenced table.
+        table: String,
     },
 }

--- a/diesel_dynamic_schema/src/lib.rs
+++ b/diesel_dynamic_schema/src/lib.rs
@@ -85,6 +85,7 @@ mod column;
 mod dummy_expression;
 mod dynamic_select;
 pub mod dynamic_value;
+mod error;
 mod schema;
 mod table;
 
@@ -96,6 +97,9 @@ pub use schema::Schema;
 
 /// A database table.
 pub use table::Table;
+
+/// Dynamic-schema errors.
+pub use error::DynamicSchemaError;
 
 #[doc(inline)]
 pub use self::dynamic_select::DynamicSelectClause;

--- a/diesel_dynamic_schema/src/table.rs
+++ b/diesel_dynamic_schema/src/table.rs
@@ -10,6 +10,13 @@ use diesel::query_source::NamedTable;
 use crate::column::Column;
 use crate::dummy_expression::*;
 
+pub(crate) fn runtime_table_display(schema: Option<&str>, table: &str) -> String {
+    match schema {
+        Some(schema) => alloc::format!("{schema}.{table}"),
+        None => table.into(),
+    }
+}
+
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 /// A database table.
 /// This type is created by the [`table`](crate::table()) function.
@@ -86,6 +93,8 @@ impl<T, U> Table<T, U> {
 impl<T, U> QuerySource for Table<T, U>
 where
     Self: Clone,
+    T: Borrow<str>,
+    U: Borrow<str>,
 {
     type FromClause = Self;
     type DefaultSelection = DummyExpression;
@@ -97,12 +106,16 @@ where
     fn default_selection(&self) -> Self::DefaultSelection {
         DummyExpression::new()
     }
+
+    fn contains_runtime_table(&self, schema: Option<&str>, table: &str) -> bool {
+        self.name.borrow() == table && self.schema.as_ref().map(Borrow::borrow) == schema
+    }
 }
 
 impl<T, U> AsQuery for Table<T, U>
 where
-    T: Clone,
-    U: Clone,
+    T: Clone + Borrow<str>,
+    U: Clone + Borrow<str>,
     SelectStatement<FromClause<Self>>: Query<SqlType = expression_types::NotSelectable>,
 {
     type SqlType = expression_types::NotSelectable;

--- a/diesel_dynamic_schema/tests/connection_setup.rs
+++ b/diesel_dynamic_schema/tests/connection_setup.rs
@@ -7,11 +7,31 @@ pub fn create_user_table(conn: &mut diesel::PgConnection) {
         .unwrap();
 }
 
+#[cfg(feature = "postgres")]
+pub fn create_posts_table(conn: &mut diesel::PgConnection) {
+    use diesel::*;
+
+    diesel::sql_query(
+        "CREATE TEMPORARY TABLE posts (id Serial PRIMARY KEY, user_id INTEGER NOT NULL)",
+    )
+    .execute(conn)
+    .unwrap();
+}
+
 #[cfg(any(feature = "sqlite", feature = "sqlite-no-std"))]
 pub fn create_user_table(conn: &mut diesel::SqliteConnection) {
     use diesel::*;
 
     diesel::sql_query("CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL DEFAULT '', hair_color TEXT)")
+        .execute(conn)
+        .unwrap();
+}
+
+#[cfg(any(feature = "sqlite", feature = "sqlite-no-std"))]
+pub fn create_posts_table(conn: &mut diesel::SqliteConnection) {
+    use diesel::*;
+
+    diesel::sql_query("CREATE TABLE IF NOT EXISTS posts (id INTEGER PRIMARY KEY AUTOINCREMENT, user_id INTEGER NOT NULL)")
         .execute(conn)
         .unwrap();
 }
@@ -25,11 +45,29 @@ pub fn create_user_table(conn: &mut diesel::MysqlConnection) {
         .unwrap();
 }
 
+#[cfg(feature = "mysql")]
+pub fn create_posts_table(conn: &mut diesel::MysqlConnection) {
+    use diesel::*;
+
+    diesel::sql_query("CREATE TEMPORARY TABLE posts (id INTEGER PRIMARY KEY AUTO_INCREMENT, user_id INTEGER NOT NULL)")
+        .execute(conn)
+        .unwrap();
+}
+
 #[cfg(feature = "mariadb")]
 pub fn create_user_table(conn: &mut diesel::MariadbConnection) {
     use diesel::*;
 
     diesel::sql_query("CREATE TEMPORARY TABLE users (id INTEGER PRIMARY KEY AUTO_INCREMENT, name TEXT NOT NULL, hair_color TEXT)")
+        .execute(conn)
+        .unwrap();
+}
+
+#[cfg(feature = "mariadb")]
+pub fn create_posts_table(conn: &mut diesel::MariadbConnection) {
+    use diesel::*;
+
+    diesel::sql_query("CREATE TEMPORARY TABLE posts (id INTEGER PRIMARY KEY AUTO_INCREMENT, user_id INTEGER NOT NULL)")
         .execute(conn)
         .unwrap();
 }

--- a/diesel_dynamic_schema/tests/dynamic_values.rs
+++ b/diesel_dynamic_schema/tests/dynamic_values.rs
@@ -335,3 +335,341 @@ fn nullable_dynamic_value() {
     );
     assert_eq!(result[1]["hair_color"], None);
 }
+
+#[test]
+fn dynamic_value_row_shapes() {
+    let connection = &mut crate::establish_connection();
+    crate::create_user_table(connection);
+    sql_query("INSERT INTO users (id, name) VALUES (7, 'Sean')")
+        .execute(connection)
+        .unwrap();
+
+    let users = diesel_dynamic_schema::table("users");
+    let id = users.column::<Untyped, _>("id");
+    let name = users.column::<Untyped, _>("name");
+    let hair_color = users.column::<Untyped, _>("hair_color");
+
+    let mut select = DynamicSelectClause::new();
+    select.add_field(id);
+    select.add_field(name);
+    select.add_field(hair_color);
+    let rows: Vec<DynamicRow<DynamicValue>> = users.select(select).load(connection).unwrap();
+    assert_eq!(rows[0][0], DynamicValue::Int(7));
+    assert_eq!(rows[0][1], DynamicValue::Text("Sean".into()));
+    assert_eq!(rows[0][2], DynamicValue::Null);
+
+    let id = users.column::<Untyped, _>("id");
+    let name = users.column::<Untyped, _>("name");
+    let hair_color = users.column::<Untyped, _>("hair_color");
+    let mut select = DynamicSelectClause::new();
+    select.add_field(id);
+    select.add_field(name);
+    select.add_field(hair_color);
+    let rows: Vec<DynamicRow<NamedField<DynamicValue>>> =
+        users.select(select).load(connection).unwrap();
+    assert_eq!(rows[0]["name"], DynamicValue::Text("Sean".into()));
+    assert_eq!(rows[0]["hair_color"], DynamicValue::Null);
+}
+
+#[test]
+fn dynamic_value_core_scalars() {
+    let connection = &mut crate::establish_connection();
+    let ddl = if cfg!(feature = "postgres") {
+        "CREATE TABLE dv_core (i INTEGER, big BIGINT, f DOUBLE PRECISION, t TEXT, b BYTEA)"
+    } else if cfg!(feature = "sqlite") {
+        "CREATE TABLE dv_core (i INTEGER, big BIGINT, f DOUBLE, t TEXT, b BLOB)"
+    } else {
+        "CREATE TEMPORARY TABLE dv_core (i INTEGER, big BIGINT, f DOUBLE, t TEXT, b BLOB)"
+    };
+    sql_query(ddl).execute(connection).unwrap();
+    let blob = if cfg!(feature = "postgres") {
+        "'\\x0102'"
+    } else {
+        "X'0102'"
+    };
+    sql_query(format!(
+        "INSERT INTO dv_core (i, big, f, t, b) VALUES (42, 9000000000, 1.5, 'hi', {blob})"
+    ))
+    .execute(connection)
+    .unwrap();
+
+    let rows = sql_query("SELECT i, big, f, t, b FROM dv_core")
+        .load::<DynamicRow<DynamicValue>>(connection)
+        .unwrap();
+    assert_eq!(rows.len(), 1);
+    let row = &rows[0];
+    assert_eq!(row[0], DynamicValue::Int(42));
+    assert_eq!(row[1], DynamicValue::Int(9_000_000_000));
+    assert_eq!(row[2], DynamicValue::Float(1.5));
+    assert_eq!(row[3], DynamicValue::Text("hi".into()));
+    assert_eq!(row[4], DynamicValue::Bytes(vec![1, 2]));
+}
+
+#[test]
+fn dynamic_value_boolean_mapping() {
+    let connection = &mut crate::establish_connection();
+    let ddl = if cfg!(any(feature = "mysql", feature = "mariadb")) {
+        "CREATE TEMPORARY TABLE dv_bool (val BOOLEAN)"
+    } else {
+        "CREATE TABLE dv_bool (val BOOLEAN)"
+    };
+    sql_query(ddl).execute(connection).unwrap();
+    sql_query("INSERT INTO dv_bool (val) VALUES (TRUE)")
+        .execute(connection)
+        .unwrap();
+
+    let rows = sql_query("SELECT val FROM dv_bool")
+        .load::<DynamicRow<DynamicValue>>(connection)
+        .unwrap();
+    let expected = if cfg!(feature = "postgres") {
+        DynamicValue::Bool(true)
+    } else {
+        DynamicValue::Int(1)
+    };
+    assert_eq!(rows[0][0], expected);
+}
+
+#[cfg(all(
+    feature = "chrono",
+    any(feature = "postgres", feature = "mysql", feature = "mariadb")
+))]
+#[test]
+fn dynamic_value_time_mapping() {
+    let connection = &mut crate::establish_connection();
+
+    #[cfg(feature = "postgres")]
+    {
+        sql_query("CREATE TABLE dv_time (val TIME)")
+            .execute(connection)
+            .unwrap();
+        sql_query("INSERT INTO dv_time (val) VALUES ('12:34:56')")
+            .execute(connection)
+            .unwrap();
+        let rows = sql_query("SELECT val FROM dv_time")
+            .load::<DynamicRow<DynamicValue>>(connection)
+            .unwrap();
+        assert_eq!(
+            rows[0][0],
+            DynamicValue::Time(chrono::NaiveTime::from_hms_opt(12, 34, 56).unwrap())
+        );
+    }
+
+    #[cfg(any(feature = "mysql", feature = "mariadb"))]
+    {
+        sql_query("CREATE TEMPORARY TABLE dv_time (a TIME, b TIME)")
+            .execute(connection)
+            .unwrap();
+        sql_query("INSERT INTO dv_time (a, b) VALUES ('25:00:00', '12:34:56')")
+            .execute(connection)
+            .unwrap();
+        let rows = sql_query("SELECT a, b FROM dv_time")
+            .load::<DynamicRow<DynamicValue>>(connection)
+            .unwrap();
+        assert_eq!(
+            rows[0][0],
+            DynamicValue::Duration(chrono::Duration::seconds(90000))
+        );
+        assert_eq!(
+            rows[0][1],
+            DynamicValue::Duration(chrono::Duration::seconds(45296))
+        );
+
+        // Diesel rejects negative `MysqlTime` before this decoder runs.
+        sql_query("CREATE TEMPORARY TABLE dv_time_neg (t TIME)")
+            .execute(connection)
+            .unwrap();
+        sql_query("INSERT INTO dv_time_neg (t) VALUES ('-01:30:00')")
+            .execute(connection)
+            .unwrap();
+        let negative =
+            sql_query("SELECT t FROM dv_time_neg").load::<DynamicRow<DynamicValue>>(connection);
+        match negative {
+            Err(diesel::result::Error::DeserializationError(e)) => {
+                assert!(e
+                    .to_string()
+                    .contains("Negative dates/times are not yet supported"));
+            }
+            other => panic!(
+                "expected a deserialization error for a negative TIME, got {:?}",
+                other
+            ),
+        }
+    }
+}
+
+#[cfg(all(
+    feature = "chrono",
+    any(feature = "postgres", feature = "mysql", feature = "mariadb")
+))]
+#[test]
+fn dynamic_value_date_and_timestamp() {
+    let connection = &mut crate::establish_connection();
+    let ddl = if cfg!(feature = "postgres") {
+        "CREATE TABLE dv_ts (ts TIMESTAMP, d DATE)"
+    } else {
+        "CREATE TEMPORARY TABLE dv_ts (ts DATETIME, d DATE)"
+    };
+    sql_query(ddl).execute(connection).unwrap();
+    sql_query("INSERT INTO dv_ts (ts, d) VALUES ('2020-01-02 03:04:05', '2020-01-02')")
+        .execute(connection)
+        .unwrap();
+
+    let rows = sql_query("SELECT ts, d FROM dv_ts")
+        .load::<DynamicRow<DynamicValue>>(connection)
+        .unwrap();
+    assert_eq!(
+        rows[0][0],
+        DynamicValue::Timestamp(
+            chrono::NaiveDate::from_ymd_opt(2020, 1, 2)
+                .unwrap()
+                .and_hms_opt(3, 4, 5)
+                .unwrap()
+        )
+    );
+    assert_eq!(
+        rows[0][1],
+        DynamicValue::Date(chrono::NaiveDate::from_ymd_opt(2020, 1, 2).unwrap())
+    );
+}
+
+#[cfg(any(feature = "mysql", feature = "mariadb"))]
+#[test]
+fn dynamic_value_unsigned_above_i64_max() {
+    let connection = &mut crate::establish_connection();
+    sql_query("CREATE TEMPORARY TABLE dv_uns (a BIGINT UNSIGNED, b INT UNSIGNED)")
+        .execute(connection)
+        .unwrap();
+    sql_query("INSERT INTO dv_uns (a, b) VALUES (18446744073709551615, 4294967295)")
+        .execute(connection)
+        .unwrap();
+
+    let rows = sql_query("SELECT a, b FROM dv_uns")
+        .load::<DynamicRow<DynamicValue>>(connection)
+        .unwrap();
+    assert_eq!(rows[0][0], DynamicValue::UInt(u64::MAX));
+    assert_eq!(rows[0][1], DynamicValue::UInt(4_294_967_295));
+}
+
+#[cfg(any(feature = "mysql", feature = "mariadb"))]
+#[test]
+fn dynamic_value_json_is_not_a_json_variant_on_mysql_like() {
+    let connection = &mut crate::establish_connection();
+    sql_query("CREATE TEMPORARY TABLE dv_mjson (j JSON)")
+        .execute(connection)
+        .unwrap();
+    sql_query("INSERT INTO dv_mjson (j) VALUES ('{\"a\": 1}')")
+        .execute(connection)
+        .unwrap();
+
+    let rows = sql_query("SELECT j FROM dv_mjson")
+        .load::<DynamicRow<DynamicValue>>(connection)
+        .unwrap();
+    let payload = match &rows[0][0] {
+        DynamicValue::Text(s) => s.clone().into_bytes(),
+        DynamicValue::Bytes(b) => b.clone(),
+        other => panic!(
+            "expected Text or Bytes for a MySQL-like JSON value, got {:?}",
+            other
+        ),
+    };
+    assert!(String::from_utf8_lossy(&payload).contains("\"a\""));
+}
+
+#[cfg(all(
+    feature = "numeric",
+    any(feature = "postgres", feature = "mysql", feature = "mariadb")
+))]
+#[test]
+fn dynamic_value_numeric() {
+    let connection = &mut crate::establish_connection();
+    let ddl = if cfg!(feature = "postgres") {
+        "CREATE TABLE dv_num (n NUMERIC(10, 2))"
+    } else {
+        "CREATE TEMPORARY TABLE dv_num (n NUMERIC(10, 2))"
+    };
+    sql_query(ddl).execute(connection).unwrap();
+    sql_query("INSERT INTO dv_num (n) VALUES (123.45)")
+        .execute(connection)
+        .unwrap();
+
+    let rows = sql_query("SELECT n FROM dv_num")
+        .load::<DynamicRow<DynamicValue>>(connection)
+        .unwrap();
+    assert_eq!(rows[0][0], DynamicValue::Numeric("123.45".parse().unwrap()));
+}
+
+#[cfg(all(feature = "uuid", feature = "postgres"))]
+#[test]
+fn dynamic_value_uuid() {
+    let connection = &mut crate::establish_connection();
+    sql_query("CREATE TABLE dv_uuid (u UUID)")
+        .execute(connection)
+        .unwrap();
+    sql_query("INSERT INTO dv_uuid (u) VALUES ('11111111-1111-1111-1111-111111111111')")
+        .execute(connection)
+        .unwrap();
+
+    let rows = sql_query("SELECT u FROM dv_uuid")
+        .load::<DynamicRow<DynamicValue>>(connection)
+        .unwrap();
+    assert_eq!(
+        rows[0][0],
+        DynamicValue::Uuid("11111111-1111-1111-1111-111111111111".parse().unwrap())
+    );
+}
+
+#[cfg(all(feature = "serde_json", feature = "postgres"))]
+#[test]
+fn dynamic_value_json_and_jsonb() {
+    let connection = &mut crate::establish_connection();
+    sql_query("CREATE TABLE dv_json (j JSON, jb JSONB)")
+        .execute(connection)
+        .unwrap();
+    sql_query("INSERT INTO dv_json (j, jb) VALUES ('{\"a\": 1}', '{\"b\": 2}')")
+        .execute(connection)
+        .unwrap();
+
+    let rows = sql_query("SELECT j, jb FROM dv_json")
+        .load::<DynamicRow<DynamicValue>>(connection)
+        .unwrap();
+    assert_eq!(rows[0][0], DynamicValue::Json(serde_json::json!({"a": 1})));
+    assert_eq!(rows[0][1], DynamicValue::Jsonb(serde_json::json!({"b": 2})));
+}
+
+#[cfg(feature = "postgres")]
+#[test]
+fn dynamic_value_rejects_unsupported_pg_oid() {
+    let connection = &mut crate::establish_connection();
+    let result = sql_query("SELECT ARRAY[1, 2] AS a").load::<DynamicRow<DynamicValue>>(connection);
+    assert!(result.is_err());
+}
+
+#[cfg(any(feature = "mysql", feature = "mariadb"))]
+#[test]
+fn dynamic_value_rejects_unsupported_mysql_like_tag() {
+    let connection = &mut crate::establish_connection();
+    sql_query("CREATE TEMPORARY TABLE dv_bit (b BIT(3))")
+        .execute(connection)
+        .unwrap();
+    sql_query("INSERT INTO dv_bit (b) VALUES (b'101')")
+        .execute(connection)
+        .unwrap();
+
+    let result = sql_query("SELECT b FROM dv_bit").load::<DynamicRow<DynamicValue>>(connection);
+    assert!(result.is_err());
+}
+
+#[cfg(all(feature = "postgres", not(feature = "numeric")))]
+#[test]
+fn dynamic_value_reports_disabled_feature() {
+    let connection = &mut crate::establish_connection();
+    sql_query("CREATE TABLE dv_fd (n NUMERIC(10, 2))")
+        .execute(connection)
+        .unwrap();
+    sql_query("INSERT INTO dv_fd (n) VALUES (1.00)")
+        .execute(connection)
+        .unwrap();
+
+    let result = sql_query("SELECT n FROM dv_fd").load::<DynamicRow<DynamicValue>>(connection);
+    assert!(result.is_err());
+}

--- a/diesel_dynamic_schema/tests/lib.rs
+++ b/diesel_dynamic_schema/tests/lib.rs
@@ -1,15 +1,16 @@
 extern crate diesel;
 extern crate diesel_dynamic_schema;
 
+use diesel::result::Error;
 use diesel::sql_types::*;
 use diesel::*;
-use diesel_dynamic_schema::{schema, table};
+use diesel_dynamic_schema::{schema, table, DynamicSchemaError};
 
 mod dynamic_values;
 
 mod connection_setup;
 
-use connection_setup::{create_user_table, establish_connection};
+use connection_setup::{create_posts_table, create_user_table, establish_connection};
 
 #[cfg(feature = "postgres")]
 type Backend = diesel::pg::Pg;
@@ -19,6 +20,21 @@ type Backend = diesel::mysql::Mysql;
 type Backend = diesel::mariadb::Mariadb;
 #[cfg(any(feature = "sqlite", feature = "sqlite-no-std"))]
 type Backend = diesel::sqlite::Sqlite;
+
+mod static_schema {
+    diesel::table! {
+        users (id) {
+            id -> diesel::sql_types::Integer,
+            name -> diesel::sql_types::Text,
+        }
+    }
+    diesel::table! {
+        posts (id) {
+            id -> diesel::sql_types::Integer,
+        }
+    }
+    diesel::allow_tables_to_appear_in_same_query!(users, posts);
+}
 
 #[test]
 fn querying_basic_schemas() {
@@ -92,6 +108,178 @@ fn providing_custom_schema_name() {
 
     #[cfg(not(feature = "postgres"))]
     assert_eq!("`information_schema`.`users` -- binds: []", sql.to_string());
+}
+
+#[track_caller]
+fn assert_foreign_table_error(err: &Error, expected_table: &str) {
+    let inner = match err {
+        Error::QueryBuilderError(inner) => inner,
+        other => panic!("expected QueryBuilderError, got {:?}", other),
+    };
+    let dynamic = inner
+        .downcast_ref::<DynamicSchemaError>()
+        .unwrap_or_else(|| panic!("expected DynamicSchemaError, got {}", inner));
+    assert!(
+        matches!(dynamic, DynamicSchemaError::ForeignTable { .. }),
+        "expected ForeignTable, got {:?}",
+        dynamic
+    );
+    assert!(
+        dynamic.to_string().contains(expected_table),
+        "expected `{}` in `{}`",
+        expected_table,
+        dynamic
+    );
+}
+
+#[test]
+fn correct_table_select_filter_and_order_execute() {
+    let conn = &mut establish_connection();
+    create_user_table(conn);
+    sql_query("INSERT INTO users (name) VALUES ('Sean'), ('Tess')")
+        .execute(conn)
+        .unwrap();
+
+    let users = table("users");
+    let id = users.column::<Integer, _>("id");
+    let name = users.column::<Text, _>("name");
+
+    let got = users
+        .select(name)
+        .filter(name.ne("Tess"))
+        .order(id.desc())
+        .load::<String>(conn);
+
+    assert_eq!(Ok(vec!["Sean".to_string()]), got);
+}
+
+#[test]
+fn foreign_table_in_select_is_rejected_before_execution() {
+    let conn = &mut establish_connection();
+    create_user_table(conn);
+
+    let users = table("users");
+    let posts = table("posts");
+    let posts_id = posts.column::<Integer, _>("id");
+
+    let err = users.select(posts_id).load::<i32>(conn).unwrap_err();
+    assert_foreign_table_error(&err, "posts");
+}
+
+#[test]
+fn foreign_column_rejected_in_filter_and_order() {
+    let conn = &mut establish_connection();
+    create_user_table(conn);
+
+    let users = table("users");
+    let name = users.column::<Text, _>("name");
+    let posts = table("posts");
+    let posts_id = posts.column::<Integer, _>("id");
+
+    let err = users
+        .select(name)
+        .filter(posts_id.eq(1))
+        .load::<String>(conn)
+        .unwrap_err();
+    assert_foreign_table_error(&err, "posts");
+
+    let err = users
+        .select(name)
+        .order(posts_id.asc())
+        .load::<String>(conn)
+        .unwrap_err();
+    assert_foreign_table_error(&err, "posts");
+}
+
+#[test]
+fn nested_and_correlated_subqueries_resolve_current_and_outer_frames() {
+    let conn = &mut establish_connection();
+    create_user_table(conn);
+    create_posts_table(conn);
+    sql_query("INSERT INTO users (name) VALUES ('Sean')")
+        .execute(conn)
+        .unwrap();
+
+    let users = table("users");
+    let id = users.column::<Integer, _>("id");
+    let name = users.column::<Text, _>("name");
+    let posts = table("posts");
+    let post_user = posts.column::<Integer, _>("user_id");
+
+    let user_id = users.select(id).first::<i32>(conn).unwrap();
+    sql_query(format!("INSERT INTO posts (user_id) VALUES ({user_id})"))
+        .execute(conn)
+        .unwrap();
+
+    let nested = users
+        .select(name)
+        .filter(id.eq_any(posts.select(post_user)))
+        .load::<String>(conn);
+    assert_eq!(Ok(vec!["Sean".to_string()]), nested);
+
+    let correlated = users
+        .select(name)
+        .filter(diesel::dsl::exists(
+            posts.select(post_user).filter(post_user.eq(id)),
+        ))
+        .load::<String>(conn);
+    assert_eq!(Ok(vec!["Sean".to_string()]), correlated);
+
+    let other = table("other");
+    let other_col = other.column::<Integer, _>("x");
+    let err = users
+        .select(name)
+        .filter(diesel::dsl::exists(
+            posts.select(post_user).filter(other_col.eq(id)),
+        ))
+        .load::<String>(conn)
+        .unwrap_err();
+    assert_foreign_table_error(&err, "other");
+}
+
+#[test]
+fn root_query_without_source_rejects_dynamic_column() {
+    let conn = &mut establish_connection();
+    create_user_table(conn);
+
+    let users = table("users");
+    let name = users.column::<Text, _>("name");
+
+    let err = diesel::select(name).load::<String>(conn).unwrap_err();
+    assert_foreign_table_error(&err, "users");
+}
+
+#[test]
+fn standalone_fragment_render_has_no_statement_context() {
+    let users = table("users");
+    let name = users.column::<Text, _>("name");
+    let rendered = debug_query::<Backend, _>(&name).to_string();
+
+    #[cfg(feature = "postgres")]
+    assert_eq!(r#""users"."name" -- binds: []"#, rendered);
+    #[cfg(not(feature = "postgres"))]
+    assert_eq!("`users`.`name` -- binds: []", rendered);
+}
+
+#[test]
+fn schema_qualified_tables_compare_both_components() {
+    let conn = &mut establish_connection();
+    create_user_table(conn);
+
+    let from_a = schema("a").table("users");
+    let from_b = schema("b").table("users");
+    let b_name = from_b.column::<Text, _>("name");
+
+    let err = from_a.select(b_name).load::<String>(conn).unwrap_err();
+    assert_foreign_table_error(&err, "b.users");
+
+    let a_name = from_a.column::<Text, _>("name");
+    let rendered = debug_query::<Backend, _>(&from_a.select(a_name)).to_string();
+    assert!(
+        rendered.contains("users"),
+        "schema-qualified select should render, got `{}`",
+        rendered
+    );
 }
 
 #[test]
@@ -170,4 +358,92 @@ fn dynamic_group_by_without_aggregate_deduplicates() {
         .load::<String>(conn);
 
     assert_eq!(Ok(vec!["Sean".to_string(), "Tess".to_string()]), names);
+}
+
+#[test]
+fn foreign_column_rejected_in_group_by_and_having() {
+    use diesel::dsl::count;
+
+    let conn = &mut establish_connection();
+    create_user_table(conn);
+
+    let users = table("users");
+    let name = users.column::<Text, _>("name");
+    let posts = table("posts");
+    let posts_id = posts.column::<Integer, _>("id");
+
+    let err = users
+        .select(name)
+        .group_by(posts_id)
+        .load::<String>(conn)
+        .unwrap_err();
+    assert_foreign_table_error(&err, "posts");
+
+    let err = users
+        .select(name)
+        .group_by(name)
+        .having(count(posts_id).gt(1))
+        .load::<String>(conn)
+        .unwrap_err();
+    assert_foreign_table_error(&err, "posts");
+}
+
+#[test]
+fn foreign_column_rejected_in_update_where() {
+    let conn = &mut establish_connection();
+    let posts = table("posts");
+    let posts_id = posts.column::<Integer, _>("id");
+
+    let err = diesel::update(static_schema::users::table)
+        .set(static_schema::users::name.eq("x"))
+        .filter(posts_id.eq(1))
+        .execute(conn)
+        .unwrap_err();
+    assert_foreign_table_error(&err, "posts");
+}
+
+#[test]
+fn foreign_column_rejected_in_delete_where() {
+    let conn = &mut establish_connection();
+    let posts = table("posts");
+    let posts_id = posts.column::<Integer, _>("id");
+
+    let err = diesel::delete(static_schema::users::table)
+        .filter(posts_id.eq(1))
+        .execute(conn)
+        .unwrap_err();
+    assert_foreign_table_error(&err, "posts");
+}
+
+#[test]
+fn foreign_column_rejected_over_static_join() {
+    use diesel::query_dsl::JoinOnDsl;
+
+    let conn = &mut establish_connection();
+    let other = table("other");
+    let other_col = other.column::<Integer, _>("x");
+
+    let err = static_schema::users::table
+        .inner_join(
+            static_schema::posts::table.on(static_schema::users::id.eq(static_schema::posts::id)),
+        )
+        .select(other_col)
+        .load::<i32>(conn)
+        .unwrap_err();
+    assert_foreign_table_error(&err, "other");
+}
+
+#[test]
+#[cfg(feature = "postgres")]
+fn foreign_column_rejected_in_insert_returning() {
+    let conn = &mut establish_connection();
+    let posts = table("posts");
+    let posts_id = posts.column::<Integer, _>("id");
+
+    let err = diesel::insert_into(static_schema::users::table)
+        .values(static_schema::users::name.eq("x"))
+        .returning(posts_id)
+        .get_result::<i32>(conn)
+        .unwrap_err();
+    assert_foreign_table_error(&err, "posts");
 }

--- a/diesel_dynamic_schema/tests/lib.rs
+++ b/diesel_dynamic_schema/tests/lib.rs
@@ -93,3 +93,81 @@ fn providing_custom_schema_name() {
     #[cfg(not(feature = "postgres"))]
     assert_eq!("`information_schema`.`users` -- binds: []", sql.to_string());
 }
+
+#[test]
+fn dynamic_group_by_having_filters_groups() {
+    use diesel::dsl::count;
+
+    let conn = &mut establish_connection();
+    create_user_table(conn);
+    sql_query("INSERT INTO users (name) VALUES ('Sean'), ('Sean'), ('Tess')")
+        .execute(conn)
+        .unwrap();
+
+    let users = table("users");
+    let id = users.column::<Integer, _>("id");
+    let name = users.column::<Text, _>("name");
+
+    let counts = users
+        .select((name, count(id)))
+        .group_by(name)
+        .having(count(id).gt(1))
+        .order(name)
+        .load::<(String, i64)>(conn);
+
+    assert_eq!(Ok(vec![("Sean".into(), 2)]), counts);
+}
+
+#[test]
+fn dynamic_group_by_multiple_columns() {
+    use diesel::dsl::count;
+
+    let conn = &mut establish_connection();
+    create_user_table(conn);
+    sql_query(
+        "INSERT INTO users (name, hair_color) VALUES \
+         ('Sean', 'black'), ('Sean', 'black'), ('Sean', 'blonde'), ('Tess', 'red')",
+    )
+    .execute(conn)
+    .unwrap();
+
+    let users = table("users");
+    let id = users.column::<Integer, _>("id");
+    let name = users.column::<Text, _>("name");
+    let hair_color = users.column::<Text, _>("hair_color");
+
+    let counts = users
+        .select((name, hair_color, count(id)))
+        .group_by((name, hair_color))
+        .order((name, hair_color))
+        .load::<(String, String, i64)>(conn);
+
+    assert_eq!(
+        Ok(vec![
+            ("Sean".into(), "black".into(), 2),
+            ("Sean".into(), "blonde".into(), 1),
+            ("Tess".into(), "red".into(), 1),
+        ]),
+        counts
+    );
+}
+
+#[test]
+fn dynamic_group_by_without_aggregate_deduplicates() {
+    let conn = &mut establish_connection();
+    create_user_table(conn);
+    sql_query("INSERT INTO users (name) VALUES ('Sean'), ('Sean'), ('Tess')")
+        .execute(conn)
+        .unwrap();
+
+    let users = table("users");
+    let name = users.column::<Text, _>("name");
+
+    let names = users
+        .select(name)
+        .group_by(name)
+        .order(name)
+        .load::<String>(conn);
+
+    assert_eq!(Ok(vec!["Sean".to_string(), "Tess".to_string()]), names);
+}


### PR DESCRIPTION
This PR validates that `diesel_dynamic_schema` columns belong to a runtime table present in the query.

I believe that the check can either be added in the core Diesel walks statements (which is what I do in this PR), or dynamic schema must wrap every relevant select and mutation path, which I believe would require significantly more code.

These core changes are internal or doc-hidden.

This PR is "stacked" on #5164 and #5165, meaning its changes are the ones in https://github.com/diesel-rs/diesel/commit/29a9f52b8aa3aba902ec37cb816af74a5cfdd733

<details>
*Since I wrote like 5 times "column are belongs" while writing this PR I could not not do this*
<img width="1672" height="941" alt="image" src="https://github.com/user-attachments/assets/379af436-f49d-4eb7-ace6-7d1e9fab126d" />
</details>