### PR TITLE
Fix queryid for several constructs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 * Potential stackoverflow on deeply nested JSONB values for the SQLite backend
 * `FromSql` impls for PostgreSQL arrays now use the element OID from the array header instead of the array type's own OID when decoding each element, matching the behavior of the record decoder.
 * Fixed undefined behavior in `SqliteConnection::serialize_database_to_buffer` when SQLite returns a null buffer for an empty deserialized database or an allocation failure. `SerializedDatabase::as_slice` is deprecated in favor of the new `SerializedDatabase::try_as_slice`, which reports the allocation failure as an error instead of panicking.
+* Fixed broken prepared statement caching for queries using positional ordering and window functions with frame offset clauses
 
 ### Changed
 

--- a/diesel/src/expression/functions/aggregate_expressions/frame_clause.rs
+++ b/diesel/src/expression/functions/aggregate_expressions/frame_clause.rs
@@ -190,7 +190,10 @@ pub struct OffsetPreceding<T = u64>(T);
 impl QueryId for OffsetPreceding {
     type QueryId = ();
 
-    const HAS_STATIC_QUERY_ID: bool = true;
+    // it's not safe to cache by type id
+    // as we inline a dynamic value (the offset) directly
+    // into the SQL
+    const HAS_STATIC_QUERY_ID: bool = false;
 }
 
 impl<DB> QueryFragment<DB> for OffsetPreceding
@@ -220,7 +223,10 @@ pub struct OffsetFollowing<I = u64>(I);
 impl QueryId for OffsetFollowing {
     type QueryId = ();
 
-    const HAS_STATIC_QUERY_ID: bool = true;
+    // it's not safe to cache by type id
+    // as we inline a dynamic value (the offset) directly
+    // into the SQL
+    const HAS_STATIC_QUERY_ID: bool = false;
 }
 
 impl<DB> QueryFragment<DB> for OffsetFollowing

--- a/diesel/src/query_dsl/positional_order_dsl.rs
+++ b/diesel/src/query_dsl/positional_order_dsl.rs
@@ -56,8 +56,17 @@ impl<T: PositionalOrderExpr> IntoPositionalOrderExpr for Desc<T> {
     }
 }
 
-#[derive(Debug, Clone, Copy, QueryId)]
+#[derive(Debug, Clone, Copy)]
 pub struct OrderColumn(pub u32);
+
+impl QueryId for OrderColumn {
+    type QueryId = ();
+
+    // it's not safe to cache by type id
+    // as we inline a dynamic value (the offset) directly
+    // into the SQL
+    const HAS_STATIC_QUERY_ID: bool = false;
+}
 
 impl Expression for OrderColumn {
     type SqlType = crate::sql_types::Integer;
@@ -68,6 +77,7 @@ where
     DB: Backend + DieselReserveSpecialization,
 {
     fn walk_ast<'b>(&'b self, mut pass: AstPass<'_, 'b, DB>) -> QueryResult<()> {
+        // unfortunally binds are not supported in this position
         pass.push_sql(&self.0.to_string());
         Ok(())
     }


### PR DESCRIPTION
It turns out that we incorrectly assumed that the queries containing any of the changed query nodes could be cached by type id. That's not true as the query content might change depending on a runtime value (the integer stored in these query nodes). Therefore we mark these query nodes as not having a static query id at all. This still allows prepared statement caching based on the SQL as key, which should be safe in these cases.

This was discoverd during a security scan from aisle. I do not consider that as a critical issue that need to be kept private

<!-- 
Please provide a short brief summary description of your change here. 
Also make sure that your code passes all tests and style checks. 
Checkout the `CONTRIBUTING.md` file in the root of the repository for running these checks locally.
It's also fine to use the CI setup for running these tests, but in this case please indicate that your PR 
is not ready for review yet by marking it as DRAFT until it is ready.

If you submit a notable change please ensure to include it into the CHANGELOG.md file in
the root of the repository.

Also make sure to follow the projects guide lines about the usage of LLM's and AI agents as outlined
in the CONTRIBUTING.md file in the root of the repository.
-->

- [x] I checked for similar changes and make sure to reference them
- [x] I included a changelog entry for relevant new features or changes
