### PR TITLE
Check for allocation failure before dereferencing the SQLite aggregate context 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 * Tighten requirements for `SqliteConnection::deserialize_readonly_database` to closely match the upstream requirements
 * `diesel print-schema` now generates `joinable!` and `allow_tables_to_appear_in_same_query!` for PostgreSQL foreign keys across multiple configured schemas
 * Fixed several Tests using schema modifications for `mysql` and `mariadb`
+* Fixed a possible null pointer dereference in the custom SQLite aggregate function support when SQLite fails to allocate the aggregate state
 
 ### Changed
 

--- a/diesel/src/sqlite/connection/raw.rs
+++ b/diesel/src/sqlite/connection/raw.rs
@@ -1069,6 +1069,12 @@ where
         )
         // we cast the returned memory here to be a pointer to the aggregate instance
         .cast::<*mut A>();
+        // sqlite3_aggregate_context returns a null pointer if the allocation fails
+        if ctx.is_null() {
+            return Err(SqliteCallbackError::Abort(
+                "sqlite3_aggregate_context failed to allocate memory for the aggregate state",
+            ));
+        }
         // we are interested in the inner pointer
         let inner = &mut *ctx;
         // if the inner pointer is null we the aggregate_step


### PR DESCRIPTION
This PR adds a `null` check to the custom aggregate `xStep` glue. `sqlite3_aggregate_context` [is documented to return a null pointer when its allocation fails](https://sqlite.org/c3ref/aggregate_context.html), and `run_aggregator_step` dereferenced the returned pointer unconditionally, so a custom aggregate running under memory pressure hit undefined behavior instead of an error.