### PR TITLE
Use `PostgreSQL` array element OIDs when decoding elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 * Fixed several Tests using schema modifications for `mysql` and `mariadb`
 * MySQL and MariaDB now decode a value according to the signedness the server reports for its column, so a `SMALLINT UNSIGNED` holding 40000 read as `Integer` returns 40000 rather than -25536
 * Fixed a possible null pointer dereference in the custom SQLite aggregate function support when SQLite fails to allocate the aggregate state
+* `FromSql` impls for PostgreSQL arrays now use the element OID from the array header instead of the array type's own OID when decoding each element, matching the behavior of the record decoder.
 
 ### Changed
 

--- a/diesel/src/pg/types/array.rs
+++ b/diesel/src/pg/types/array.rs
@@ -1,5 +1,6 @@
 use byteorder::{NetworkEndian, ReadBytesExt, WriteBytesExt};
 use core::fmt;
+use core::num::NonZeroU32;
 use std::io::Write;
 
 use crate::deserialize::{self, FromSql, FromSqlRow};
@@ -49,7 +50,8 @@ where
         let mut bytes = value.as_bytes();
         let num_dimensions = bytes.read_i32::<NetworkEndian>()?;
         let has_null = bytes.read_i32::<NetworkEndian>()? != 0;
-        let _oid = bytes.read_i32::<NetworkEndian>()?;
+        let element_oid =
+            NonZeroU32::new(bytes.read_u32::<NetworkEndian>()?).ok_or("Oid's aren't zero")?;
 
         if num_dimensions == 0 {
             return Ok(Vec::new());
@@ -77,7 +79,7 @@ where
                             )
                         })?;
                     bytes = new_bytes;
-                    T::from_sql(PgValue::new_internal(elem_bytes, &value))
+                    T::from_sql(PgValue::new_internal(elem_bytes, &element_oid))
                 }
             })
             .collect()
@@ -93,7 +95,8 @@ where
         let mut bytes = value.as_bytes();
         let num_dimensions = bytes.read_i32::<NetworkEndian>()?;
         let has_null = bytes.read_i32::<NetworkEndian>()? != 0;
-        let _oid = bytes.read_i32::<NetworkEndian>()?;
+        let element_oid =
+            NonZeroU32::new(bytes.read_u32::<NetworkEndian>()?).ok_or("Oid's aren't zero")?;
 
         if num_dimensions == 0 {
             return Ok(NdArray {
@@ -138,7 +141,7 @@ where
                             )
                         })?;
                     bytes = new_bytes;
-                    T::from_sql(PgValue::new_internal(elem_bytes, &value))
+                    T::from_sql(PgValue::new_internal(elem_bytes, &element_oid))
                 }
             })
             .collect::<deserialize::Result<Vec<T>>>()?;
@@ -256,9 +259,59 @@ mod tests {
     use byteorder::{NetworkEndian, WriteBytesExt};
 
     use crate::data_types::NdArray;
-    use crate::deserialize::FromSql;
+    use crate::deserialize::{self, FromSql};
     use crate::pg::{Pg, PgValue};
     use crate::sql_types::{Array, Integer};
+
+    #[derive(Debug, PartialEq)]
+    struct ElementOid(u32);
+
+    impl FromSql<Integer, Pg> for ElementOid {
+        fn from_sql(value: PgValue<'_>) -> deserialize::Result<Self> {
+            Ok(Self(value.get_oid().get()))
+        }
+    }
+
+    fn one_element_array_value(element_oid: u32) -> Vec<u8> {
+        let mut value = Vec::<u8>::new();
+        value.write_i32::<NetworkEndian>(1).unwrap();
+        value.write_i32::<NetworkEndian>(0).unwrap();
+        value.write_u32::<NetworkEndian>(element_oid).unwrap();
+        value.write_i32::<NetworkEndian>(1).unwrap();
+        value.write_i32::<NetworkEndian>(0).unwrap();
+        value.write_i32::<NetworkEndian>(4).unwrap();
+        value.write_i32::<NetworkEndian>(42).unwrap();
+        value
+    }
+
+    #[test]
+    fn zero_element_oid_is_rejected() {
+        let value = one_element_array_value(0);
+        let value = PgValue::for_test(&value);
+        let res = <Vec<ElementOid> as FromSql<Array<Integer>, Pg>>::from_sql(value);
+        assert!(res.is_err());
+        assert_eq!(format!("{}", res.unwrap_err()), "Oid's aren't zero");
+
+        let value = one_element_array_value(0);
+        let value = PgValue::for_test(&value);
+        let res = <NdArray<ElementOid> as FromSql<Array<Integer>, Pg>>::from_sql(value);
+        assert!(res.is_err());
+        assert_eq!(format!("{}", res.unwrap_err()), "Oid's aren't zero");
+    }
+
+    #[test]
+    fn nonzero_header_oid_is_used_for_element() {
+        let value = one_element_array_value(23);
+        let value = PgValue::for_test(&value);
+        let res = <Vec<ElementOid> as FromSql<Array<Integer>, Pg>>::from_sql(value);
+        assert_eq!(vec![ElementOid(23)], res.unwrap());
+
+        let value = one_element_array_value(23);
+        let value = PgValue::for_test(&value);
+        let res = <NdArray<ElementOid> as FromSql<Array<Integer>, Pg>>::from_sql(value).unwrap();
+        assert_eq!(vec![1], res.dims);
+        assert_eq!(vec![ElementOid(23)], res.data);
+    }
 
     #[test]
     fn check_invalid_element_size_for_array() {
@@ -270,7 +323,7 @@ mod tests {
         // has null
         value.write_i32::<NetworkEndian>(0).unwrap();
         // oid
-        value.write_i32::<NetworkEndian>(0).unwrap();
+        value.write_u32::<NetworkEndian>(23).unwrap();
         // num elements
         value.write_i32::<NetworkEndian>(2).unwrap();
         // lower bound
@@ -296,7 +349,7 @@ mod tests {
         // has null
         value.write_i32::<NetworkEndian>(0).unwrap();
         // oid
-        value.write_i32::<NetworkEndian>(0).unwrap();
+        value.write_u32::<NetworkEndian>(23).unwrap();
         // num elements
         value.write_i32::<NetworkEndian>(2).unwrap();
         // lower bound
@@ -325,7 +378,7 @@ mod tests {
         // has null
         value.write_i32::<NetworkEndian>(0).unwrap();
         // oid
-        value.write_i32::<NetworkEndian>(0).unwrap();
+        value.write_u32::<NetworkEndian>(23).unwrap();
         // num elements
         value.write_i32::<NetworkEndian>(2).unwrap();
         // lower bound
@@ -351,7 +404,7 @@ mod tests {
         // has null
         value.write_i32::<NetworkEndian>(0).unwrap();
         // oid
-        value.write_i32::<NetworkEndian>(0).unwrap();
+        value.write_u32::<NetworkEndian>(23).unwrap();
         // num elements
         value.write_i32::<NetworkEndian>(2).unwrap();
         // lower bound

--- a/diesel_tests/tests/types.rs
+++ b/diesel_tests/tests/types.rs
@@ -829,6 +829,59 @@ fn pg_ndim_array_from_sql() {
     );
 }
 
+#[diesel_test_helper::test]
+#[cfg(feature = "postgres")]
+fn pg_array_element_oid_uses_array_header() {
+    use diesel::data_types::NdArray;
+    use diesel::deserialize::FromSql;
+    use diesel::pg::PgValue;
+
+    #[derive(Debug, Clone, Copy, QueryId, SqlType)]
+    struct ElementOidInteger;
+
+    #[derive(Debug, PartialEq)]
+    struct ElementWithOid {
+        value: i32,
+        oid: u32,
+    }
+
+    impl HasSqlType<ElementOidInteger> for Pg {
+        fn metadata(lookup: &mut Self::MetadataLookup) -> Self::TypeMetadata {
+            <Pg as HasSqlType<Integer>>::metadata(lookup)
+        }
+    }
+
+    impl FromSql<ElementOidInteger, Pg> for ElementWithOid {
+        fn from_sql(bytes: PgValue<'_>) -> deserialize::Result<Self> {
+            let oid = bytes.get_oid().get();
+            let value = FromSql::<Integer, Pg>::from_sql(bytes)?;
+            Ok(Self { value, oid })
+        }
+    }
+
+    assert_eq!(
+        vec![
+            ElementWithOid { value: 1, oid: 23 },
+            ElementWithOid { value: 2, oid: 23 },
+        ],
+        query_single_value::<Array<ElementOidInteger>, Vec<ElementWithOid>>("ARRAY[1, 2]::int4[]")
+    );
+
+    let ndarray = query_single_value::<Array<ElementOidInteger>, NdArray<ElementWithOid>>(
+        "ARRAY[ARRAY[1, 2], ARRAY[3, 4]]::int4[]",
+    );
+    assert_eq!(vec![2, 2], ndarray.dims);
+    assert_eq!(
+        vec![
+            ElementWithOid { value: 1, oid: 23 },
+            ElementWithOid { value: 2, oid: 23 },
+            ElementWithOid { value: 3, oid: 23 },
+            ElementWithOid { value: 4, oid: 23 },
+        ],
+        ndarray.data
+    );
+}
+
 #[cfg(feature = "postgres")]
 #[diesel_test_helper::test]
 fn pg_array_from_sql_non_one_lower_bound() {


### PR DESCRIPTION
Diesel was building each array element `PgValue` from the outer array lookup, so custom `FromSql` code that calls `PgValue::get_oid()` saw the array `OID`, for example `1007` for `int4[]`, instead of the element OID, for example `23` for `int4`.

This uses the element OID from the PostgreSQL array header for each decoded element, while keeping the existing fallback when the header OID is zero. The regression test covers both `Vec<T>` and `NdArray<T>`.

Found out while working on #5164