### PR TITLE
Document the Insertable embed attribute

### DIFF
--- a/diesel_derives/build.rs
+++ b/diesel_derives/build.rs
@@ -274,6 +274,10 @@ fn main() {
                     "diesel_derives__tests__insertable_table_name_1.snap",
                     "With `#[diesel(table_name = crate::schema::users)]`",
                 ),
+                Example::with_heading(
+                    "diesel_derives__tests__insertable_embed_1.snap",
+                    "With `#[diesel(embed)]`",
+                ),
             ],
         ),
         (

--- a/diesel_derives/src/tests/insertable.rs
+++ b/diesel_derives/src/tests/insertable.rs
@@ -35,3 +35,22 @@ pub(crate) fn insertable_table_name_1() {
         "insertable_table_name_1",
     );
 }
+
+#[test]
+pub(crate) fn insertable_embed_1() {
+    let input = quote::quote! {
+        struct User {
+            id: i32,
+            name: String,
+            #[diesel(embed)]
+            post: Post,
+        }
+    };
+
+    expand_with(
+        &crate::derive_insertable_inner as &dyn Fn(_) -> _,
+        input,
+        derive(syn::parse_quote!(#[derive(Insertable)])),
+        "insertable_embed_1",
+    );
+}

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__insertable_embed_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__insertable_embed_1.snap
@@ -1,0 +1,79 @@
+---
+source: diesel_derives/src/tests/mod.rs
+expression: out
+info:
+  input: "#[derive(Insertable)]\nstruct User {\n    id: i32,\n    name: String,\n    #[diesel(embed)]\n    post: Post,\n}\n"
+---
+const _: () = {
+    use diesel;
+    impl diesel::insertable::Insertable<users::table> for User
+    where
+        i32: diesel::expression::AsExpression<
+            <users::r#id as diesel::Expression>::SqlType,
+        >,
+        String: diesel::expression::AsExpression<
+            <users::r#name as diesel::Expression>::SqlType,
+        >,
+    {
+        type Values = <(
+            std::option::Option<diesel::dsl::Eq<users::r#id, i32>>,
+            std::option::Option<diesel::dsl::Eq<users::r#name, String>>,
+            Post,
+        ) as diesel::insertable::Insertable<users::table>>::Values;
+        fn values(
+            self,
+        ) -> <(
+            std::option::Option<diesel::dsl::Eq<users::r#id, i32>>,
+            std::option::Option<diesel::dsl::Eq<users::r#name, String>>,
+            Post,
+        ) as diesel::insertable::Insertable<users::table>>::Values {
+            diesel::insertable::Insertable::<
+                users::table,
+            >::values((
+                std::option::Option::Some(
+                    diesel::ExpressionMethods::eq(users::r#id, self.id),
+                ),
+                std::option::Option::Some(
+                    diesel::ExpressionMethods::eq(users::r#name, self.name),
+                ),
+                self.post,
+            ))
+        }
+    }
+    impl<'insert> diesel::insertable::Insertable<users::table> for &'insert User
+    where
+        &'insert i32: diesel::expression::AsExpression<
+            <users::r#id as diesel::Expression>::SqlType,
+        >,
+        &'insert String: diesel::expression::AsExpression<
+            <users::r#name as diesel::Expression>::SqlType,
+        >,
+    {
+        type Values = <(
+            std::option::Option<diesel::dsl::Eq<users::r#id, &'insert i32>>,
+            std::option::Option<diesel::dsl::Eq<users::r#name, &'insert String>>,
+            &'insert Post,
+        ) as diesel::insertable::Insertable<users::table>>::Values;
+        fn values(
+            self,
+        ) -> <(
+            std::option::Option<diesel::dsl::Eq<users::r#id, &'insert i32>>,
+            std::option::Option<diesel::dsl::Eq<users::r#name, &'insert String>>,
+            &'insert Post,
+        ) as diesel::insertable::Insertable<users::table>>::Values {
+            diesel::insertable::Insertable::<
+                users::table,
+            >::values((
+                std::option::Option::Some(
+                    diesel::ExpressionMethods::eq(users::r#id, &self.id),
+                ),
+                std::option::Option::Some(
+                    diesel::ExpressionMethods::eq(users::r#name, &self.name),
+                ),
+                &self.post,
+            ))
+        }
+    }
+    impl diesel::internal::derives::insertable::UndecoratedInsertRecord<users::table>
+    for User {}
+};


### PR DESCRIPTION
References #4840 (one attribute checkbox)

Adds a focused derive test and snapshot for `#[diesel(embed)]` on `#[derive(Insertable)]`, and wires the generated example into the API docs (mirroring the existing `insertable_1` / `insertable_table_name_1` examples).

The snapshot shows that the embedded field (`post: Post`) is inserted wholesale into the values tuple as the nested `Post` Insertable.

Verified with: `cargo test -p diesel_derives --lib tests::insertable::insertable_embed_1` (passes).