### PR TITLE
Raise `libsqlite3-sys >= 0.30.1` (or `0.23.0`) and `SQLite >= 3.36.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 ### Changed
 
 * The minimal supported Rust version is now 1.88.0
+* The minimal supported `libsqlite3-sys` version is now 0.30.1 and the minimal supported SQLite version is now 3.36.0
 * Add support for no-std environments using the SQLite backend
 * Improved documentation and added examples for `filter_target` on `IncompleteOnConflict`
 

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -51,7 +51,7 @@ version = "~2.3.0"
 path = "../diesel_derives"
 
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
-libsqlite3-sys = { version = ">=0.17.2, <0.39.0", optional = true, features = ["bundled_bindings"] }
+libsqlite3-sys = { version = ">=0.30.1, <0.39.0", optional = true, features = ["bundled_bindings"] }
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
 sqlite-wasm-rs = { version = ">=0.4.0, <0.6.0", optional = true, default-features = false }

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -151,11 +151,12 @@
 
 //!
 //! - `sqlite`: This feature enables the diesel sqlite backend. Enabling this feature requires per default
-//!   a compatible copy of `libsqlite3` for your target architecture. Alternatively, you can add `libsqlite3-sys`
+//!   a compatible copy of `libsqlite3` for your target architecture. Diesel supports SQLite 3.36.0 or newer.
+//!   Alternatively, you can add `libsqlite3-sys`
 //!   with the `bundled` feature as a dependency to your crate so SQLite will be bundled:
 //!   ```toml
 //!   [dependencies]
-//!   libsqlite3-sys = { version = "0.29", features = ["bundled"] }
+//!   libsqlite3-sys = { version = "0.30", features = ["bundled"] }
 //!   ```
 //! - `sqlite-no-std` A diesel sqlite backend for no-std environments. This is mostly the same as the `sqlite` backend,
 //!   but it doesn't enable the `std` feature flag

--- a/diesel/src/sqlite/connection/raw.rs
+++ b/diesel/src/sqlite/connection/raw.rs
@@ -35,7 +35,7 @@ use core::{mem, ptr, slice, str};
 // `sqlite3_db_config()` option codes controlling whether ATTACH may create new
 // database files (ATTACH_CREATE) or open them in write mode (ATTACH_WRITE).
 // Introduced in SQLite 3.49.0 / `libsqlite3-sys` 0.35.0, but Diesel supports
-// `libsqlite3-sys` >= 0.17.2, so we define them here to build against any
+// `libsqlite3-sys` >= 0.30.1, so we define them here to build against any
 // supported version. On an older linked SQLite the `sqlite3_db_config()` call
 // fails at runtime, which callers already handle.
 pub(super) const SQLITE_DBCONFIG_ENABLE_ATTACH_CREATE: i32 = 1020;
@@ -312,8 +312,9 @@ impl RawConnection {
             .len()
             .try_into()
             .map_err(|e| Error::DeserializationError(Box::new(e)))?;
-        // the cast for `ffi::SQLITE_DESERIALIZE_READONLY` is required for old libsqlite3-sys versions
-        #[allow(clippy::unnecessary_cast)]
+        // SAFETY: The connection pointer is valid by construction and the caller
+        // guarantees the buffer stays valid and unmodified until the connection
+        // is closed, as required by `sqlite3_deserialize` with a borrowed buffer.
         unsafe {
             let result = ffi::sqlite3_deserialize(
                 self.internal_connection.as_ptr(),
@@ -321,7 +322,7 @@ impl RawConnection {
                 data.as_ptr() as *mut u8,
                 db_size,
                 db_size,
-                ffi::SQLITE_DESERIALIZE_READONLY as u32,
+                ffi::SQLITE_DESERIALIZE_READONLY,
             );
 
             ensure_sqlite_ok(result, self.internal_connection.as_ptr())


### PR DESCRIPTION
While looking to adding support for [`sqlite3_create_window_function`](https://sqlite.org/c3ref/create_function.html), I discovered by chance that **Diesel has effectively required `SQLite >= 3.36.0` and `libsqlite3-sys >= 0.23.0` since `2.2.0`.**

Specifically, the serialization support added in #3792 links `sqlite3_serialize` and `sqlite3_deserialize` unconditionally, and stock distribution builds only export those symbols from `3.36.0` on, where the `SQLITE_ENABLE_DESERIALIZE` option became the default, and even the bundled builds have the same problem as no `libsqlite3-sys` older than `0.23.0` defines the flag, therefore their bundled `SQLite` (`3.31` through `3.35`) omits the symbols and the final link fails.

**I understand this normally would count as a semver change, but if anything it would need to be retroactively applied.**

While executing these checks, I have also realized that my #4993 PR actually requires `libsqlite3-sys >= 0.29.0`, so a crate depending on diesel alone fails to compile under cargo minimal-versions, while CI never notices because the workspace manifest already requires `>= 0.30.1` for `diesel_cli` and the shared lockfile resolves above the broken range.

The reason I had not noticed the bump in #4993 is that while the `sqlite3_auto_extension` function is ancient and present in earlier versions of `libsqlite3-sys`, but it was implemented in a buggy manner and fixed only in version `0.29` in https://github.com/rusqlite/rusqlite/pull/1487

Therefore, I propose we either:

1. Bump `libsqlite3-sys` to `>=0.30.1`
2. Bump `libsqlite3-sys` to `>=0.23.0` and revert #4993

This PR proposes to move `libsqlite3-sys` to `>=0.30.1` to match that workspace range, which makes the minimal-versions job verify exactly what the manifest declares.

Also, it fixes a minor `clippy::unnecessary_cast` which is now no longer necessary.