### PR TITLE
Align backend-only feature gates so a bare backend build is lint clean

### DIFF
--- a/diesel/src/mysql_like/mod.rs
+++ b/diesel/src/mysql_like/mod.rs
@@ -62,6 +62,11 @@ where
 
 pub(crate) trait MapErrorNumber {
     /// Resolve the returned error number to a `DatabaseErrorKind`
+    // Bound on `MysqlLikeBackend` everywhere, called only by the connections.
+    #[cfg_attr(
+        not(any(feature = "mysql", feature = "mariadb")),
+        expect(dead_code, reason = "only the connections call it")
+    )]
     fn map_error_number(error_number: u32) -> DatabaseErrorKind;
 }
 

--- a/diesel/src/pg/query_builder/copy/copy_from.rs
+++ b/diesel/src/pg/query_builder/copy/copy_from.rs
@@ -18,6 +18,7 @@ use crate::pg::backend::FailedToLookupTypeError;
 use crate::pg::metadata_lookup::PgMetadataCacheKey;
 use crate::query_builder::BatchInsert;
 use crate::query_builder::QueryFragment;
+#[cfg(feature = "postgres")]
 use crate::query_builder::QueryId;
 use crate::query_builder::ValuesClause;
 use crate::serialize::IsNull;
@@ -93,6 +94,8 @@ pub struct CopyFrom<S, F> {
     p: PhantomData<S>,
 }
 
+// Same gate as the re-export, only the `postgres` connection builds this.
+#[cfg(feature = "postgres")]
 pub(crate) struct InternalCopyFromQuery<S, T> {
     pub(crate) target: S,
     p: PhantomData<T>,
@@ -108,6 +111,7 @@ impl<S, T> InternalCopyFromQuery<S, T> {
     }
 }
 
+#[cfg(feature = "postgres")]
 impl<S, T> QueryId for InternalCopyFromQuery<S, T>
 where
     S: CopyFromExpression<T>,
@@ -116,6 +120,7 @@ where
     type QueryId = ();
 }
 
+#[cfg(feature = "postgres")]
 impl<S, T> QueryFragment<Pg> for InternalCopyFromQuery<S, T>
 where
     S: CopyFromExpression<T>,

--- a/diesel/src/util.rs
+++ b/diesel/src/util.rs
@@ -41,12 +41,13 @@ pub(crate) mod std_compat {
 #[cfg(feature = "std")]
 pub(crate) mod std_compat {
     pub(crate) use std::collections::HashMap;
+    // Used only by the statement cache, which needs a connection, not a bare backend.
     #[cfg(any(
         feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes",
         feature = "__sqlite-shared",
-        feature = "mysql_backend",
-        feature = "mariadb_backend",
-        feature = "postgres_backend"
+        feature = "mysql",
+        feature = "mariadb",
+        feature = "postgres"
     ))]
     pub(crate) use std::collections::hash_map::Entry;
     #[cfg(feature = "__sqlite-shared")]


### PR DESCRIPTION
Building `diesel` with only a backend feature such as `postgres_backend` or `mysql_backend` fails `-D warnings` on `main`. Three items are gated on the backend features while their only consumers are the connection implementations, so an `Entry` re-export, `InternalCopyFromQuery` and `map_error_number` all come out unused. Any crate that depends on `diesel` without also enabling a client feature runs into this, which is how `diesel-dynamic-schema` reaches it through its own `postgres` feature.

Two of the three move onto the gate their consumers already use. `map_error_number` cannot, since `MapErrorNumber` is a supertrait bound of the public `MysqlLikeBackend` and therefore has to exist in every configuration, leaving only the method unreachable, so that one carries a `cfg`-scoped `expect(dead_code)`.