### PR TITLE
Add integration tests for SQLite json -> and ->> operators

### DIFF
--- a/diesel_tests/tests/expressions/json_operators.rs
+++ b/diesel_tests/tests/expressions/json_operators.rs
@@ -1,6 +1,10 @@
+#[cfg(feature = "sqlite")]
 use crate::schema::connection;
+#[cfg(feature = "sqlite")]
 use diesel::dsl::sql;
+#[cfg(feature = "sqlite")]
 use diesel::prelude::*;
+#[cfg(feature = "sqlite")]
 use diesel::sql_types::{Json, Jsonb};
 
 #[diesel_test_helper::test]

--- a/diesel_tests/tests/expressions/json_operators.rs
+++ b/diesel_tests/tests/expressions/json_operators.rs
@@ -12,22 +12,25 @@ use diesel::sql_types::{Json, Jsonb};
 fn json_arrow_operator_with_path() {
     let conn = &mut connection();
 
-    let result = diesel::select(sql::<Json>(r#"json('{"a": {"b": [1, 2, 3]}}')"#)
-        .retrieve_as_object_sqlite("$.a.b[0]"))
-        .get_result::<serde_json::Value>(conn)
-        .unwrap();
+    let result = diesel::select(
+        sql::<Json>(r#"json('{"a": {"b": [1, 2, 3]}}')"#).retrieve_as_object_sqlite("$.a.b[0]"),
+    )
+    .get_result::<serde_json::Value>(conn)
+    .unwrap();
     assert_eq!(serde_json::json!(1), result);
 
-    let result = diesel::select(sql::<Json>(r#"json('{"a": [1, 2, 3]}')"#)
-        .retrieve_as_object_sqlite("$.a[1]"))
-        .get_result::<serde_json::Value>(conn)
-        .unwrap();
+    let result = diesel::select(
+        sql::<Json>(r#"json('{"a": [1, 2, 3]}')"#).retrieve_as_object_sqlite("$.a[1]"),
+    )
+    .get_result::<serde_json::Value>(conn)
+    .unwrap();
     assert_eq!(serde_json::json!(2), result);
 
-    let result = diesel::select(sql::<Jsonb>(r#"json('{"a": {"b": [1, 2, 3]}}')"#)
-        .retrieve_as_object_sqlite("$.a.b[0]"))
-        .get_result::<serde_json::Value>(conn)
-        .unwrap();
+    let result = diesel::select(
+        sql::<Jsonb>(r#"json('{"a": {"b": [1, 2, 3]}}')"#).retrieve_as_object_sqlite("$.a.b[0]"),
+    )
+    .get_result::<serde_json::Value>(conn)
+    .unwrap();
     assert_eq!(serde_json::json!(1), result);
 }
 
@@ -36,16 +39,16 @@ fn json_arrow_operator_with_path() {
 fn json_arrow_operator_with_integer() {
     let conn = &mut connection();
 
-    let result = diesel::select(sql::<Json>(r#"json('[10, 20, 30]')"#)
-        .retrieve_as_object_sqlite(0))
-        .get_result::<serde_json::Value>(conn)
-        .unwrap();
+    let result =
+        diesel::select(sql::<Json>(r#"json('[10, 20, 30]')"#).retrieve_as_object_sqlite(0))
+            .get_result::<serde_json::Value>(conn)
+            .unwrap();
     assert_eq!(serde_json::json!(10), result);
 
-    let result = diesel::select(sql::<Json>(r#"json('[10, 20, 30]')"#)
-        .retrieve_as_object_sqlite(-1))
-        .get_result::<serde_json::Value>(conn)
-        .unwrap();
+    let result =
+        diesel::select(sql::<Json>(r#"json('[10, 20, 30]')"#).retrieve_as_object_sqlite(-1))
+            .get_result::<serde_json::Value>(conn)
+            .unwrap();
     assert_eq!(serde_json::json!(30), result);
 }
 
@@ -54,20 +57,17 @@ fn json_arrow_operator_with_integer() {
 fn json_arrow_arrow_operator_with_path() {
     let conn = &mut connection();
 
-    let result = diesel::select(sql::<Json>(r#"json('{"a": "xyz"}')"#)
-        .retrieve_as_text("$.a"))
+    let result = diesel::select(sql::<Json>(r#"json('{"a": "xyz"}')"#).retrieve_as_text("$.a"))
         .get_result::<String>(conn)
         .unwrap();
     assert_eq!("xyz", result);
 
-    let result = diesel::select(sql::<Json>(r#"json('{"a": 42}')"#)
-        .retrieve_as_text("$.a"))
+    let result = diesel::select(sql::<Json>(r#"json('{"a": 42}')"#).retrieve_as_text("$.a"))
         .get_result::<String>(conn)
         .unwrap();
     assert_eq!("42", result);
 
-    let result = diesel::select(sql::<Jsonb>(r#"json('{"a": "xyz"}')"#)
-        .retrieve_as_text("$.a"))
+    let result = diesel::select(sql::<Jsonb>(r#"json('{"a": "xyz"}')"#).retrieve_as_text("$.a"))
         .get_result::<String>(conn)
         .unwrap();
     assert_eq!("xyz", result);
@@ -78,11 +78,13 @@ fn json_arrow_arrow_operator_with_path() {
 fn json_arrow_arrow_operator_missing_path_is_null() {
     let conn = &mut connection();
 
-    let result = diesel::select(sql::<Json>(r#"json('{"a": 1}')"#)
-        .retrieve_as_text("$.missing")
-        .nullable())
-        .get_result::<Option<String>>(conn)
-        .unwrap();
+    let result = diesel::select(
+        sql::<Json>(r#"json('{"a": 1}')"#)
+            .retrieve_as_text("$.missing")
+            .nullable(),
+    )
+    .get_result::<Option<String>>(conn)
+    .unwrap();
     assert_eq!(None, result);
 }
 
@@ -91,9 +93,9 @@ fn json_arrow_arrow_operator_missing_path_is_null() {
 fn json_arrow_arrow_operator_with_integer() {
     let conn = &mut connection();
 
-    let result = diesel::select(sql::<Json>(r#"json('{"a": ["x", "y", "z"]}')"#)
-        .retrieve_as_text("$.a[1]"))
-        .get_result::<String>(conn)
-        .unwrap();
+    let result =
+        diesel::select(sql::<Json>(r#"json('{"a": ["x", "y", "z"]}')"#).retrieve_as_text("$.a[1]"))
+            .get_result::<String>(conn)
+            .unwrap();
     assert_eq!("y", result);
 }

--- a/diesel_tests/tests/expressions/json_operators.rs
+++ b/diesel_tests/tests/expressions/json_operators.rs
@@ -1,0 +1,95 @@
+use crate::schema::connection;
+use diesel::dsl::sql;
+use diesel::prelude::*;
+use diesel::sql_types::{Json, Jsonb};
+
+#[diesel_test_helper::test]
+#[cfg(feature = "sqlite")]
+fn json_arrow_operator_with_path() {
+    let conn = &mut connection();
+
+    let result = diesel::select(sql::<Json>(r#"json('{"a": {"b": [1, 2, 3]}}')"#)
+        .retrieve_as_object_sqlite("$.a.b[0]"))
+        .get_result::<serde_json::Value>(conn)
+        .unwrap();
+    assert_eq!(serde_json::json!(1), result);
+
+    let result = diesel::select(sql::<Json>(r#"json('{"a": [1, 2, 3]}')"#)
+        .retrieve_as_object_sqlite("$.a[1]"))
+        .get_result::<serde_json::Value>(conn)
+        .unwrap();
+    assert_eq!(serde_json::json!(2), result);
+
+    let result = diesel::select(sql::<Jsonb>(r#"json('{"a": {"b": [1, 2, 3]}}')"#)
+        .retrieve_as_object_sqlite("$.a.b[0]"))
+        .get_result::<serde_json::Value>(conn)
+        .unwrap();
+    assert_eq!(serde_json::json!(1), result);
+}
+
+#[diesel_test_helper::test]
+#[cfg(feature = "sqlite")]
+fn json_arrow_operator_with_integer() {
+    let conn = &mut connection();
+
+    let result = diesel::select(sql::<Json>(r#"json('[10, 20, 30]')"#)
+        .retrieve_as_object_sqlite(0))
+        .get_result::<serde_json::Value>(conn)
+        .unwrap();
+    assert_eq!(serde_json::json!(10), result);
+
+    let result = diesel::select(sql::<Json>(r#"json('[10, 20, 30]')"#)
+        .retrieve_as_object_sqlite(-1))
+        .get_result::<serde_json::Value>(conn)
+        .unwrap();
+    assert_eq!(serde_json::json!(30), result);
+}
+
+#[diesel_test_helper::test]
+#[cfg(feature = "sqlite")]
+fn json_arrow_arrow_operator_with_path() {
+    let conn = &mut connection();
+
+    let result = diesel::select(sql::<Json>(r#"json('{"a": "xyz"}')"#)
+        .retrieve_as_text("$.a"))
+        .get_result::<String>(conn)
+        .unwrap();
+    assert_eq!("xyz", result);
+
+    let result = diesel::select(sql::<Json>(r#"json('{"a": 42}')"#)
+        .retrieve_as_text("$.a"))
+        .get_result::<String>(conn)
+        .unwrap();
+    assert_eq!("42", result);
+
+    let result = diesel::select(sql::<Jsonb>(r#"json('{"a": "xyz"}')"#)
+        .retrieve_as_text("$.a"))
+        .get_result::<String>(conn)
+        .unwrap();
+    assert_eq!("xyz", result);
+}
+
+#[diesel_test_helper::test]
+#[cfg(feature = "sqlite")]
+fn json_arrow_arrow_operator_missing_path_is_null() {
+    let conn = &mut connection();
+
+    let result = diesel::select(sql::<Json>(r#"json('{"a": 1}')"#)
+        .retrieve_as_text("$.missing")
+        .nullable())
+        .get_result::<Option<String>>(conn)
+        .unwrap();
+    assert_eq!(None, result);
+}
+
+#[diesel_test_helper::test]
+#[cfg(feature = "sqlite")]
+fn json_arrow_arrow_operator_with_integer() {
+    let conn = &mut connection();
+
+    let result = diesel::select(sql::<Json>(r#"json('{"a": ["x", "y", "z"]}')"#)
+        .retrieve_as_text("$.a[1]"))
+        .get_result::<String>(conn)
+        .unwrap();
+    assert_eq!("y", result);
+}

--- a/diesel_tests/tests/expressions/mod.rs
+++ b/diesel_tests/tests/expressions/mod.rs
@@ -1,6 +1,7 @@
 use bigdecimal;
 
 mod date_and_time;
+mod json_operators;
 mod ops;
 
 use self::bigdecimal::BigDecimal;


### PR DESCRIPTION
Issue #4366 asked for integration coverage of the SQLite json `->` and `->>` operators. The operators exist but only doc-tests cover them.

These integration tests add:
- `->` (`retrieve_as_object_sqlite`) with a JSON path and an integer index, on `Json` and `Jsonb`
- `->>` (`retrieve_as_text`) with a JSON path and an array index, plus the NULL case for a missing path

Relates to #4366.
