### PR TITLE
Support `PostgreSQL` numeric infinities in `PgNumeric`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 * `diesel print-schema` now generates `joinable!` and `allow_tables_to_appear_in_same_query!` for PostgreSQL foreign keys across multiple configured schemas
 * Fixed several Tests using schema modifications for `mysql` and `mariadb`
 * Fixed an overflow while converting a PostgreSQL `Interval` into a `chrono::Duration`, which panicked with debug assertions enabled and silently produced a wrong, sometimes negative, duration without them
+* `'Infinity'::numeric` and `'-Infinity'::numeric` (PostgreSQL >= 14) now decode into `PgNumeric::PositiveInfinity` and `PgNumeric::NegativeInfinity` instead of failing with an invalid sign error. `BigDecimal` has no infinity, so converting either errors
 
 ### Changed
 
@@ -74,6 +75,7 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 * Add support for no-std environments using the SQLite backend
 * Improved documentation and added examples for `filter_target` on `IncompleteOnConflict`
 * A MySQL or MariaDB read whose requested signedness disagrees with the column's now errors instead of reinterpreting the bits, which affects a signed value read through `Unsigned<T>` and an `UNSIGNED BIGINT` above `i64::MAX` read as `BigInt`
+* `PgNumeric` gained the `PositiveInfinity` and `NegativeInfinity` variants, so an exhaustive `match` on it needs updating
 
 
 ## [2.3.13] 2026-09-4

--- a/diesel/src/pg/types/floats/mod.rs
+++ b/diesel/src/pg/types/floats/mod.rs
@@ -32,6 +32,12 @@ pub enum PgNumeric {
         /// The digits in this number, stored in base 10000
         digits: Vec<i16>,
     },
+    /// Positive infinity, requires PostgreSQL >= 14
+    ///
+    /// See [the PostgreSQL documentation](https://www.postgresql.org/docs/current/datatype-numeric.html#DATATYPE-NUMERIC-DECIMAL)
+    PositiveInfinity,
+    /// Negative infinity, requires PostgreSQL >= 14
+    NegativeInfinity,
     /// Not a number
     #[default]
     NaN,
@@ -43,7 +49,7 @@ struct InvalidNumericSign(u16);
 
 impl core::fmt::Display for InvalidNumericSign {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.write_str("sign for numeric field was not one of 0, 0x4000, 0xC000")
+        f.write_str("sign for numeric field was not one of 0, 0x4000, 0xC000, 0xD000, 0xF000")
     }
 }
 
@@ -54,7 +60,7 @@ impl FromSql<sql_types::Numeric, Pg> for PgNumeric {
     fn from_sql(bytes: PgValue<'_>) -> deserialize::Result<Self> {
         let mut bytes = bytes.as_bytes();
         let digit_count = bytes.read_u16::<NetworkEndian>()?;
-        let mut digits = Vec::with_capacity(digit_count as usize);
+        let mut digits = Vec::with_capacity(usize::from(digit_count));
         let weight = bytes.read_i16::<NetworkEndian>()?;
         let sign = bytes.read_u16::<NetworkEndian>()?;
         let scale = bytes.read_u16::<NetworkEndian>()?;
@@ -74,6 +80,8 @@ impl FromSql<sql_types::Numeric, Pg> for PgNumeric {
                 digits,
             }),
             0xC000 => Ok(PgNumeric::NaN),
+            0xD000 => Ok(PgNumeric::PositiveInfinity),
+            0xF000 => Ok(PgNumeric::NegativeInfinity),
             invalid => Err(Box::new(InvalidNumericSign(invalid))),
         }
     }
@@ -86,21 +94,22 @@ impl ToSql<sql_types::Numeric, Pg> for PgNumeric {
             PgNumeric::Positive { .. } => 0,
             PgNumeric::Negative { .. } => 0x4000,
             PgNumeric::NaN => 0xC000,
+            PgNumeric::PositiveInfinity => 0xD000,
+            PgNumeric::NegativeInfinity => 0xF000,
         };
-        let empty_vec = Vec::new();
-        let digits = match *self {
+        let digits: &[i16] = match *self {
             PgNumeric::Positive { ref digits, .. } | PgNumeric::Negative { ref digits, .. } => {
                 digits
             }
-            PgNumeric::NaN => &empty_vec,
+            PgNumeric::NaN | PgNumeric::PositiveInfinity | PgNumeric::NegativeInfinity => &[],
         };
         let weight = match *self {
             PgNumeric::Positive { weight, .. } | PgNumeric::Negative { weight, .. } => weight,
-            PgNumeric::NaN => 0,
+            PgNumeric::NaN | PgNumeric::PositiveInfinity | PgNumeric::NegativeInfinity => 0,
         };
         let scale = match *self {
             PgNumeric::Positive { scale, .. } | PgNumeric::Negative { scale, .. } => scale,
-            PgNumeric::NaN => 0,
+            PgNumeric::NaN | PgNumeric::PositiveInfinity | PgNumeric::NegativeInfinity => 0,
         };
         out.write_u16::<NetworkEndian>(digits.len().try_into()?)?;
         out.write_i16::<NetworkEndian>(weight)?;

--- a/diesel/src/pg/types/floats/quickcheck_impls.rs
+++ b/diesel/src/pg/types/floats/quickcheck_impls.rs
@@ -8,31 +8,42 @@ const SCALE_MASK: u16 = 0x3FFF;
 
 impl Arbitrary for PgNumeric {
     fn arbitrary(g: &mut Gen) -> Self {
-        let mut variant = Option::<bool>::arbitrary(g);
+        match g
+            .choose(&[0u8, 1, 2, 3, 4])
+            .copied()
+            .expect("the slice is not empty")
+        {
+            2 => return PgNumeric::NaN,
+            3 => return PgNumeric::PositiveInfinity,
+            4 => return PgNumeric::NegativeInfinity,
+            _ => {}
+        }
+
+        let mut positive = bool::arbitrary(g);
         let mut weight = -1;
         while weight < 0 {
             // Oh postgres... Don't ever change. https://bit.ly/lol-code-comments
             weight = i16::arbitrary(g);
         }
         let scale = u16::arbitrary(g) & SCALE_MASK;
-        let digits = gen_vec_of_appropriate_length_valid_digits(g, weight as u16, scale);
+        let weight_u16 = u16::try_from(weight).expect("weight is non-negative");
+        let digits = gen_vec_of_appropriate_length_valid_digits(g, weight_u16, scale);
         if digits.is_empty() {
             weight = 0;
-            variant = Some(true);
+            positive = true;
         }
 
-        match variant {
-            Some(true) => PgNumeric::Positive {
-                digits: digits,
-                weight: weight,
-                scale: scale,
+        match positive {
+            true => PgNumeric::Positive {
+                digits,
+                weight,
+                scale,
             },
-            Some(false) => PgNumeric::Negative {
-                digits: digits,
-                weight: weight,
-                scale: scale,
+            false => PgNumeric::Negative {
+                digits,
+                weight,
+                scale,
             },
-            None => PgNumeric::NaN,
         }
     }
 }
@@ -43,7 +54,7 @@ fn gen_vec_of_appropriate_length_valid_digits(g: &mut Gen, weight: u16, scale: u
         .into_iter()
         .map(|d| d.0)
         .skip_while(|d| d == &0) // drop leading zeros
-        .take(max_digits as usize)
+        .take(usize::from(max_digits))
         .collect::<Vec<_>>();
     while digits.last() == Some(&0) {
         digits.pop(); // drop trailing zeros

--- a/diesel/src/pg/types/numeric.rs
+++ b/diesel/src/pg/types/numeric.rs
@@ -55,6 +55,9 @@ mod bigdecimal {
                 PgNumeric::NaN => {
                     return Err(Box::from("NaN is not (yet) supported in BigDecimal"));
                 }
+                PgNumeric::PositiveInfinity | PgNumeric::NegativeInfinity => {
+                    return Err(Box::from("Infinity is not supported in BigDecimal"));
+                }
             };
 
             let mut result = BigUint::default();
@@ -201,6 +204,12 @@ mod bigdecimal {
 
         use super::*;
         use std::str::FromStr;
+
+        #[diesel_test_helper::test]
+        fn infinity_pgnumeric_does_not_convert_to_bigdecimal() {
+            assert!(BigDecimal::try_from(PgNumeric::PositiveInfinity).is_err());
+            assert!(BigDecimal::try_from(PgNumeric::NegativeInfinity).is_err());
+        }
 
         #[diesel_test_helper::test]
         fn bigdecimal_to_pgnumeric_converts_digits_to_base_10000() {

--- a/diesel_tests/tests/types.rs
+++ b/diesel_tests/tests/types.rs
@@ -1074,6 +1074,33 @@ fn pg_numeric_from_sql() {
         expected_value,
         query_single_value::<Numeric, PgNumeric>(query)
     );
+    let query = "'Infinity'::numeric";
+    let expected_value = PgNumeric::PositiveInfinity;
+    assert_eq!(
+        expected_value,
+        query_single_value::<Numeric, PgNumeric>(query)
+    );
+    let query = "'-Infinity'::numeric";
+    let expected_value = PgNumeric::NegativeInfinity;
+    assert_eq!(
+        expected_value,
+        query_single_value::<Numeric, PgNumeric>(query)
+    );
+}
+
+#[diesel_test_helper::test]
+#[cfg(feature = "postgres")]
+fn pg_numeric_infinity_to_sql() {
+    use diesel::data_types::PgNumeric;
+
+    assert!(query_to_sql_equality::<Numeric, PgNumeric>(
+        "'Infinity'::numeric",
+        PgNumeric::PositiveInfinity,
+    ));
+    assert!(query_to_sql_equality::<Numeric, PgNumeric>(
+        "'-Infinity'::numeric",
+        PgNumeric::NegativeInfinity,
+    ));
 }
 
 #[diesel_test_helper::test]


### PR DESCRIPTION
`PostgreSQL` accepts `Infinity` and `-Infinity` for unconstrained numeric, but Diesel rejects their binary sign words during decoding with `InvalidNumericSign`. Diesel also cannot bind those values today, because `PgNumeric` has no public value that represents either infinity.

This patch adds explicit `PgNumeric` variants for both infinity values, using `PostgreSQL`'s wire sign words `0xD000` and `0xF000`. `BigDecimal` remains finite-only, so reading either infinity as `BigDecimal` still returns an error, matching its existing `NaN` behavior.

**This is, to my understanding, API breaking**, but the only variant I could come up with is a second full-domain enum, for example `PgNumericWithInfinities`, maybe wrapping `PgNumeric`.