### PR TITLE
Document the Insertable serialize_as attribute

### DIFF
--- a/diesel_derives/build.rs
+++ b/diesel_derives/build.rs
@@ -274,6 +274,10 @@ fn main() {
                     "diesel_derives__tests__insertable_table_name_1.snap",
                     "With `#[diesel(table_name = crate::schema::users)]`",
                 ),
+                Example::with_heading(
+                    "diesel_derives__tests__insertable_serialize_as_1.snap",
+                    "With `#[diesel(serialize_as = String)]`",
+                ),
             ],
         ),
         (

--- a/diesel_derives/src/tests/insertable.rs
+++ b/diesel_derives/src/tests/insertable.rs
@@ -35,3 +35,22 @@ pub(crate) fn insertable_table_name_1() {
         "insertable_table_name_1",
     );
 }
+
+#[test]
+pub(crate) fn insertable_serialize_as_1() {
+    let input = quote::quote! {
+        struct User {
+            id: i32,
+            name: String,
+            #[diesel(serialize_as = String)]
+            age: i32,
+        }
+    };
+
+    expand_with(
+        &crate::derive_insertable_inner as &dyn Fn(_) -> _,
+        input,
+        derive(syn::parse_quote!(#[derive(Insertable)])),
+        "insertable_serialize_as_1",
+    );
+}

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__insertable_serialize_as_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__insertable_serialize_as_1.snap
@@ -1,0 +1,53 @@
+---
+source: diesel_derives/src/tests/mod.rs
+expression: out
+info:
+  input: "#[derive(Insertable)]\nstruct User {\n    id: i32,\n    name: String,\n    #[diesel(serialize_as = String)]\n    age: i32,\n}\n"
+---
+const _: () = {
+    use diesel;
+    impl diesel::insertable::Insertable<users::table> for User
+    where
+        i32: diesel::expression::AsExpression<
+            <users::r#id as diesel::Expression>::SqlType,
+        >,
+        String: diesel::expression::AsExpression<
+            <users::r#name as diesel::Expression>::SqlType,
+        >,
+        String: diesel::expression::AsExpression<
+            <users::r#age as diesel::Expression>::SqlType,
+        >,
+    {
+        type Values = <(
+            std::option::Option<diesel::dsl::Eq<users::r#id, i32>>,
+            std::option::Option<diesel::dsl::Eq<users::r#name, String>>,
+            std::option::Option<diesel::dsl::Eq<users::r#age, String>>,
+        ) as diesel::insertable::Insertable<users::table>>::Values;
+        fn values(
+            self,
+        ) -> <(
+            std::option::Option<diesel::dsl::Eq<users::r#id, i32>>,
+            std::option::Option<diesel::dsl::Eq<users::r#name, String>>,
+            std::option::Option<diesel::dsl::Eq<users::r#age, String>>,
+        ) as diesel::insertable::Insertable<users::table>>::Values {
+            diesel::insertable::Insertable::<
+                users::table,
+            >::values((
+                std::option::Option::Some(
+                    diesel::ExpressionMethods::eq(users::r#id, self.id),
+                ),
+                std::option::Option::Some(
+                    diesel::ExpressionMethods::eq(users::r#name, self.name),
+                ),
+                std::option::Option::Some(
+                    diesel::ExpressionMethods::eq(
+                        users::r#age,
+                        ::std::convert::Into::<String>::into(self.age),
+                    ),
+                ),
+            ))
+        }
+    }
+    impl diesel::internal::derives::insertable::UndecoratedInsertRecord<users::table>
+    for User {}
+};


### PR DESCRIPTION
References #4840 (one attribute checkbox)

Adds a focused derive test and snapshot for `#[diesel(serialize_as = String)]` on `#[derive(Insertable)]`, and wires the generated example into the API docs (mirroring the existing `insertable_1` / `insertable_table_name_1` examples).

The snapshot shows that `serialize_as` correctly routes the field through `Into::<String>::into` and uses `String` for the `AsExpression` bound of the target column.

Verified with: `cargo test -p diesel_derives --lib tests::insertable::insertable_serialize_as_1` (passes).