### PR TITLE
Preserve old libsqlite3-sys support for auto-extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 ### Fixed
 
 * `Bpchar` is now a distinct PostgreSQL SQL type (previously a hidden alias for `Varchar`). Binds on `CHAR(N)` / `BPCHAR` columns are now sent with OID 1042, allowing PostgreSQL to use the column's index instead of casting it to text.
+* Restore SQLite auto-extension support with `libsqlite3-sys` versions before 0.29
 * Fix non-deterministic test failures on PostgreSQL caused by loading rows without `ORDER BY` and assuming insertion order
 * `diesel_derives` does now correctly handle feature flag unification in mixed build/target dependency situations
 * Fixed several panics in the serialization and deserialization code for PostgreSQL and MySQL

--- a/diesel/src/sqlite/auto_extension.rs
+++ b/diesel/src/sqlite/auto_extension.rs
@@ -9,14 +9,34 @@ use crate::sqlite::SqliteConnection;
 use alloc::boxed::Box;
 use alloc::string::{String, ToString};
 use core::ffi::{c_char, c_int};
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+type RawApiPointer = *const core::ffi::c_void;
+#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+type RawApiPointer = *const ffi::sqlite3_api_routines;
 
-/// The fn type `libsqlite3-sys` expects for `sqlite3_auto_extension`, used only
-/// to name the private trampoline below.
+/// SQLite's auto-extension callback type.
 type RawAutoExtension = unsafe extern "C" fn(
     db: *mut ffi::sqlite3,
     pz_err_msg: *mut *mut c_char,
-    p_api: *const ffi::sqlite3_api_routines,
+    p_api: RawApiPointer,
 ) -> c_int;
+
+// TODO: diesel 3.0 use `libsqlite3-sys` declarations after raising the minimum to 0.29.
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+mod auto_extension_ffi {
+    use super::{RawAutoExtension, c_int};
+
+    // SAFETY: These declarations match SQLite's C ABI and bypass incompatible callback types in older bindings.
+    #[allow(unsafe_code)]
+    unsafe extern "C" {
+        pub(super) fn sqlite3_auto_extension(entry_point: Option<RawAutoExtension>) -> c_int;
+        pub(super) fn sqlite3_cancel_auto_extension(entry_point: Option<RawAutoExtension>)
+        -> c_int;
+    }
+}
+
+#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+use ffi as auto_extension_ffi;
 
 /// Registers an auto-extension that runs for every SQLite connection opened in
 /// this process, including non-Diesel ones.
@@ -67,7 +87,9 @@ pub fn register_auto_extension<F>(extension: F) -> QueryResult<()>
 where
     F: Fn(&mut SqliteConnection) -> QueryResult<()> + Sync + 'static,
 {
-    let result = unsafe { ffi::sqlite3_auto_extension(Some(entry_point(extension))) };
+    // SAFETY: `entry_point` returns a stable function pointer with SQLite's callback ABI.
+    let result =
+        unsafe { auto_extension_ffi::sqlite3_auto_extension(Some(entry_point(extension))) };
     if result == ffi::SQLITE_OK {
         Ok(())
     } else {
@@ -91,7 +113,8 @@ pub fn cancel_auto_extension<F>(extension: F) -> bool
 where
     F: Fn(&mut SqliteConnection) -> QueryResult<()> + Sync + 'static,
 {
-    unsafe { ffi::sqlite3_cancel_auto_extension(Some(entry_point(extension))) != 0 }
+    // SAFETY: `entry_point` returns the same stable pointer used for registration.
+    unsafe { auto_extension_ffi::sqlite3_cancel_auto_extension(Some(entry_point(extension))) != 0 }
 }
 
 /// Clears **all** registered auto-extensions ([docs][reset_docs]).
@@ -122,7 +145,7 @@ where
 unsafe extern "C" fn trampoline<F>(
     db: *mut ffi::sqlite3,
     pz_err_msg: *mut *mut c_char,
-    _p_api: *const ffi::sqlite3_api_routines,
+    _p_api: RawApiPointer,
 ) -> c_int
 where
     F: Fn(&mut SqliteConnection) -> QueryResult<()> + Sync + 'static,

--- a/diesel_compile_tests/tests/Cargo.toml
+++ b/diesel_compile_tests/tests/Cargo.toml
@@ -5,5 +5,7 @@ edition = "2024"
 
 [dependencies]
 diesel = { version = "2.0.0", default-features = false, features = ["extras", "sqlite", "postgres", "mysql" , "mariadb", "with-deprecated"], path = "../../diesel" }
+# Pin Diesel's declared minimum so the compile tests cover it.
+libsqlite3-sys = "=0.17.2"
 
 [workspace]


### PR DESCRIPTION
`sqlite3_auto_extension` and `sqlite3_cancel_auto_extension` had incompatible callback declarations before `libsqlite3-sys 0.29`, so Diesel's auto-extension wrappers did not compile across the declared dependency range. I had not noticed this when I wrote #4993.

To amend this semver breaking bump, I have now added two C interfaces to preserves libsqlite3-sys >= 0.17.2 without changing the linked SQLite requirement.

I have also added `libsqlite3-sys = "=0.17.2"` to the compile tests, so that such an occurrence does not re-occur in the future, and a `TODO` note which hopefully will not go forgotten for when eventually the version bump occurs.