### PR TITLE
Handle null `sqlite3_serialize` buffers safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 * MySQL and MariaDB now decode a value according to the signedness the server reports for its column, so a `SMALLINT UNSIGNED` holding 40000 read as `Integer` returns 40000 rather than -25536
 * Fixed a possible null pointer dereference in the custom SQLite aggregate function support when SQLite fails to allocate the aggregate state
 * `FromSql` impls for PostgreSQL arrays now use the element OID from the array header instead of the array type's own OID when decoding each element, matching the behavior of the record decoder.
+* Fixed undefined behavior in `SqliteConnection::serialize_database_to_buffer` when SQLite returns a null buffer for an empty deserialized database or an allocation failure. `SerializedDatabase::as_slice` is deprecated in favor of the new `SerializedDatabase::try_as_slice`, which reports the allocation failure as an error instead of panicking.
 
 ### Changed
 

--- a/diesel/src/sqlite/connection/mod.rs
+++ b/diesel/src/sqlite/connection/mod.rs
@@ -747,7 +747,9 @@ impl SqliteConnection {
     ///
     /// # Returns
     ///
-    /// This function returns a byte slice representing the serialized database.
+    /// This function returns a [`SerializedDatabase`] wrapping the serialized
+    /// bytes. If SQLite fails to allocate the buffer holding them, the failure
+    /// is reported by [`SerializedDatabase::try_as_slice`].
     pub fn serialize_database_to_buffer(&mut self) -> SerializedDatabase {
         self.raw_connection.serialize()
     }
@@ -784,7 +786,7 @@ impl SqliteConnection {
     /// let connection = &mut SqliteConnection::establish(":memory:").unwrap();
     ///
     /// // Deserialize the byte vector into the new database
-    /// connection.deserialize_readonly_database_from_buffer(serialized_db.as_slice()).unwrap();
+    /// connection.deserialize_readonly_database_from_buffer(serialized_db.try_as_slice().unwrap()).unwrap();
     /// #
     /// # }
     /// ```
@@ -2256,7 +2258,9 @@ mod tests {
             let serialized_database = conn1.serialize_database_to_buffer();
             let conn2 = &mut connection();
             conn2
-                .deserialize_readonly_database_from_buffer(serialized_database.as_slice())
+                .deserialize_readonly_database_from_buffer(
+                    serialized_database.try_as_slice().unwrap(),
+                )
                 .unwrap();
 
             let query =
@@ -2326,6 +2330,177 @@ mod tests {
             r.unwrap_err().to_string(),
             "database disk image is malformed"
         );
+    }
+
+    #[diesel_test_helper::test]
+    fn database_serializes_empty_deserialized_database() {
+        let conn = &mut SqliteConnection::establish(":memory:").unwrap();
+        conn.deserialize_readonly_database_from_buffer(&[]).unwrap();
+
+        let serialized = conn.serialize_database_to_buffer();
+
+        assert!(serialized.is_empty());
+        assert!(serialized.try_as_slice().unwrap().is_empty());
+    }
+
+    #[cfg(all(
+        feature = "std",
+        not(all(target_family = "wasm", target_os = "unknown"))
+    ))]
+    #[allow(unsafe_code)]
+    mod sqlite_serialize_oom {
+        use super::super::{SerializedDatabase, ffi};
+        use crate::connection::{Connection, SimpleConnection};
+        use crate::sqlite::SqliteConnection;
+
+        const CHILD_ENV: &str = "DIESEL_SQLITE_SERIALIZE_OOM_CHILD";
+        const MIN_DATABASE_BYTES: i64 = 1_048_576;
+
+        struct HardHeapLimit(i64);
+
+        impl Drop for HardHeapLimit {
+            fn drop(&mut self) {
+                // SAFETY: SQLite accepts every i64 and does not retain Rust memory.
+                unsafe {
+                    ffi::sqlite3_hard_heap_limit64(self.0);
+                }
+            }
+        }
+
+        // 64 KiB covers statement setup but cannot hold the 1 MiB serialization,
+        // pinning the failure to output allocation after SQLite reports its size.
+        fn with_failing_serialize<R>(f: impl FnOnce() -> R) -> R {
+            // SAFETY: These process-global SQLite APIs do not dereference Rust memory.
+            let previous = unsafe {
+                let current = ffi::sqlite3_memory_used();
+                ffi::sqlite3_hard_heap_limit64(current + 65_536)
+            };
+            let _guard = HardHeapLimit(previous);
+            f()
+        }
+
+        #[test]
+        fn sqlite_serialize_oom_is_contained() {
+            run_in_child("serialize", || {
+                let mut conn = large_database();
+
+                let (baseline_size, baseline) = serialize_direct(&conn);
+                assert!(
+                    baseline_size >= MIN_DATABASE_BYTES,
+                    "the serialized database is smaller than 1 MiB"
+                );
+                assert!(
+                    !baseline.is_null(),
+                    "SQLite refused to serialize a valid database"
+                );
+                // SAFETY: `sqlite3_serialize` returned this buffer and no wrapper owns it.
+                unsafe { ffi::sqlite3_free(baseline as _) };
+
+                let (reported_size, data) = with_failing_serialize(|| serialize_direct(&conn));
+                if !data.is_null() {
+                    // SAFETY: `sqlite3_serialize` returned this buffer and no wrapper owns it.
+                    unsafe { ffi::sqlite3_free(data as _) };
+                }
+                assert!(
+                    data.is_null(),
+                    "SQLite did not fail the output allocation of the serialization"
+                );
+                // SQLite reports the required size before attempting output allocation.
+                assert!(
+                    reported_size >= MIN_DATABASE_BYTES,
+                    "SQLite reported a serialization size of {reported_size} with a null buffer"
+                );
+
+                let serialized: SerializedDatabase =
+                    with_failing_serialize(|| conn.serialize_database_to_buffer());
+                let error = serialized
+                    .try_as_slice()
+                    .expect_err("the failed output allocation must surface as an error");
+                assert_eq!(error.to_string(), "out of memory");
+
+                let outcome = std::panic::catch_unwind(core::panic::AssertUnwindSafe(|| {
+                    core::hint::black_box(serialized[0]);
+                }));
+                let message = panic_message(&outcome);
+                assert!(
+                    message.contains("Cannot access the serialized database: out of memory"),
+                    "SQLite serialization allocation failure surfaced as `{message}` instead \
+                     of a caught allocation panic"
+                );
+            });
+        }
+
+        // The SQLite heap limit is process-global, so a child process keeps the
+        // artificially induced allocation failures away from concurrent tests.
+        fn run_in_child(case: &str, f: impl FnOnce()) {
+            if std::env::var_os(CHILD_ENV).as_deref() == Some(std::ffi::OsStr::new(case)) {
+                f();
+                return;
+            }
+
+            let current_thread = std::thread::current();
+            let test_name = current_thread
+                .name()
+                .expect("the test harness names every test thread");
+            let output = std::process::Command::new(
+                std::env::current_exe().expect("the test binary has a path"),
+            )
+            .arg("--exact")
+            .arg(test_name)
+            .arg("--nocapture")
+            .env(CHILD_ENV, case)
+            .output()
+            .expect("the child test process starts");
+
+            assert!(
+                output.status.success(),
+                "child test failed\nstdout:\n{}\nstderr:\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            // libtest exits successfully when an exact filter matches no tests.
+            assert!(
+                String::from_utf8_lossy(&output.stdout).contains("test result: ok. 1 passed"),
+                "child test did not run exactly one test\nstdout:\n{}\nstderr:\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+
+        fn large_database() -> SqliteConnection {
+            let mut conn = SqliteConnection::establish(":memory:").unwrap();
+            conn.batch_execute(&format!(
+                "CREATE TABLE blobs (id INTEGER PRIMARY KEY, payload BLOB);
+                 INSERT INTO blobs (payload) VALUES (zeroblob({MIN_DATABASE_BYTES}));"
+            ))
+            .unwrap();
+            conn
+        }
+
+        fn serialize_direct(conn: &SqliteConnection) -> (ffi::sqlite3_int64, *mut u8) {
+            // SAFETY: The connection is live, a null schema selects `main`, and `size` is a writable out-parameter.
+            unsafe {
+                let mut size: ffi::sqlite3_int64 = 0;
+                let data = ffi::sqlite3_serialize(
+                    conn.raw_connection.internal_connection.as_ptr(),
+                    core::ptr::null(),
+                    &mut size as *mut _,
+                    0,
+                );
+                (size, data)
+            }
+        }
+
+        fn panic_message(outcome: &std::thread::Result<()>) -> String {
+            match outcome {
+                Ok(()) => "the call returned without a panic".to_string(),
+                Err(payload) => payload
+                    .downcast_ref::<&str>()
+                    .map(|s| (*s).to_string())
+                    .or_else(|| payload.downcast_ref::<String>().cloned())
+                    .unwrap_or_else(|| "non-string panic payload".to_string()),
+            }
+        }
     }
 
     #[diesel_test_helper::test]

--- a/diesel/src/sqlite/connection/raw.rs
+++ b/diesel/src/sqlite/connection/raw.rs
@@ -287,20 +287,26 @@ impl RawConnection {
     }
 
     pub(super) fn serialize(&mut self) -> SerializedDatabase {
-        unsafe {
-            let mut size: ffi::sqlite3_int64 = 0;
-            let data_ptr = ffi::sqlite3_serialize(
+        let mut size: ffi::sqlite3_int64 = 0;
+        // SAFETY: The connection is live, a null schema selects `main`, and `size` is a writable out-parameter.
+        let data_ptr = unsafe {
+            ffi::sqlite3_serialize(
                 self.internal_connection.as_ptr(),
                 core::ptr::null(),
                 &mut size as *mut _,
                 0,
-            );
-            SerializedDatabase::new(
-                data_ptr,
-                size.try_into()
-                    .expect("Cannot fit the serialized database into memory"),
             )
-        }
+        };
+        // SQLite returns null with size zero for a valid empty deserialized
+        // database and null with a nonzero size when the output allocation
+        // fails. `SerializedDatabase` reports the failure when accessed.
+        let data = match core::ptr::NonNull::new(data_ptr) {
+            Some(data) => data,
+            None if size == 0 => return SerializedDatabase::empty(),
+            None => return SerializedDatabase::allocation_failed(),
+        };
+        // SAFETY: SQLite transferred an exclusive allocation holding `size` initialized bytes.
+        unsafe { SerializedDatabase::new(data, size) }
     }
 
     // SAFETY:

--- a/diesel/src/sqlite/connection/serialized_database.rs
+++ b/diesel/src/sqlite/connection/serialized_database.rs
@@ -5,45 +5,136 @@ extern crate libsqlite3_sys as ffi;
 #[cfg(all(target_family = "wasm", target_os = "unknown"))]
 use sqlite_wasm_rs as ffi;
 
+use crate::result::{DatabaseErrorKind, Error, QueryResult};
+use alloc::boxed::Box;
+use alloc::string::ToString;
 use core::ops::Deref;
+use core::ptr::NonNull;
 
-/// `SerializedDatabase` is a wrapper for a serialized database that is dynamically allocated by calling `sqlite3_serialize`.
-/// This RAII wrapper is necessary to deallocate the memory when it goes out of scope with `sqlite3_free`.
+/// Owns a database serialization returned by `sqlite3_serialize` and releases any allocated buffer with `sqlite3_free`.
 #[derive(Debug)]
 pub struct SerializedDatabase {
-    data: *mut u8,
-    len: usize,
+    state: State,
+}
+
+#[derive(Debug)]
+enum State {
+    /// A successful serialization owning a SQLite allocation.
+    Owned { data: NonNull<u8>, len: i64 },
+    /// A valid serialization of an empty deserialized database.
+    Empty,
+    /// SQLite failed to allocate the output buffer.
+    AllocationFailed,
 }
 
 impl SerializedDatabase {
     /// Creates a new `SerializedDatabase` with the given data pointer and length.
     ///
-    /// SAFETY: The data pointer needs to be returned by sqlite
-    ///         and the length must match the underlying buffer pointer
-    pub(crate) unsafe fn new(data: *mut u8, len: usize) -> Self {
-        Self { data, len }
+    /// # Safety
+    ///
+    /// `data` must exclusively own a successful `sqlite3_serialize` allocation that this value may free, and, if `0 <= len <= isize::MAX`, that allocation must hold `len` initialized bytes.
+    pub(crate) unsafe fn new(data: NonNull<u8>, len: i64) -> Self {
+        Self {
+            state: State::Owned { data, len },
+        }
+    }
+
+    pub(crate) fn empty() -> Self {
+        Self {
+            state: State::Empty,
+        }
+    }
+
+    pub(crate) fn allocation_failed() -> Self {
+        Self {
+            state: State::AllocationFailed,
+        }
     }
 
     /// Returns a slice of the serialized database.
+    ///
+    /// # Panics
+    ///
+    /// Panics if SQLite failed to allocate the buffer holding the serialized database, or if it reported a size this platform cannot address.
+    #[deprecated(note = "Use `SerializedDatabase::try_as_slice` instead")]
+    #[cfg(all(feature = "with-deprecated", not(feature = "without-deprecated")))]
     pub fn as_slice(&self) -> &[u8] {
-        // The pointer is never null because we don't pass the NO_COPY flag
-        unsafe { core::slice::from_raw_parts(self.data, self.len) }
+        self.expect_slice()
+    }
+
+    /// Returns a slice of the serialized database, the out of memory error if
+    /// SQLite failed to allocate the buffer holding it, or a conversion error
+    /// if SQLite reported a size this platform cannot address.
+    pub fn try_as_slice(&self) -> QueryResult<&[u8]> {
+        match self.state {
+            State::Owned { data, len } => {
+                // `from_raw_parts` requires a length no larger than `isize::MAX`.
+                let len = isize::try_from(len).map_err(Error::IntegerConversion)?;
+                let len = usize::try_from(len).map_err(Error::IntegerConversion)?;
+                // SAFETY: `new` guarantees an exclusively owned immutable allocation of `len` initialized bytes for every addressable `len`.
+                Ok(unsafe { core::slice::from_raw_parts(data.as_ptr(), len) })
+            }
+            State::Empty => Ok(&[]),
+            State::AllocationFailed => Err(Error::DatabaseError(
+                DatabaseErrorKind::Unknown,
+                Box::new("out of memory".to_string()),
+            )),
+        }
+    }
+
+    fn expect_slice(&self) -> &[u8] {
+        match self.try_as_slice() {
+            Ok(slice) => slice,
+            Err(e) => panic!("Cannot access the serialized database: {e}"),
+        }
     }
 }
 
 impl Deref for SerializedDatabase {
     type Target = [u8];
 
+    /// Returns a slice of the serialized database.
+    ///
+    /// Panics if SQLite failed to allocate the buffer holding the serialized
+    /// database or reported a size this platform cannot address, use
+    /// [`try_as_slice`](Self::try_as_slice) to handle those failures instead.
     fn deref(&self) -> &Self::Target {
-        self.as_slice()
+        self.expect_slice()
     }
 }
 
 impl Drop for SerializedDatabase {
     /// Deallocates the memory of the serialized database when it goes out of scope.
     fn drop(&mut self) {
-        unsafe {
-            ffi::sqlite3_free(self.data as _);
+        if let State::Owned { data, .. } = self.state {
+            // SAFETY: `new` transfers one SQLite allocation that remains owned until this single `Drop` call.
+            unsafe {
+                ffi::sqlite3_free(data.as_ptr() as _);
+            }
         }
+    }
+}
+
+#[cfg(all(test, target_pointer_width = "32"))]
+mod tests {
+    use super::{SerializedDatabase, ffi};
+    use crate::result::Error;
+    use core::ptr::NonNull;
+
+    // A serialization one byte past `isize::MAX` still fits `usize`, so only an `isize` bound
+    // keeps it from building a slice `from_raw_parts` rejects. Its allocation is still freed.
+    #[diesel_test_helper::test]
+    fn oversized_serialization_is_rejected() {
+        let len = i64::try_from(isize::MAX).expect("`isize::MAX` fits `i64`") + 1;
+        // SAFETY: SQLite's allocator requires no connection and returns an exclusive allocation.
+        let data = unsafe { ffi::sqlite3_malloc(1) };
+        let data = NonNull::new(data.cast::<u8>()).expect("SQLite allocates a single byte");
+        // SAFETY: `data` exclusively owns a SQLite allocation and `len` exceeds `isize::MAX`, so no byte count is required of it.
+        let serialized = unsafe { SerializedDatabase::new(data, len) };
+
+        assert!(matches!(
+            serialized.try_as_slice(),
+            Err(Error::IntegerConversion(_))
+        ));
     }
 }


### PR DESCRIPTION
`sqlite3_serialize` returns `NULL` both when allocation fails and when a deserialized database is valid but empty. The former can carry a nonzero size, so constructing a slice from the returned pointer invokes undefined behavior.

`SqliteConnection::serialize_database_to_buffer` cannot return an error without a breaking API change, hence the diesel3 todo. This preserves empty serialization and keeps allocation failure as the documented panic, with regressions for both cases.