### PR TITLE
Handle SQLite value allocation failures safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 
 ### Fixed
 
+* Fixed SQLite value reads to panic instead of creating invalid slices or returning incorrect data when SQLite allocation fails. Row iteration reports a failed value duplication as an error instead.
+* Fixed a use after free where reading a SQLite value in a second representation, for example a blob as text, invalidated slices another `SqliteValue` of the same field had returned. Such a read now works on a copy of the value.
 * `Bpchar` is now a distinct PostgreSQL SQL type (previously a hidden alias for `Varchar`). Binds on `CHAR(N)` / `BPCHAR` columns are now sent with OID 1042, allowing PostgreSQL to use the column's index instead of casting it to text.
 * Restore SQLite auto-extension support with `libsqlite3-sys` versions before 0.29
 * Fix non-deterministic test failures on PostgreSQL caused by loading rows without `ORDER BY` and assuming insertion order

--- a/diesel/src/sqlite/connection/functions.rs
+++ b/diesel/src/sqlite/connection/functions.rs
@@ -40,7 +40,7 @@ where
     }
 
     conn.register_sql_function(fn_name, fields_needed, behavior, move |conn, args| {
-        let args = build_sql_function_args::<ArgsSqlType, Args>(args)?;
+        let args = build_sql_function_args::<ArgsSqlType, Args>(args, conn.internal_connection)?;
 
         Ok(f(conn, args))
     })?;
@@ -92,11 +92,12 @@ where
 
 pub(super) fn build_sql_function_args<ArgsSqlType, Args>(
     args: &mut [*mut ffi::sqlite3_value],
+    connection: core::ptr::NonNull<ffi::sqlite3>,
 ) -> Result<Args, Error>
 where
     Args: FromSqlRow<ArgsSqlType, Sqlite>,
 {
-    let row = FunctionRow::new(args);
+    let row = FunctionRow::new(args, connection);
     Args::build_from_row(&row).map_err(Error::DeserializationError)
 }
 
@@ -127,11 +128,15 @@ where
 struct FunctionRow<'a> {
     args: &'a [Option<OwnedSqliteValue>],
     field_count: usize,
+    connection: core::ptr::NonNull<ffi::sqlite3>,
 }
 
 impl FunctionRow<'_> {
     #[allow(unsafe_code)] // complicated ptr cast
-    fn new(args: &mut [*mut ffi::sqlite3_value]) -> Self {
+    fn new(
+        args: &mut [*mut ffi::sqlite3_value],
+        connection: core::ptr::NonNull<ffi::sqlite3>,
+    ) -> Self {
         let lengths = args.len();
         let args = unsafe {
             core::slice::from_raw_parts(
@@ -156,6 +161,7 @@ impl FunctionRow<'_> {
         Self {
             field_count: lengths,
             args,
+            connection,
         }
     }
 }
@@ -183,6 +189,7 @@ impl<'a> Row<'a, Sqlite> for FunctionRow<'a> {
         Some(FunctionArgument {
             args: self.args,
             col_idx,
+            connection: self.connection,
         })
     }
 
@@ -210,6 +217,7 @@ impl<'a> RowIndex<&'a str> for FunctionRow<'_> {
 struct FunctionArgument<'a> {
     args: &'a [Option<OwnedSqliteValue>],
     col_idx: usize,
+    connection: core::ptr::NonNull<ffi::sqlite3>,
 }
 
 impl<'a> Field<'a, Sqlite> for FunctionArgument<'a> {
@@ -222,6 +230,6 @@ impl<'a> Field<'a, Sqlite> for FunctionArgument<'a> {
     }
 
     fn value(&self) -> Option<<Sqlite as Backend>::RawValue<'_>> {
-        SqliteValue::from_function_row(self.args, self.col_idx)
+        SqliteValue::from_function_row(self.args, self.col_idx, self.connection)
     }
 }

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -10,6 +10,13 @@ mod collation_needed;
 mod functions;
 mod hooks;
 mod limits;
+#[cfg(all(
+    test,
+    feature = "std",
+    not(all(target_family = "wasm", target_os = "unknown"))
+))]
+#[allow(unsafe_code)]
+mod oom_test_support;
 mod owned_row;
 mod raw;
 mod row;
@@ -2349,39 +2356,22 @@ mod tests {
     ))]
     #[allow(unsafe_code)]
     mod sqlite_serialize_oom {
+        use super::super::oom_test_support::{panic_message, run_in_child, with_heap_limit};
         use super::super::{SerializedDatabase, ffi};
         use crate::connection::{Connection, SimpleConnection};
         use crate::sqlite::SqliteConnection;
 
-        const CHILD_ENV: &str = "DIESEL_SQLITE_SERIALIZE_OOM_CHILD";
         const MIN_DATABASE_BYTES: i64 = 1_048_576;
-
-        struct HardHeapLimit(i64);
-
-        impl Drop for HardHeapLimit {
-            fn drop(&mut self) {
-                // SAFETY: SQLite accepts every i64 and does not retain Rust memory.
-                unsafe {
-                    ffi::sqlite3_hard_heap_limit64(self.0);
-                }
-            }
-        }
 
         // 64 KiB covers statement setup but cannot hold the 1 MiB serialization,
         // pinning the failure to output allocation after SQLite reports its size.
         fn with_failing_serialize<R>(f: impl FnOnce() -> R) -> R {
-            // SAFETY: These process-global SQLite APIs do not dereference Rust memory.
-            let previous = unsafe {
-                let current = ffi::sqlite3_memory_used();
-                ffi::sqlite3_hard_heap_limit64(current + 65_536)
-            };
-            let _guard = HardHeapLimit(previous);
-            f()
+            with_heap_limit(65_536, f)
         }
 
         #[test]
         fn sqlite_serialize_oom_is_contained() {
-            run_in_child("serialize", || {
+            run_in_child(|| {
                 let mut conn = large_database();
 
                 let (baseline_size, baseline) = serialize_direct(&conn);
@@ -2418,53 +2408,17 @@ mod tests {
                     .expect_err("the failed output allocation must surface as an error");
                 assert_eq!(error.to_string(), "out of memory");
 
-                let outcome = std::panic::catch_unwind(core::panic::AssertUnwindSafe(|| {
+                let payload = std::panic::catch_unwind(core::panic::AssertUnwindSafe(|| {
                     core::hint::black_box(serialized[0]);
-                }));
-                let message = panic_message(&outcome);
+                }))
+                .expect_err("the serialized database access did not panic");
+                let message = panic_message(&*payload);
                 assert!(
                     message.contains("Cannot access the serialized database: out of memory"),
                     "SQLite serialization allocation failure surfaced as `{message}` instead \
                      of a caught allocation panic"
                 );
             });
-        }
-
-        // The SQLite heap limit is process-global, so a child process keeps the
-        // artificially induced allocation failures away from concurrent tests.
-        fn run_in_child(case: &str, f: impl FnOnce()) {
-            if std::env::var_os(CHILD_ENV).as_deref() == Some(std::ffi::OsStr::new(case)) {
-                f();
-                return;
-            }
-
-            let current_thread = std::thread::current();
-            let test_name = current_thread
-                .name()
-                .expect("the test harness names every test thread");
-            let output = std::process::Command::new(
-                std::env::current_exe().expect("the test binary has a path"),
-            )
-            .arg("--exact")
-            .arg(test_name)
-            .arg("--nocapture")
-            .env(CHILD_ENV, case)
-            .output()
-            .expect("the child test process starts");
-
-            assert!(
-                output.status.success(),
-                "child test failed\nstdout:\n{}\nstderr:\n{}",
-                String::from_utf8_lossy(&output.stdout),
-                String::from_utf8_lossy(&output.stderr)
-            );
-            // libtest exits successfully when an exact filter matches no tests.
-            assert!(
-                String::from_utf8_lossy(&output.stdout).contains("test result: ok. 1 passed"),
-                "child test did not run exactly one test\nstdout:\n{}\nstderr:\n{}",
-                String::from_utf8_lossy(&output.stdout),
-                String::from_utf8_lossy(&output.stderr)
-            );
         }
 
         fn large_database() -> SqliteConnection {
@@ -2488,17 +2442,6 @@ mod tests {
                     0,
                 );
                 (size, data)
-            }
-        }
-
-        fn panic_message(outcome: &std::thread::Result<()>) -> String {
-            match outcome {
-                Ok(()) => "the call returned without a panic".to_string(),
-                Err(payload) => payload
-                    .downcast_ref::<&str>()
-                    .map(|s| (*s).to_string())
-                    .or_else(|| payload.downcast_ref::<String>().cloned())
-                    .unwrap_or_else(|| "non-string panic payload".to_string()),
             }
         }
     }

--- a/diesel/src/sqlite/connection/oom_test_support.rs
+++ b/diesel/src/sqlite/connection/oom_test_support.rs
@@ -1,0 +1,71 @@
+//! Test support for forcing SQLite allocation failures.
+
+use super::ffi;
+use alloc::string::String;
+
+const CHILD_ENV: &str = "DIESEL_SQLITE_OOM_CHILD";
+
+struct HardHeapLimit(i64);
+
+impl Drop for HardHeapLimit {
+    fn drop(&mut self) {
+        // SAFETY: SQLite accepts every i64 as a limit and reads no Rust memory.
+        unsafe {
+            ffi::sqlite3_hard_heap_limit64(self.0);
+        }
+    }
+}
+
+/// Rejects every SQLite allocation beyond `spare` bytes while `f` runs.
+pub(super) fn with_heap_limit<R>(spare: i64, f: impl FnOnce() -> R) -> R {
+    // SAFETY: These process global SQLite APIs read no Rust memory.
+    let previous = unsafe {
+        let current = ffi::sqlite3_memory_used();
+        ffi::sqlite3_hard_heap_limit64(current + spare)
+    };
+    let _guard = HardHeapLimit(previous);
+    f()
+}
+
+/// Reruns the calling test in a child process, as the heap limit is process global.
+pub(super) fn run_in_child(f: impl FnOnce()) {
+    let current_thread = std::thread::current();
+    let test_name = current_thread
+        .name()
+        .expect("the test harness names every test thread");
+    if std::env::var_os(CHILD_ENV).as_deref() == Some(std::ffi::OsStr::new(test_name)) {
+        f();
+        return;
+    }
+
+    let output =
+        std::process::Command::new(std::env::current_exe().expect("the test binary has a path"))
+            .arg("--exact")
+            .arg(test_name)
+            .arg("--nocapture")
+            .env(CHILD_ENV, test_name)
+            .output()
+            .expect("the child test process starts");
+
+    assert!(
+        output.status.success(),
+        "child test failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    // libtest exits successfully when an exact filter matches no tests.
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("test result: ok. 1 passed"),
+        "child test did not run exactly one test\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+pub(super) fn panic_message(payload: &(dyn core::any::Any + Send)) -> &str {
+    payload
+        .downcast_ref::<String>()
+        .map(String::as_str)
+        .or_else(|| payload.downcast_ref::<&str>().copied())
+        .expect("the panic payload is a string")
+}

--- a/diesel/src/sqlite/connection/raw.rs
+++ b/diesel/src/sqlite/connection/raw.rs
@@ -1098,7 +1098,12 @@ where
         &mut **inner
     };
 
-    let args = build_sql_function_args::<ArgsSqlType, Args>(args)?;
+    // SAFETY: SQLite passes a live context for the duration of this callback.
+    let connection = unsafe { NonNull::new(ffi::sqlite3_context_db_handle(ctx)) };
+    let connection = connection.ok_or(SqliteCallbackError::Abort(
+        "sqlite3_context_db_handle returned a null pointer. This should never happen",
+    ))?;
+    let args = build_sql_function_args::<ArgsSqlType, Args>(args, connection)?;
 
     aggregator.step(args);
     Ok(())

--- a/diesel/src/sqlite/connection/row.rs
+++ b/diesel/src/sqlite/connection/row.rs
@@ -2,6 +2,7 @@ use super::owned_row::OwnedSqliteRow;
 use super::sqlite_value::{OwnedSqliteValue, SqliteValue};
 use super::stmt::StatementUse;
 use crate::backend::Backend;
+use crate::result::QueryResult;
 use crate::row::{Field, IntoOwnedRow, PartialRow, Row, RowIndex, RowSealed};
 use crate::sqlite::Sqlite;
 use alloc::borrow::ToOwned;
@@ -39,7 +40,7 @@ impl<'stmt, 'query> PrivateSqliteRow<'stmt, 'query> {
     pub(super) fn duplicate(
         &mut self,
         column_names: &mut Option<Rc<[Option<String>]>>,
-    ) -> PrivateSqliteRow<'stmt, 'query> {
+    ) -> QueryResult<PrivateSqliteRow<'stmt, 'query>> {
         match self {
             PrivateSqliteRow::Direct(stmt) => {
                 let column_names = if let Some(column_names) = column_names {
@@ -53,26 +54,32 @@ impl<'stmt, 'query> PrivateSqliteRow<'stmt, 'query> {
                     *column_names = Some(c.clone());
                     c
                 };
-                PrivateSqliteRow::Duplicated {
+                Ok(PrivateSqliteRow::Duplicated {
                     values: (0..stmt.column_count())
                         .map(|idx| stmt.copy_value(idx))
-                        .collect(),
+                        .collect::<QueryResult<Vec<_>>>()?,
                     column_names,
-                }
+                })
             }
             PrivateSqliteRow::Duplicated {
                 values,
                 column_names,
-            } => PrivateSqliteRow::Duplicated {
+            } => Ok(PrivateSqliteRow::Duplicated {
                 values: values
                     .iter()
-                    .map(|v| v.as_ref().map(|v| v.duplicate()))
-                    .collect(),
+                    .map(|v| v.as_ref().map(OwnedSqliteValue::duplicate).transpose())
+                    .collect::<QueryResult<Vec<_>>>()?,
                 column_names: column_names.clone(),
-            },
+            }),
         }
     }
 
+    /// Copies the row out of the statement, so that it outlives it.
+    ///
+    /// # Panics
+    ///
+    /// Panics if SQLite cannot allocate the copies, as `IntoOwnedRow::into_owned`
+    /// cannot report an error.
     pub(super) fn moveable(
         &self,
         column_name_cache: &mut Option<Arc<[Option<String>]>>,
@@ -95,7 +102,8 @@ impl<'stmt, 'query> PrivateSqliteRow<'stmt, 'query> {
                 OwnedSqliteRow::new(
                     (0..stmt.column_count())
                         .map(|idx| stmt.copy_value(idx))
-                        .collect(),
+                        .collect::<QueryResult<Vec<_>>>()
+                        .unwrap_or_else(|e| panic!("{e}")),
                     column_names,
                 )
             }
@@ -120,8 +128,9 @@ impl<'stmt, 'query> PrivateSqliteRow<'stmt, 'query> {
                 OwnedSqliteRow::new(
                     values
                         .iter()
-                        .map(|v| v.as_ref().map(|v| v.duplicate()))
-                        .collect(),
+                        .map(|v| v.as_ref().map(OwnedSqliteValue::duplicate).transpose())
+                        .collect::<QueryResult<Vec<_>>>()
+                        .unwrap_or_else(|e| panic!("{e}")),
                     column_names,
                 )
             }

--- a/diesel/src/sqlite/connection/sqlite_value.rs
+++ b/diesel/src/sqlite/connection/sqlite_value.rs
@@ -9,6 +9,7 @@ use core::cell::Ref;
 use core::ptr::NonNull;
 use core::{slice, str};
 
+use crate::result::QueryResult;
 use crate::sqlite::SqliteType;
 
 use super::owned_row::OwnedSqliteRow;
@@ -21,10 +22,10 @@ use super::row::PrivateSqliteRow;
 /// to convert this into rust values
 #[allow(missing_debug_implementations, missing_copy_implementations)]
 pub struct SqliteValue<'row, 'stmt, 'query> {
-    // This field exists to ensure that nobody
-    // can modify the underlying row while we are
-    // holding a reference to some row value here
-    _row: Option<Ref<'row, PrivateSqliteRow<'stmt, 'query>>>,
+    // This field exists to ensure that nobody can modify the underlying row
+    // while we are holding a reference to some row value here, and to reach
+    // the connection a value is still attached to
+    owner: ValueOwner<'row, 'stmt, 'query>,
     // we extract the raw value pointer as part of the constructor
     // to safe the match statements for each method
     // According to benchmarks this leads to a ~20-30% speedup
@@ -41,6 +42,37 @@ pub struct SqliteValue<'row, 'stmt, 'query> {
     // use `String::from_utf8_lossy` there and need
     // to store the potential owned result here
     string_ref: Option<alloc::boxed::Box<str>>,
+    // The type the value declared before any read converted it, as
+    // https://www.sqlite.org/c3ref/value_blob.html requires asking first
+    initial_type: SqliteType,
+    // A private copy of the value, used by reads that would otherwise convert the
+    // shared value in place and free the buffer another handle points at
+    converted: Option<OwnedSqliteValue>,
+}
+
+enum ValueOwner<'row, 'stmt, 'query> {
+    // Only a direct row is still attached to its connection, a duplicated one
+    // holds values from `sqlite3_value_dup`
+    Row(Ref<'row, PrivateSqliteRow<'stmt, 'query>>),
+    // A value outside a row: a function argument carries its connection, a
+    // duplicated value has none
+    NonRow(Option<NonNull<ffi::sqlite3>>),
+}
+
+/// A form a value read hands out, which SQLite stores by converting the value.
+#[derive(Copy, Clone)]
+enum Representation {
+    Text,
+    Blob,
+}
+
+impl Representation {
+    fn target(self) -> &'static str {
+        match self {
+            Self::Text => "text",
+            Self::Blob => "a blob",
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -59,6 +91,23 @@ impl Drop for OwnedSqliteValue {
 // see https://www.sqlite.org/c3ref/value.html
 unsafe impl Send for OwnedSqliteValue {}
 
+#[cold]
+fn allocation_failed(out_of_memory: bool, target: &str) -> ! {
+    let reason = if out_of_memory {
+        "ran out of memory"
+    } else {
+        "failed to allocate memory"
+    };
+    panic!("SQLite {reason} while reading a value as {target}")
+}
+
+#[cold]
+fn duplication_failed() -> crate::result::Error {
+    crate::result::Error::DeserializationError(
+        "SQLite failed to allocate a duplicated value".into(),
+    )
+}
+
 impl<'row, 'stmt, 'query> SqliteValue<'row, 'stmt, 'query> {
     pub(super) fn new(
         row: Ref<'row, PrivateSqliteRow<'stmt, 'query>>,
@@ -74,17 +123,15 @@ impl<'row, 'stmt, 'query> SqliteValue<'row, 'stmt, 'query> {
                 values.get(col_idx).and_then(|v| v.as_ref())?.value
             }
         };
-
-        let ret = Self {
-            _row: Some(row),
+        // SAFETY: the row owns the value and keeps it alive for `'row`.
+        let initial_type = unsafe { value_type_of(value) }?;
+        Some(Self {
+            owner: ValueOwner::Row(row),
             value,
             string_ref: None,
-        };
-        if ret.value_type().is_none() {
-            None
-        } else {
-            Some(ret)
-        }
+            initial_type,
+            converted: None,
+        })
     }
 
     pub(super) fn from_owned_row(
@@ -92,44 +139,103 @@ impl<'row, 'stmt, 'query> SqliteValue<'row, 'stmt, 'query> {
         col_idx: usize,
     ) -> Option<SqliteValue<'row, 'stmt, 'query>> {
         let value = row.values.get(col_idx).and_then(|v| v.as_ref())?.value;
-        let ret = Self {
-            _row: None,
+        // SAFETY: `row` owns the value and keeps it alive for `'row`.
+        let initial_type = unsafe { value_type_of(value) }?;
+        Some(Self {
+            owner: ValueOwner::NonRow(None),
             value,
             string_ref: None,
-        };
-        if ret.value_type().is_none() {
-            None
-        } else {
-            Some(ret)
-        }
+            initial_type,
+            converted: None,
+        })
     }
 
     pub(super) fn from_function_row(
         row: &'row [Option<OwnedSqliteValue>],
         col_idx: usize,
+        connection: NonNull<ffi::sqlite3>,
     ) -> Option<SqliteValue<'row, 'stmt, 'query>> {
         let value = row.get(col_idx).and_then(|v| v.as_ref())?.value;
-        let ret = Self {
-            _row: None,
+        // SAFETY: the callback's argument row owns the value for the call.
+        let initial_type = unsafe { value_type_of(value) }?;
+        Some(Self {
+            owner: ValueOwner::NonRow(Some(connection)),
             value,
             string_ref: None,
-        };
-        if ret.value_type().is_none() {
-            None
-        } else {
-            Some(ret)
+            initial_type,
+            converted: None,
+        })
+    }
+
+    // Values from `sqlite3_value_dup` are disconnected from the connection, so they
+    // cannot be asked: https://www.sqlite.org/c3ref/value_blob.html
+    fn connection(&self) -> Option<NonNull<ffi::sqlite3>> {
+        match &self.owner {
+            ValueOwner::Row(row) => match &**row {
+                PrivateSqliteRow::Direct(stmt) => NonNull::new(stmt.raw_connection()),
+                PrivateSqliteRow::Duplicated { .. } => None,
+            },
+            ValueOwner::NonRow(connection) => *connection,
         }
     }
 
-    pub(crate) fn as_byte_string(&mut self) -> &'row [u8] {
+    /// Reports whether an allocation just failed, which must be asked before any other call.
+    fn reports_out_of_memory(&self) -> bool {
+        let Some(connection) = self.connection() else {
+            return false;
+        };
+        // SAFETY: The owner keeps the connection alive and this call only reads
+        // connection state.
+        unsafe { ffi::sqlite3_errcode(connection.as_ptr()) == ffi::SQLITE_NOMEM }
+    }
+
+    /// Returns the value to read `wanted` from, copying it first when SQLite would
+    /// convert the shared value in place and free a buffer another handle points at.
+    fn value_to_read(&mut self, wanted: Representation) -> NonNull<ffi::sqlite3_value> {
+        // A value gains its other textual form by conversion, while a numeric one
+        // gains it in a fresh buffer that replaces nothing.
+        let converts_in_place = matches!(
+            (self.initial_type, wanted),
+            (SqliteType::Text, Representation::Blob) | (SqliteType::Binary, Representation::Text)
+        );
+        if !converts_in_place {
+            return self.value;
+        }
+        if self.converted.is_none() {
+            // SAFETY: `self.owner` keeps `self.value` alive across this call, which
+            // only reads it while copying it into an independently owned value.
+            let copy = unsafe { ffi::sqlite3_value_dup(self.value.as_ptr()) };
+            // The value above is not SQL NULL, so only a failed allocation is null.
+            let Some(copy) = NonNull::new(copy) else {
+                // Ask the connection before any other call to it clears the error code.
+                allocation_failed(self.reports_out_of_memory(), wanted.target());
+            };
+            self.converted = Some(OwnedSqliteValue { value: copy });
+        }
+        self.converted
+            .as_ref()
+            .expect("We initialised it literally above")
+            .value
+    }
+
+    pub(crate) fn as_byte_string(&mut self) -> &[u8] {
+        let value = self.value_to_read(Representation::Text);
+        // SAFETY: `self.owner` keeps the value alive, a copy is owned by `self`, and
+        // the returned slice borrows `self` for as long as either can be converted.
         unsafe {
-            // https://sqlite.org/c3ref/value_blob.html
-            // Please pay particular attention to the fact that the pointer returned
-            // from sqlite3_value_blob(), sqlite3_value_text(), or sqlite3_value_text16()
-            // can be invalidated by a subsequent call to sqlite3_value_bytes(), sqlite3_value_bytes16(),
-            // sqlite3_value_text(), or sqlite3_value_text16().
-            let len = ffi::sqlite3_value_bytes(self.value.as_ptr());
-            let ptr = ffi::sqlite3_value_text(self.value.as_ptr());
+            // Force the UTF-8 conversion now so the length below cannot
+            // trigger one (moving the buffer, or failing as zero length).
+            // https://www.sqlite.org/c3ref/column_blob.html
+            if ffi::sqlite3_value_text(value.as_ptr()).is_null() {
+                // Zero length text has a valid pointer, so this is a failed conversion.
+                allocation_failed(self.reports_out_of_memory(), Representation::Text.target());
+            }
+            let len = ffi::sqlite3_value_bytes(value.as_ptr());
+            // The length above may have invalidated the pointer.
+            let ptr = ffi::sqlite3_value_text(value.as_ptr());
+            if ptr.is_null() {
+                allocation_failed(self.reports_out_of_memory(), Representation::Text.target());
+            }
             slice::from_raw_parts(
                 ptr,
                 len.try_into()
@@ -143,19 +249,21 @@ impl<'row, 'stmt, 'query> SqliteValue<'row, 'stmt, 'query> {
     }
 
     pub(crate) fn parse_string<'value, R>(&'value mut self, f: impl FnOnce(&'value str) -> R) -> R {
-        let bytes = self.as_byte_string();
         // For blobs this might return non-utf values
         //
         // The sqlite documentation there seems to be at least inaccurate
-        let s = match alloc::string::String::from_utf8_lossy(bytes) {
-            alloc::borrow::Cow::Borrowed(s) => s,
-            alloc::borrow::Cow::Owned(b) => {
-                self.string_ref = Some(b.into_boxed_str());
-                self.string_ref
-                    .as_deref()
-                    .expect("We initialised it literally above")
-            }
-        };
+        if str::from_utf8(self.as_byte_string()).is_err() {
+            // Read again to drop the byte borrow before storing the lossy copy, as
+            // repeated reads of one value do not convert it again.
+            let lossy = alloc::string::String::from_utf8_lossy(self.as_byte_string()).into_owned();
+            self.string_ref = Some(lossy.into_boxed_str());
+            let s = self
+                .string_ref
+                .as_deref()
+                .expect("We initialised it literally above");
+            return f(s);
+        }
+        let s = str::from_utf8(self.as_byte_string()).expect("The bytes are valid utf8 above");
         f(s)
     }
 
@@ -168,7 +276,15 @@ impl<'row, 'stmt, 'query> SqliteValue<'row, 'stmt, 'query> {
     /// type of the value.
     ///
     /// See <https://www.sqlite.org/c3ref/value_blob.html> for details
+    ///
+    /// Reading a blob value as text copies it, so slices returned for the same
+    /// field elsewhere stay valid.
+    ///
+    /// # Panics
+    ///
+    /// Panics if SQLite cannot allocate the requested text representation.
     pub fn read_text(&mut self) -> &str {
+        // TODO: Return Result in Diesel 3 so SQLite allocation failures reach callers.
         self.parse_string(|s| s)
     }
 
@@ -181,26 +297,54 @@ impl<'row, 'stmt, 'query> SqliteValue<'row, 'stmt, 'query> {
     /// type of the value.
     ///
     /// See <https://www.sqlite.org/c3ref/value_blob.html> for details
+    ///
+    /// Zero-length text and blob values are read as an empty slice even when
+    /// SQLite reports a null pointer for them.
+    ///
+    /// Reading a text value as a blob copies it, so slices returned for the same
+    /// field elsewhere stay valid.
+    ///
+    /// # Panics
+    ///
+    /// Panics if SQLite cannot allocate the requested blob representation.
     pub fn read_blob(&mut self) -> &[u8] {
+        // TODO: Return Result in Diesel 3 so SQLite allocation failures reach callers.
+        let value = self.value_to_read(Representation::Blob);
+        // SAFETY: as in `as_byte_string`, the owner keeps the value alive, `self` owns
+        // a copy, and the returned slice borrows `self` for as long as either lives.
         unsafe {
-            // https://sqlite.org/c3ref/value_blob.html
-            // Please pay particular attention to the fact that the pointer returned
-            // from sqlite3_value_blob(), sqlite3_value_text(), or sqlite3_value_text16()
-            // can be invalidated by a subsequent call to sqlite3_value_bytes(), sqlite3_value_bytes16(),
-            // sqlite3_value_text(), or sqlite3_value_text16().
-            let len = ffi::sqlite3_value_bytes(self.value.as_ptr());
-            let ptr = ffi::sqlite3_value_blob(self.value.as_ptr());
-            if len == 0 {
-                // rusts std-lib has an debug_assert that prevents creating
-                // slices without elements from a pointer
-                &[]
+            // Preserve a zeroblob's length because failed expansion changes it to SQL NULL.
+            let initial_blob_len = if matches!(self.initial_type, SqliteType::Binary) {
+                Some(ffi::sqlite3_value_bytes(value.as_ptr()))
             } else {
-                slice::from_raw_parts(
-                    ptr as *const u8,
-                    len.try_into()
-                        .expect("Diesel expects to run at least on a 32 bit platform"),
-                )
+                None
+            };
+            // Pin the blob form before the length: bytes() must not measure
+            // (or fail at) a text conversion of the value instead.
+            // https://www.sqlite.org/c3ref/column_blob.html
+            if ffi::sqlite3_value_blob(value.as_ptr()).is_null() {
+                // Ask the connection before any other call to it clears the error code.
+                let out_of_memory = self.reports_out_of_memory();
+                let len = ffi::sqlite3_value_bytes(value.as_ptr());
+                if !out_of_memory
+                    && ((matches!(self.initial_type, SqliteType::Text) && len == 0)
+                        || initial_blob_len == Some(0))
+                {
+                    return &[];
+                }
+                allocation_failed(out_of_memory, Representation::Blob.target());
             }
+            let len = ffi::sqlite3_value_bytes(value.as_ptr());
+            // The length above may have invalidated the pointer.
+            let ptr = ffi::sqlite3_value_blob(value.as_ptr());
+            if ptr.is_null() {
+                allocation_failed(self.reports_out_of_memory(), Representation::Blob.target());
+            }
+            slice::from_raw_parts(
+                ptr as *const u8,
+                len.try_into()
+                    .expect("Diesel expects to run at least on a 32 bit platform"),
+            )
         }
     }
 
@@ -245,44 +389,62 @@ impl<'row, 'stmt, 'query> SqliteValue<'row, 'stmt, 'query> {
 
     /// Get the type of the value as returned by sqlite
     pub fn value_type(&self) -> Option<SqliteType> {
-        let tpe = unsafe { ffi::sqlite3_value_type(self.value.as_ptr()) };
-        match tpe {
-            ffi::SQLITE_TEXT => Some(SqliteType::Text),
-            ffi::SQLITE_INTEGER => Some(SqliteType::Long),
-            ffi::SQLITE_FLOAT => Some(SqliteType::Double),
-            ffi::SQLITE_BLOB => Some(SqliteType::Binary),
-            ffi::SQLITE_NULL => None,
-            _ => unreachable!(
-                "Sqlite's documentation state that this case ({}) is not reachable. \
-                 If you ever see this error message please open an issue at \
-                 https://github.com/diesel-rs/diesel.",
-                tpe
-            ),
-        }
+        // SAFETY: `self.owner` keeps the value alive and this call only inspects it.
+        unsafe { value_type_of(self.value) }
+    }
+}
+
+/// Reads a value's type, which SQLite reports as SQL `NULL` for a failed conversion.
+///
+/// # Safety
+///
+/// `value` must point to a live `sqlite3_value`.
+unsafe fn value_type_of(value: NonNull<ffi::sqlite3_value>) -> Option<SqliteType> {
+    // SAFETY: the caller guarantees a live value, which this call only inspects.
+    let tpe = unsafe { ffi::sqlite3_value_type(value.as_ptr()) };
+    match tpe {
+        ffi::SQLITE_TEXT => Some(SqliteType::Text),
+        ffi::SQLITE_INTEGER => Some(SqliteType::Long),
+        ffi::SQLITE_FLOAT => Some(SqliteType::Double),
+        ffi::SQLITE_BLOB => Some(SqliteType::Binary),
+        ffi::SQLITE_NULL => None,
+        _ => unreachable!(
+            "Sqlite's documentation state that this case ({}) is not reachable. \
+             If you ever see this error message please open an issue at \
+             https://github.com/diesel-rs/diesel.",
+            tpe
+        ),
     }
 }
 
 impl OwnedSqliteValue {
-    pub(super) fn copy_from_ptr(ptr: NonNull<ffi::sqlite3_value>) -> Option<OwnedSqliteValue> {
+    /// Copies a value out of a statement or a function argument.
+    ///
+    /// `Ok(None)` is SQL `NULL`. A failed allocation is an error instead, as reporting
+    /// it as `NULL` would hand out a wrong value.
+    pub(super) fn copy_from_ptr(
+        ptr: NonNull<ffi::sqlite3_value>,
+    ) -> QueryResult<Option<OwnedSqliteValue>> {
+        // SAFETY: `ptr` points to a live `sqlite3_value` owned by the statement or
+        // callback that outlives this call, and reading its type only inspects it.
         let tpe = unsafe { ffi::sqlite3_value_type(ptr.as_ptr()) };
         if ffi::SQLITE_NULL == tpe {
-            return None;
+            return Ok(None);
         }
+        // SAFETY: the same live value as above, which `sqlite3_value_dup` only reads
+        // while it copies it into an independently owned value.
         let value = unsafe { ffi::sqlite3_value_dup(ptr.as_ptr()) };
-        Some(Self {
-            value: NonNull::new(value)?,
-        })
+        // The value above is not null, so only a failed allocation returns null here.
+        let value = NonNull::new(value).ok_or_else(duplication_failed)?;
+        Ok(Some(Self { value }))
     }
 
-    pub(super) fn duplicate(&self) -> OwnedSqliteValue {
-        // self.value is a `NonNull` ptr so this cannot be null
+    pub(super) fn duplicate(&self) -> QueryResult<OwnedSqliteValue> {
+        // SAFETY: `self` owns `self.value` and keeps it alive across this call, and
+        // `sqlite3_value_dup` only reads it while copying it.
         let value = unsafe { ffi::sqlite3_value_dup(self.value.as_ptr()) };
-        let value = NonNull::new(value).expect(
-            "Sqlite documentation states this returns only null if value is null \
-                 or OOM. If you ever see this panic message please open an issue at \
-                 https://github.com/diesel-rs/diesel.",
-        );
-        OwnedSqliteValue { value }
+        let value = NonNull::new(value).ok_or_else(duplication_failed)?;
+        Ok(OwnedSqliteValue { value })
     }
 }
 
@@ -293,6 +455,394 @@ mod tests {
     use crate::row::Row;
     use crate::sql_types::{Blob, Double, Int4, Text};
     use crate::*;
+
+    #[cfg(all(
+        feature = "std",
+        not(all(target_family = "wasm", target_os = "unknown"))
+    ))]
+    mod allocation_failure {
+        use super::super::SqliteValue;
+        use crate::connection::{LoadConnection, SimpleConnection};
+        use crate::deserialize::{self, FromSql};
+        use crate::prelude::*;
+        use crate::row::{Field, Row};
+        use crate::sql_types::Binary;
+        use crate::sqlite::connection::oom_test_support::{
+            panic_message, run_in_child, with_heap_limit,
+        };
+        use crate::sqlite::{Sqlite, SqliteConnection};
+        use alloc::string::{String, ToString};
+
+        const VALUE_LEN: usize = 1_048_576;
+
+        crate::table! {
+            oom_blob (id) {
+                id -> Integer,
+                value -> Binary,
+            }
+        }
+
+        crate::table! {
+            oom_text (id) {
+                id -> Integer,
+                value -> Text,
+            }
+        }
+
+        crate::table! {
+            oom_zeroblob (id) {
+                id -> Integer,
+                len -> Integer,
+            }
+        }
+
+        crate::define_sql_function! {
+            fn read_blob_under_pressure(value: Binary) -> Integer;
+        }
+
+        /// Carries the panic message of a blob read that ran out of memory, as the
+        /// failing statement reports SQLite's own error instead.
+        struct BlobUnderPressure(String);
+
+        impl FromSql<Binary, Sqlite> for BlobUnderPressure {
+            fn from_sql(mut value: SqliteValue<'_, '_, '_>) -> deserialize::Result<Self> {
+                let payload = std::panic::catch_unwind(core::panic::AssertUnwindSafe(|| {
+                    without_spare_memory(|| core::hint::black_box(value.read_blob().len()));
+                }))
+                .expect_err("the blob read did not panic");
+                Ok(Self(panic_message(&*payload).to_string()))
+            }
+        }
+
+        impl crate::deserialize::Queryable<Binary, Sqlite> for BlobUnderPressure {
+            type Row = Self;
+
+            fn build(row: Self::Row) -> deserialize::Result<Self> {
+                Ok(row)
+            }
+        }
+
+        /// Rejects every further SQLite allocation while `f` runs.
+        fn without_spare_memory<R>(f: impl FnOnce() -> R) -> R {
+            with_heap_limit(0, f)
+        }
+
+        fn expect_panic(f: impl FnOnce() + core::panic::UnwindSafe, expected: &str) {
+            let payload = std::panic::catch_unwind(f).expect_err("the read did not panic");
+            let message = panic_message(&*payload);
+            assert!(
+                message.contains(expected),
+                "unexpected panic message: {message}"
+            );
+        }
+
+        fn blob_connection(rows: i32) -> SqliteConnection {
+            let mut conn = SqliteConnection::establish(":memory:").unwrap();
+            // Diesel has no typed DDL.
+            conn.batch_execute(
+                "CREATE TABLE oom_blob (id INTEGER PRIMARY KEY, value BLOB NOT NULL)",
+            )
+            .unwrap();
+            for id in 1..=rows {
+                crate::insert_into(oom_blob::table)
+                    .values((
+                        oom_blob::id.eq(id),
+                        oom_blob::value.eq(alloc::vec![b'x'; VALUE_LEN]),
+                    ))
+                    .execute(&mut conn)
+                    .unwrap();
+            }
+            conn
+        }
+
+        fn utf16_text_connection(rows: i32) -> SqliteConnection {
+            let mut conn = SqliteConnection::establish(":memory:").unwrap();
+            // Diesel has no typed DDL and no typed representation of the database encoding.
+            conn.batch_execute(
+                "PRAGMA encoding = 'UTF-16le';
+                 CREATE TABLE oom_text (id INTEGER PRIMARY KEY, value TEXT NOT NULL)",
+            )
+            .unwrap();
+            for id in 1..=rows {
+                crate::insert_into(oom_text::table)
+                    .values((
+                        oom_text::id.eq(id),
+                        oom_text::value.eq("x".repeat(VALUE_LEN)),
+                    ))
+                    .execute(&mut conn)
+                    .unwrap();
+            }
+            conn
+        }
+
+        #[test]
+        fn text_read_panics_when_conversion_fails() {
+            run_in_child(|| {
+                let mut conn = utf16_text_connection(1);
+                let mut rows = conn.load(oom_text::table.select(oom_text::value)).unwrap();
+                let row = rows.next().unwrap().unwrap();
+                let field = row.get(0).unwrap();
+                let mut value = field.value().unwrap();
+
+                expect_panic(
+                    core::panic::AssertUnwindSafe(|| {
+                        without_spare_memory(|| {
+                            core::hint::black_box(value.read_text().len());
+                        });
+                    }),
+                    "SQLite ran out of memory while reading a value as text",
+                );
+            });
+        }
+
+        #[test]
+        fn duplicated_text_read_panics_when_conversion_fails() {
+            run_in_child(|| {
+                let mut conn = utf16_text_connection(2);
+                let mut rows = conn.load(oom_text::table.select(oom_text::value)).unwrap();
+                let first = rows.next().unwrap().unwrap();
+                // Advancing while the first row lives copies its values out of the statement,
+                // and `sqlite3_value_dup` disconnects them from the connection.
+                let _second = rows.next().unwrap().unwrap();
+                let field = first.get(0).unwrap();
+                let mut value = field.value().unwrap();
+
+                expect_panic(
+                    core::panic::AssertUnwindSafe(|| {
+                        without_spare_memory(|| {
+                            core::hint::black_box(value.read_text().len());
+                        });
+                    }),
+                    "SQLite failed to allocate memory while reading a value as text",
+                );
+            });
+        }
+
+        #[test]
+        fn blob_read_as_text_panics_when_the_copy_fails() {
+            run_in_child(|| {
+                let mut conn = blob_connection(1);
+                let mut rows = conn.load(oom_blob::table.select(oom_blob::value)).unwrap();
+                let row = rows.next().unwrap().unwrap();
+                let field = row.get(0).unwrap();
+                let mut value = field.value().unwrap();
+
+                expect_panic(
+                    core::panic::AssertUnwindSafe(|| {
+                        without_spare_memory(|| {
+                            core::hint::black_box(value.read_text().len());
+                        });
+                    }),
+                    "SQLite failed to allocate memory while reading a value as text",
+                );
+            });
+        }
+
+        #[test]
+        fn text_read_as_blob_panics_when_the_copy_fails() {
+            run_in_child(|| {
+                let mut conn = utf16_text_connection(1);
+                let mut rows = conn.load(oom_text::table.select(oom_text::value)).unwrap();
+                let row = rows.next().unwrap().unwrap();
+                let field = row.get(0).unwrap();
+                let mut value = field.value().unwrap();
+
+                expect_panic(
+                    core::panic::AssertUnwindSafe(|| {
+                        without_spare_memory(|| {
+                            core::hint::black_box(value.read_blob().len());
+                        });
+                    }),
+                    "SQLite failed to allocate memory while reading a value as a blob",
+                );
+            });
+        }
+
+        #[test]
+        fn blob_read_keeps_utf16_text_bytes_across_a_text_read() {
+            let mut conn = utf16_text_connection(1);
+            let mut rows = conn.load(oom_text::table.select(oom_text::value)).unwrap();
+            let row = rows.next().unwrap().unwrap();
+            let field = row.get(0).unwrap();
+            let mut blob_value = field.value().unwrap();
+            let mut text_value = field.value().unwrap();
+
+            let blob = blob_value.read_blob();
+            assert_eq!(blob.len(), 2 * VALUE_LEN);
+            let (pairs, rest) = blob.as_chunks::<2>();
+            assert!(
+                pairs.iter().all(|pair| pair == b"x\0") && rest.is_empty(),
+                "SQLite blob content changed"
+            );
+
+            // Converting the shared value to UTF-8 frees its UTF-16 buffer.
+            assert_eq!(text_value.read_text().len(), VALUE_LEN);
+            let (pairs, rest) = blob.as_chunks::<2>();
+            assert!(
+                pairs.iter().all(|pair| pair == b"x\0") && rest.is_empty(),
+                "the text read invalidated the blob bytes"
+            );
+        }
+
+        #[test]
+        fn zeroblob_read_panics_when_expansion_fails() {
+            run_in_child(|| {
+                let mut conn = SqliteConnection::establish(":memory:").unwrap();
+                // Diesel has no typed DDL.
+                conn.batch_execute(
+                    "CREATE TABLE oom_zeroblob (id INTEGER PRIMARY KEY, len INTEGER NOT NULL)",
+                )
+                .unwrap();
+                crate::insert_into(oom_zeroblob::table)
+                    .values((
+                        oom_zeroblob::id.eq(1),
+                        oom_zeroblob::len.eq(i32::try_from(VALUE_LEN).unwrap()),
+                    ))
+                    .execute(&mut conn)
+                    .unwrap();
+                let observed = alloc::sync::Arc::new(core::sync::atomic::AtomicBool::new(false));
+                let callback_observed = alloc::sync::Arc::clone(&observed);
+                read_blob_under_pressure_utils::register_impl(
+                    &mut conn,
+                    move |value: BlobUnderPressure| {
+                        assert!(
+                            value.0.contains(
+                                "SQLite ran out of memory while reading a value as a blob"
+                            ),
+                            "unexpected panic message: {}",
+                            value.0
+                        );
+                        callback_observed.store(true, core::sync::atomic::Ordering::Relaxed);
+                        1
+                    },
+                )
+                .unwrap();
+
+                // Diesel has no typed representation of `zeroblob`, and a constant argument
+                // would be expanded by the virtual machine before the function sees it.
+                let result = oom_zeroblob::table
+                    .select(read_blob_under_pressure(crate::dsl::sql::<Binary>(
+                        "zeroblob(len)",
+                    )))
+                    .get_result::<i32>(&mut conn);
+                assert!(result.is_err(), "the blob read did not fail the statement");
+                assert!(
+                    observed.load(core::sync::atomic::Ordering::Relaxed),
+                    "the function did not read its argument"
+                );
+            });
+        }
+
+        #[test]
+        fn row_duplication_reports_value_duplication_failure() {
+            run_in_child(|| {
+                let mut conn = blob_connection(2);
+                let mut rows = conn.load(oom_blob::table.select(oom_blob::value)).unwrap();
+                // Holding the first row makes the next step copy it out of the statement.
+                let _first = rows.next().unwrap().unwrap();
+
+                let error = match without_spare_memory(|| rows.next()) {
+                    Some(Err(e)) => e,
+                    Some(Ok(_)) => panic!("the row duplication did not fail"),
+                    None => panic!("the iterator ended instead of copying the row"),
+                };
+                assert!(
+                    error
+                        .to_string()
+                        .contains("SQLite failed to allocate a duplicated value"),
+                    "unexpected error: {error}"
+                );
+            });
+        }
+    }
+
+    crate::table! {
+        empty_values (id) {
+            id -> Integer,
+            text -> Text,
+            blob -> Binary,
+            zero_blob -> Binary,
+        }
+    }
+
+    #[diesel_test_helper::test]
+    fn can_read_empty_values_as_empty_blob() {
+        use crate::prelude::*;
+        let mut conn = SqliteConnection::establish(":memory:").unwrap();
+        // Diesel has no typed DDL, and BLOB affinity keeps the empty text literal in
+        // `blob` as TEXT, which the typed DSL cannot store there.
+        conn.batch_execute(
+            "CREATE TABLE empty_values (id INTEGER PRIMARY KEY, text TEXT, blob BLOB, zero_blob BLOB);
+             INSERT INTO empty_values (id, text, blob, zero_blob) VALUES (1, '', '', X'');",
+        )
+        .unwrap();
+
+        // The same empty TEXT through the typed `FromSql<Binary, Sqlite>` path.
+        let loaded = crate::select(crate::dsl::sql::<crate::sql_types::Binary>("''"))
+            .get_result::<Vec<u8>>(&mut conn)
+            .unwrap();
+        assert!(loaded.is_empty());
+
+        let mut rows = conn
+            .load(empty_values::table.select((
+                empty_values::text,
+                empty_values::blob,
+                empty_values::zero_blob,
+            )))
+            .unwrap();
+        let row = rows.next().unwrap().unwrap();
+        let text_field = row.get(0).unwrap();
+        let blob_field = row.get(1).unwrap();
+        let zero_blob_field = row.get(2).unwrap();
+
+        let mut text_value = text_field.value().unwrap();
+        assert_eq!(text_value.read_text(), "");
+        let mut text_value = text_field.value().unwrap();
+        assert_eq!(text_value.read_blob(), b"");
+
+        let mut blob_value = blob_field.value().unwrap();
+        assert_eq!(blob_value.value_type(), Some(super::SqliteType::Text));
+        assert_eq!(blob_value.read_blob(), b"");
+
+        // A zero length BLOB, for which SQLite also reports a null pointer.
+        let mut zero_blob_value = zero_blob_field.value().unwrap();
+        assert_eq!(
+            zero_blob_value.value_type(),
+            Some(super::SqliteType::Binary)
+        );
+        assert_eq!(zero_blob_value.read_blob(), b"");
+    }
+
+    #[diesel_test_helper::test]
+    fn blob_bytes_survive_a_text_read_of_the_same_value() {
+        use crate::prelude::*;
+        let mut conn = SqliteConnection::establish(":memory:").unwrap();
+        // Diesel has no typed `randomblob`, and a stored blob points into the page
+        // image, which a conversion never frees.
+        let mut rows = conn
+            .load(crate::select(crate::dsl::sql::<crate::sql_types::Binary>(
+                "randomblob(1048576)",
+            )))
+            .unwrap();
+        let row = rows.next().unwrap().unwrap();
+        let field = row.get(0).unwrap();
+        let mut blob_value = field.value().unwrap();
+        let mut text_value = field.value().unwrap();
+        let mut other_blob_value = field.value().unwrap();
+
+        let blob = blob_value.read_blob();
+        let expected = Vec::from(blob);
+        let address = blob.as_ptr();
+
+        // Converting the shared value to text would free the buffer `blob` points at.
+        assert!(!text_value.read_text().is_empty());
+        assert_eq!(blob, expected.as_slice(), "the text read moved the blob");
+        assert_eq!(
+            other_blob_value.read_blob().as_ptr(),
+            address,
+            "the text read converted the shared value"
+        );
+    }
 
     #[expect(clippy::approx_constant)] // we really want to use 3.14
     #[diesel_test_helper::test]

--- a/diesel/src/sqlite/connection/statement_iterator.rs
+++ b/diesel/src/sqlite/connection/statement_iterator.rs
@@ -37,7 +37,11 @@ impl<'stmt, 'query> StatementIterator<'stmt, 'query> {
                 }
             };
             let last_row = &mut *last_row;
-            let duplicated = last_row.duplicate(column_names);
+            let duplicated = match last_row.duplicate(column_names) {
+                Ok(duplicated) => duplicated,
+                // The statement is not advanced, so the row it holds stays current.
+                Err(e) => return Some(Err(e)),
+            };
             core::mem::replace(last_row, duplicated)
         };
         if let PrivateSqliteRow::Direct(mut stmt) = last_row {

--- a/diesel/src/sqlite/connection/stmt.rs
+++ b/diesel/src/sqlite/connection/stmt.rs
@@ -575,8 +575,11 @@ impl<'stmt, 'query> StatementUse<'stmt, 'query> {
             .and_then(|c| unsafe { c.as_ref() })
     }
 
-    pub(super) fn copy_value(&self, idx: i32) -> Option<OwnedSqliteValue> {
-        OwnedSqliteValue::copy_from_ptr(self.column_value(idx)?)
+    pub(super) fn copy_value(&self, idx: i32) -> QueryResult<Option<OwnedSqliteValue>> {
+        match self.column_value(idx) {
+            Some(ptr) => OwnedSqliteValue::copy_from_ptr(ptr),
+            None => Ok(None),
+        }
     }
 
     pub(super) fn column_value(&self, idx: i32) -> Option<NonNull<ffi::sqlite3_value>> {
@@ -584,6 +587,10 @@ impl<'stmt, 'query> StatementUse<'stmt, 'query> {
             ffi::sqlite3_column_value(self.statement.statement.inner_statement.as_ptr(), idx)
         };
         NonNull::new(ptr)
+    }
+
+    pub(super) fn raw_connection(&self) -> *mut ffi::sqlite3 {
+        self.statement.statement.raw_connection()
     }
 }
 


### PR DESCRIPTION
SQLite uses null pointers and zero lengths for SQL `NULL`, empty values, and allocation failures. Diesel did not distinguish them, so failed text or blob conversions could produce invalid slices or incorrect empty or `NULL` data.

Value reads now validate conversions, preserve the original `zeroblob` length, and panic where Diesel 2.x signatures cannot return errors. Statement row copying already yields `QueryResult` and now returns an error when `sqlite3_value_dup` fails; only the infallible `IntoOwnedRow` path still panics.