### PR TITLE
Document skip_insertion for the Insertable derive

### DIFF
--- a/diesel_derives/build.rs
+++ b/diesel_derives/build.rs
@@ -274,6 +274,10 @@ fn main() {
                     "diesel_derives__tests__insertable_table_name_1.snap",
                     "With `#[diesel(table_name = crate::schema::users)]`",
                 ),
+                Example::with_heading(
+                    "diesel_derives__tests__insertable_skip_insertion_1.snap",
+                    "With `#[diesel(skip_insertion)]`",
+                ),
             ],
         ),
         (

--- a/diesel_derives/src/tests/insertable.rs
+++ b/diesel_derives/src/tests/insertable.rs
@@ -35,3 +35,21 @@ pub(crate) fn insertable_table_name_1() {
         "insertable_table_name_1",
     );
 }
+
+#[test]
+pub(crate) fn insertable_skip_insertion_1() {
+    let input = quote::quote! {
+        struct User {
+            id: i32,
+            name: String,
+            #[diesel(skip_insertion)]
+            generated: String,
+        }
+    };
+    expand_with(
+        &crate::derive_insertable_inner as &dyn Fn(_) -> _,
+        input,
+        derive(syn::parse_quote!(#[derive(Insertable)])),
+        "insertable_skip_insertion_1",
+    );
+}

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__insertable_skip_insertion_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__insertable_skip_insertion_1.snap
@@ -1,0 +1,73 @@
+---
+source: diesel_derives/src/tests/mod.rs
+expression: out
+info:
+  input: "#[derive(Insertable)]\nstruct User {\n    id: i32,\n    name: String,\n    #[diesel(skip_insertion)]\n    generated: String,\n}\n"
+---
+const _: () = {
+    use diesel;
+    impl diesel::insertable::Insertable<users::table> for User
+    where
+        i32: diesel::expression::AsExpression<
+            <users::r#id as diesel::Expression>::SqlType,
+        >,
+        String: diesel::expression::AsExpression<
+            <users::r#name as diesel::Expression>::SqlType,
+        >,
+    {
+        type Values = <(
+            std::option::Option<diesel::dsl::Eq<users::r#id, i32>>,
+            std::option::Option<diesel::dsl::Eq<users::r#name, String>>,
+        ) as diesel::insertable::Insertable<users::table>>::Values;
+        fn values(
+            self,
+        ) -> <(
+            std::option::Option<diesel::dsl::Eq<users::r#id, i32>>,
+            std::option::Option<diesel::dsl::Eq<users::r#name, String>>,
+        ) as diesel::insertable::Insertable<users::table>>::Values {
+            diesel::insertable::Insertable::<
+                users::table,
+            >::values((
+                std::option::Option::Some(
+                    diesel::ExpressionMethods::eq(users::r#id, self.id),
+                ),
+                std::option::Option::Some(
+                    diesel::ExpressionMethods::eq(users::r#name, self.name),
+                ),
+            ))
+        }
+    }
+    impl<'insert> diesel::insertable::Insertable<users::table> for &'insert User
+    where
+        &'insert i32: diesel::expression::AsExpression<
+            <users::r#id as diesel::Expression>::SqlType,
+        >,
+        &'insert String: diesel::expression::AsExpression<
+            <users::r#name as diesel::Expression>::SqlType,
+        >,
+    {
+        type Values = <(
+            std::option::Option<diesel::dsl::Eq<users::r#id, &'insert i32>>,
+            std::option::Option<diesel::dsl::Eq<users::r#name, &'insert String>>,
+        ) as diesel::insertable::Insertable<users::table>>::Values;
+        fn values(
+            self,
+        ) -> <(
+            std::option::Option<diesel::dsl::Eq<users::r#id, &'insert i32>>,
+            std::option::Option<diesel::dsl::Eq<users::r#name, &'insert String>>,
+        ) as diesel::insertable::Insertable<users::table>>::Values {
+            diesel::insertable::Insertable::<
+                users::table,
+            >::values((
+                std::option::Option::Some(
+                    diesel::ExpressionMethods::eq(users::r#id, &self.id),
+                ),
+                std::option::Option::Some(
+                    diesel::ExpressionMethods::eq(users::r#name, &self.name),
+                ),
+            ))
+        }
+    }
+    impl diesel::internal::derives::insertable::UndecoratedInsertRecord<users::table>
+    for User {}
+};


### PR DESCRIPTION
Add an expanded-code example for `#[diesel(skip_insertion)]` so the Insertable docs cover that field attribute.

Refs #4840
