### PR TITLE
Expose group-by clause types for third-party backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 * Added support for generating matching Rust enums for database enums in Diesel-CLI
 * Added `#[diesel_async]` attribute to `#[derive(MultiConnection)]` to support async MultiConnections. 
 * Exposed the SQLite bind values collected for a query under the `i-implement-a-third-party-backend-and-opt-into-breaking-changes` feature, via public `SqliteBindCollector` and `SqliteBindCollectorData`, each with a `binds()` iterator over the live values and the owned snapshot respectively, plus the `SqliteBindValueRef` and `OwnedSqliteBindValue` enums.
+* Exposed `GroupByClause` and `NoGroupByClause` under the `i-implement-a-third-party-backend-and-opt-into-breaking-changes` feature so third-party crates can distinguish grouped and ungrouped `SelectStatement` types.
 * Added `--no-schema` CLI flag to the `migration run` subcommand
 * Added `SqliteConnection::auto_vacuum` and `SqliteConnection::set_auto_vacuum` to read and set a database's `auto_vacuum` mode through the typed `AutoVacuumMode` enum, each accepting an optional schema name to target an attached database.
 * Added `SqliteConnection::page_count` and `SqliteConnection::freelist_count` to read a database's total and reclaimable page counts, each accepting an optional schema name to target an attached database.

--- a/diesel/src/query_builder/group_by_clause.rs
+++ b/diesel/src/query_builder/group_by_clause.rs
@@ -1,4 +1,31 @@
-simple_clause!(NoGroupByClause, GroupByClause, " GROUP BY ");
+simple_clause!(
+    /// A query node indicating that no group-by clause is set.
+    NoGroupByClause,
+    /// A query node containing a group-by clause.
+    ///
+    /// ```
+    /// # #[cfg(feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes")]
+    /// # fn main() {
+    /// use diesel::query_builder::{GroupByClause, NoGroupByClause, SelectStatement};
+    ///
+    /// trait SelectionMarker {}
+    ///
+    /// impl<F, S, D, W, O, LOf, H, LC> SelectionMarker
+    ///     for SelectStatement<F, S, D, W, O, LOf, NoGroupByClause, H, LC>
+    /// {
+    /// }
+    ///
+    /// impl<F, S, D, W, O, LOf, GB, H, LC> SelectionMarker
+    ///     for SelectStatement<F, S, D, W, O, LOf, GroupByClause<GB>, H, LC>
+    /// {
+    /// }
+    /// # }
+    /// # #[cfg(not(feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"))]
+    /// # fn main() {}
+    /// ```
+    GroupByClause,
+    " GROUP BY "
+);
 
 pub trait ValidGroupByClause {
     type Expressions;

--- a/diesel/src/query_builder/mod.rs
+++ b/diesel/src/query_builder/mod.rs
@@ -125,6 +125,15 @@ pub(crate) use self::select_clause::SelectClauseExpression;
     feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
 )]
 pub(crate) use self::from_clause::{FromClause, NoFromClause};
+#[cfg_attr(
+    not(feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"),
+    allow(unused_imports)
+)]
+#[diesel_derives::__diesel_public_if(
+    feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
+)]
+#[doc(inline)]
+pub(crate) use self::group_by_clause::{GroupByClause, NoGroupByClause};
 #[diesel_derives::__diesel_public_if(
     feature = "i-implement-a-third-party-backend-and-opt-into-breaking-changes"
 )]


### PR DESCRIPTION
Downstream crates could name `SelectStatement` but could not implement separate behavior for grouped and ungrouped statements because the concrete types in its group-by slot remained private.

Exposing `GroupByClause` and `NoGroupByClause` under `i-implement-a-third-party-backend-and-opt-into-breaking-changes` keeps the normal API boundary intact and lets Rust prove the two implementations do not overlap.