### PR TITLE
Support negative `MySQL` and `MariaDB` `TIME` values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 * `diesel print-schema` now generates `joinable!` and `allow_tables_to_appear_in_same_query!` for PostgreSQL foreign keys across multiple configured schemas
 * Fixed several Tests using schema modifications for `mysql` and `mariadb`
 * Fixed an overflow while converting a PostgreSQL `Interval` into a `chrono::Duration`, which panicked with debug assertions enabled and silently produced a wrong, sometimes negative, duration without them
+* Negative MySQL and MariaDB `TIME` values now load into `MysqlTime` instead of being rejected while decoding. `chrono::NaiveTime` and `time::Time` cannot represent them, so those targets report that instead
 
 ### Changed
 

--- a/diesel/src/mysql_like/types/date_and_time/chrono.rs
+++ b/diesel/src/mysql_like/types/date_and_time/chrono.rs
@@ -85,6 +85,9 @@ impl<DB: MysqlLikeBackend> ToSql<Time, DB> for NaiveTime {
 impl<DB: MysqlLikeBackend> FromSql<Time, DB> for NaiveTime {
     fn from_sql(bytes: MysqlValue<'_>) -> deserialize::Result<Self> {
         let mysql_time = <MysqlTime as FromSql<Time, DB>>::from_sql(bytes)?;
+        if mysql_time.neg {
+            return Err("Negative times cannot be deserialized as chrono::NaiveTime".into());
+        }
         let micro = mysql_time.second_part.try_into()?;
         NaiveTime::from_hms_micro_opt(mysql_time.hour, mysql_time.minute, mysql_time.second, micro)
             .ok_or_else(|| format!("Unable to convert {mysql_time:?} to chrono").into())

--- a/diesel/src/mysql_like/types/date_and_time/time.rs
+++ b/diesel/src/mysql_like/types/date_and_time/time.rs
@@ -10,7 +10,9 @@ use crate::sql_types::{Date, Datetime, Time, Timestamp};
 
 use super::{MysqlTime, MysqlTimestampType};
 
+// Callers reject a negative `MysqlTime` first, the sign has nowhere to go here.
 fn to_time(dt: MysqlTime) -> Result<NaiveTime, Box<dyn core::error::Error>> {
+    debug_assert!(!dt.neg);
     for (name, field) in [
         ("year", dt.year),
         ("month", dt.month),
@@ -161,6 +163,9 @@ impl<DB: MysqlLikeBackend> ToSql<Time, DB> for NaiveTime {
 impl<DB: MysqlLikeBackend> FromSql<Time, DB> for NaiveTime {
     fn from_sql(bytes: MysqlValue<'_>) -> deserialize::Result<Self> {
         let mysql_time = <MysqlTime as FromSql<Time, DB>>::from_sql(bytes)?;
+        if mysql_time.neg {
+            return Err("Negative times cannot be deserialized as time::Time".into());
+        }
 
         to_time(mysql_time)
             .map_err(|err| format!("Unable to convert {mysql_time:?} to time: {err}").into())

--- a/diesel/src/mysql_like/value.rs
+++ b/diesel/src/mysql_like/value.rs
@@ -92,8 +92,8 @@ impl<'a> MysqlValue<'a> {
                     // We check for that above by looking at the byte before copying
                     out.assume_init()
                 };
-                if result.neg {
-                    Err("Negative dates/times are not yet supported".into())
+                if result.neg && self.tpe != MysqlType::Time {
+                    Err("Negative date, datetime, and timestamp values are not supported".into())
                 } else {
                     Ok(result)
                 }
@@ -236,6 +236,41 @@ fn invalid_reads() {
     }
     let offset = std::mem::offset_of!(MysqlTime, neg);
     bytes[offset] = 42;
+    assert!(
+        MysqlValue::new_internal(&bytes, MysqlType::Timestamp)
+            .time_value()
+            .is_err()
+    );
+
+    let negative_time = MysqlTime {
+        year: 0,
+        month: 0,
+        day: 0,
+        hour: 10,
+        minute: 11,
+        second: 12,
+        second_part: 0,
+        neg: true,
+        time_type: MysqlTimestampType::MYSQL_TIMESTAMP_TIME,
+        time_zone_displacement: 0,
+    };
+    let bytes = negative_time.serialize();
+    assert!(
+        MysqlValue::new_internal(&bytes, MysqlType::Time)
+            .time_value()
+            .unwrap()
+            .neg
+    );
+    assert!(
+        MysqlValue::new_internal(&bytes, MysqlType::Date)
+            .time_value()
+            .is_err()
+    );
+    assert!(
+        MysqlValue::new_internal(&bytes, MysqlType::DateTime)
+            .time_value()
+            .is_err()
+    );
     assert!(
         MysqlValue::new_internal(&bytes, MysqlType::Timestamp)
             .time_value()

--- a/diesel_tests/Cargo.toml
+++ b/diesel_tests/Cargo.toml
@@ -21,6 +21,7 @@ ipnet = { version = "2.5.0" }
 ipnetwork = ">=0.12.2, <0.22.0"
 bigdecimal = ">= 0.0.13, < 0.5.0"
 libsqlite3-sys = { workspace = true, optional = true }
+time = { version = "0.3.9", optional = true }
 rand = "0.9.0"
 pq-sys = { workspace = true, optional = true }
 pq-src = { version = "0.3", optional = true }
@@ -42,6 +43,7 @@ postgres = ["diesel/postgres", "diesel/network-address", "diesel/ipnet-address"]
 sqlite = ["diesel/sqlite"]
 mysql = ["diesel/mysql"]
 mariadb = ["diesel/mariadb"]
+time = ["diesel/time", "dep:time"]
 returning_clauses_for_sqlite_3_35 = ["diesel/returning_clauses_for_sqlite_3_35"]
 
 [[test]]

--- a/diesel_tests/tests/schema_dsl/functions.rs
+++ b/diesel_tests/tests/schema_dsl/functions.rs
@@ -31,6 +31,11 @@ pub fn time(name: &str) -> Column<'_, sql_types::VarChar> {
     Column::new(name, "TIME")
 }
 
+#[cfg(any(feature = "mysql", feature = "mariadb"))]
+pub fn time_with_fractional_seconds(name: &str) -> Column<'_, sql_types::VarChar> {
+    Column::new(name, "TIME(6)")
+}
+
 pub fn date(name: &str) -> Column<'_, sql_types::VarChar> {
     Column::new(name, "DATE")
 }

--- a/diesel_tests/tests/types.rs
+++ b/diesel_tests/tests/types.rs
@@ -30,6 +30,12 @@ table! {
     }
 }
 
+table! {
+    time_values(time_value) {
+        time_value -> Time,
+    }
+}
+
 #[diesel_test_helper::test]
 #[cfg(feature = "postgres")]
 fn errors_during_deserialization_do_not_panic() {
@@ -136,6 +142,148 @@ fn test_chrono_types_sqlite() {
     assert_eq!(result.datetime, dt);
     assert_eq!(result.date, dt.date());
     assert_eq!(result.time, dt.time());
+}
+
+#[cfg(any(feature = "mysql", feature = "mariadb"))]
+fn insert_time(connection: &mut TestConnection, value: diesel::data_types::MysqlTime) {
+    use crate::schema_dsl::*;
+
+    create_temporary_table(
+        "time_values",
+        (time_with_fractional_seconds("time_value").not_null(),),
+    )
+    .execute(connection)
+    .unwrap();
+
+    insert_into(time_values::table)
+        .values(time_values::time_value.eq(value))
+        .execute(connection)
+        .unwrap();
+}
+
+#[cfg(any(feature = "mysql", feature = "mariadb"))]
+fn insert_negative_time(connection: &mut TestConnection) {
+    use diesel::data_types::{MysqlTime, MysqlTimestampType};
+
+    insert_time(
+        connection,
+        MysqlTime::new(
+            0,
+            0,
+            0,
+            10,
+            11,
+            12,
+            123456,
+            true,
+            MysqlTimestampType::MYSQL_TIMESTAMP_TIME,
+            0,
+        ),
+    );
+}
+
+#[diesel_test_helper::test]
+#[cfg(any(feature = "mysql", feature = "mariadb"))]
+fn negative_time_loads_as_mysql_time() {
+    use diesel::data_types::{MysqlTime, MysqlTimestampType};
+
+    let connection = &mut connection();
+    insert_negative_time(connection);
+
+    let actual = time_values::table
+        .select(time_values::time_value)
+        .first::<MysqlTime>(connection)
+        .unwrap();
+
+    assert!(actual.neg);
+    assert_eq!(0, actual.year);
+    assert_eq!(0, actual.month);
+    assert_eq!(0, actual.day);
+    assert_eq!(10, actual.hour);
+    assert_eq!(11, actual.minute);
+    assert_eq!(12, actual.second);
+    assert_eq!(123456, actual.second_part);
+    assert_eq!(MysqlTimestampType::MYSQL_TIMESTAMP_TIME, actual.time_type);
+    assert_eq!(0, actual.time_zone_displacement);
+}
+
+#[diesel_test_helper::test]
+#[cfg(any(feature = "mysql", feature = "mariadb"))]
+fn negative_time_loads_as_chrono_time_fails() {
+    use diesel::result::Error::DeserializationError;
+
+    let connection = &mut connection();
+    insert_negative_time(connection);
+
+    let result = time_values::table
+        .select(time_values::time_value)
+        .first::<chrono::NaiveTime>(connection);
+
+    assert_matches!(result, Err(DeserializationError(_)));
+}
+
+#[diesel_test_helper::test]
+#[cfg(all(any(feature = "mysql", feature = "mariadb"), feature = "time"))]
+fn negative_time_loads_as_time_crate_time_fails() {
+    use diesel::result::Error::DeserializationError;
+
+    let connection = &mut connection();
+    insert_negative_time(connection);
+
+    let result = time_values::table
+        .select(time_values::time_value)
+        .first::<time::Time>(connection);
+
+    assert_matches!(result, Err(DeserializationError(_)));
+}
+
+// TIME range, 838 hours folded as 34 days plus 22 hours:
+// https://dev.mysql.com/doc/refman/8.4/en/time.html
+#[cfg(any(feature = "mysql", feature = "mariadb"))]
+fn assert_extreme_time_round_trip(neg: bool) {
+    use diesel::data_types::{MysqlTime, MysqlTimestampType};
+
+    let connection = &mut connection();
+    insert_time(
+        connection,
+        MysqlTime::new(
+            0,
+            0,
+            34,
+            22,
+            59,
+            59,
+            0,
+            neg,
+            MysqlTimestampType::MYSQL_TIMESTAMP_TIME,
+            0,
+        ),
+    );
+
+    let actual = time_values::table
+        .select(time_values::time_value)
+        .first::<MysqlTime>(connection)
+        .unwrap();
+
+    assert_eq!(neg, actual.neg);
+    // The server may redistribute the hours across `day` and `hour`.
+    assert_eq!(838, actual.day * 24 + actual.hour);
+    assert_eq!(59, actual.minute);
+    assert_eq!(59, actual.second);
+    assert_eq!(0, actual.second_part);
+    assert_eq!(MysqlTimestampType::MYSQL_TIMESTAMP_TIME, actual.time_type);
+}
+
+#[diesel_test_helper::test]
+#[cfg(any(feature = "mysql", feature = "mariadb"))]
+fn minimum_time_loads_as_mysql_time() {
+    assert_extreme_time_round_trip(true);
+}
+
+#[diesel_test_helper::test]
+#[cfg(any(feature = "mysql", feature = "mariadb"))]
+fn maximum_time_loads_as_mysql_time() {
+    assert_extreme_time_round_trip(false);
 }
 
 #[diesel_test_helper::test]


### PR DESCRIPTION
`MySQL` and `MariaDB` use `TIME` for signed durations, but Diesel rejects every negative `MYSQL_TIME` before `MysqlTime` or custom decoders can inspect it.

This PR only adds support to the sign only for SQL Time, while `chrono::NaiveTime` and `time::Time` continue to return a deserialization error because neither type can represent a signed duration. Negative `Date`, `Datetime`, and `Timestamp` values remain rejected at the raw-value boundary.

**For this PR I use GPT Sol.**