### PR TITLE
Fix panic during interval deserialization in pg backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 * Potential stackoverflow on deeply nested JSONB values for the SQLite backend
 * `FromSql` impls for PostgreSQL arrays now use the element OID from the array header instead of the array type's own OID when decoding each element, matching the behavior of the record decoder.
 * Fixed undefined behavior in `SqliteConnection::serialize_database_to_buffer` when SQLite returns a null buffer for an empty deserialized database or an allocation failure. `SerializedDatabase::as_slice` is deprecated in favor of the new `SerializedDatabase::try_as_slice`, which reports the allocation failure as an error instead of panicking.
+* Fixed a potential panic while deserializing a `PgInterval` type from a too short buffer
 
 ### Changed
 

--- a/diesel/src/pg/types/date_and_time/mod.rs
+++ b/diesel/src/pg/types/date_and_time/mod.rs
@@ -174,9 +174,9 @@ impl ToSql<sql_types::Interval, Pg> for PgInterval {
 impl FromSql<sql_types::Interval, Pg> for PgInterval {
     fn from_sql(value: PgValue<'_>) -> deserialize::Result<Self> {
         Ok(PgInterval {
-            microseconds: FromSql::<sql_types::BigInt, Pg>::from_sql(value.subslice(0..8))?,
-            days: FromSql::<sql_types::Integer, Pg>::from_sql(value.subslice(8..12))?,
-            months: FromSql::<sql_types::Integer, Pg>::from_sql(value.subslice(12..16))?,
+            microseconds: FromSql::<sql_types::BigInt, Pg>::from_sql(value.subslice(0..8)?)?,
+            days: FromSql::<sql_types::Integer, Pg>::from_sql(value.subslice(8..12)?)?,
+            months: FromSql::<sql_types::Integer, Pg>::from_sql(value.subslice(12..16)?)?,
         })
     }
 }
@@ -190,5 +190,18 @@ impl Add<PgInterval> for PgInterval {
             days: self.days + other.days,
             months: self.months + other.months,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prevent_panic_on_too_short_buffer() {
+        let bytes: &[u8] = &[0u8; 4];
+        let v = PgValue::for_test(bytes);
+        let r = <PgInterval as FromSql<Interval, Pg>>::from_sql(v);
+        assert!(r.is_err());
     }
 }

--- a/diesel/src/pg/value.rs
+++ b/diesel/src/pg/value.rs
@@ -90,10 +90,19 @@ impl<'a> PgValue<'a> {
         self.type_oid_lookup.lookup()
     }
 
-    pub(crate) fn subslice(&self, range: Range<usize>) -> Self {
-        Self {
-            raw_value: &self.raw_value[range],
-            ..*self
+    pub(crate) fn subslice(&self, range: Range<usize>) -> crate::deserialize::Result<Self> {
+        if range.end <= self.raw_value.len() {
+            Ok(Self {
+                raw_value: &self.raw_value[range],
+                ..*self
+            })
+        } else {
+            Err(format!(
+                "Value buffer only contains {} bytes, but requested {} bytes",
+                self.raw_value.len(),
+                range.end
+            )
+            .into())
         }
     }
 }


### PR DESCRIPTION
The `FromSql` impl of `PgInterval` did not check the buffer size correctly before subslicing the buffer. This could lead to a panic for malformed database responses.

Given that we do not consider malformed database responses as security critical that's no critical issue, but a bug that should be fixed.

Reported by Aisle as part of their scan.

<!-- 
Please provide a short brief summary description of your change here. 
Also make sure that your code passes all tests and style checks. 
Checkout the `CONTRIBUTING.md` file in the root of the repository for running these checks locally.
It's also fine to use the CI setup for running these tests, but in this case please indicate that your PR 
is not ready for review yet by marking it as DRAFT until it is ready.

If you submit a notable change please ensure to include it into the CHANGELOG.md file in
the root of the repository.

Also make sure to follow the projects guide lines about the usage of LLM's and AI agents as outlined
in the CONTRIBUTING.md file in the root of the repository.
-->

- [x] I checked for similar changes and make sure to reference them
- [x] I included a changelog entry for relevant new features or changes
