### PR TITLE
Reject sqlite jsonb floats without a fraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 * Potential stackoverflow on deeply nested JSONB values for the SQLite backend
 * `FromSql` impls for PostgreSQL arrays now use the element OID from the array header instead of the array type's own OID when decoding each element, matching the behavior of the record decoder.
 * Fixed undefined behavior in `SqliteConnection::serialize_database_to_buffer` when SQLite returns a null buffer for an empty deserialized database or an allocation failure. `SerializedDatabase::as_slice` is deprecated in favor of the new `SerializedDatabase::try_as_slice`, which reports the allocation failure as an error instead of panicking.
+* Fixed encoding floating point values without a decimal part in a roundtrip safe way in SQLite's jsonb encoding
 
 ### Changed
 

--- a/diesel/src/sqlite/types/json.rs
+++ b/diesel/src/sqlite/types/json.rs
@@ -577,7 +577,7 @@ mod jsonb {
         buffer: &mut Vec<u8>,
     ) -> serialize::Result {
         let n = n.to_string();
-        let tpe = if n.contains('.') {
+        let tpe = if n.chars().any(|c| !c.is_ascii_digit()) {
             JSONB_FLOAT
         } else {
             JSONB_INT

--- a/diesel/src/sqlite/types/json.rs
+++ b/diesel/src/sqlite/types/json.rs
@@ -669,6 +669,27 @@ mod tests {
 
     #[diesel_test_helper::test]
     #[cfg(not(miri))] // ffi call
+    fn regression_float_without_a_fraction_is_written_invalid() {
+        let conn = &mut connection();
+        for value in [json!(3.0), json!(-0.0), json!(1.5e300)] {
+            let blob = diesel::select(sql::<sql_types::Binary>("").bind::<Jsonb, _>(value.clone()))
+                .get_result::<Vec<u8>>(conn)
+                .unwrap();
+            let valid = diesel::select(
+                sql::<sql_types::Integer>("json_valid(")
+                    .bind::<sql_types::Binary, _>(blob.clone())
+                    .sql(", 8)"),
+            )
+            .get_result::<i32>(conn)
+            .unwrap();
+            assert_eq!(
+                valid, 1,
+                "sqlite rejects the blob written for {value}: {blob:02X?}"
+            );
+        }
+    }
+    #[diesel_test_helper::test]
+    #[cfg(not(miri))] // ffi call
     fn json_to_sql() {
         let conn = &mut connection();
         let res = diesel::select(json!(true).into_sql::<Json>().eq(&sql("json('true')")))

--- a/diesel/src/sqlite/types/json.rs
+++ b/diesel/src/sqlite/types/json.rs
@@ -576,37 +576,16 @@ mod jsonb {
         n: &serde_json::Value,
         buffer: &mut Vec<u8>,
     ) -> serialize::Result {
-        if let Some(i) = n.as_i64() {
-            // Write an integer (INT type)
-            write_jsonb_int(i, buffer)
-        } else if let Some(f) = n.as_f64() {
-            // Write a float (FLOAT type)
-            write_jsonb_float(f, buffer)
+        let n = n.to_string();
+        let tpe = if n.contains('.') {
+            JSONB_FLOAT
         } else {
-            Err("Invalid JSONB number type".into())
-        }
-    }
+            JSONB_INT
+        };
+        write_jsonb_header(buffer, tpe, n.len())?;
 
-    // Write an integer in JSONB format
-    pub(super) fn write_jsonb_int(i: i64, buffer: &mut Vec<u8>) -> serialize::Result {
-        let int_str = i.to_string();
-
-        write_jsonb_header(buffer, JSONB_INT, int_str.len())?;
-
-        // Write the ASCII text representation of the integer as the payload
-        buffer.extend_from_slice(int_str.as_bytes());
-
-        Ok(IsNull::No)
-    }
-
-    // Write a floating-point number in JSONB format
-    pub(super) fn write_jsonb_float(f: f64, buffer: &mut Vec<u8>) -> serialize::Result {
-        let float_str = f.to_string();
-
-        write_jsonb_header(buffer, JSONB_FLOAT, float_str.len())?;
-
-        // Write the ASCII text representation of the float as the payload
-        buffer.extend_from_slice(float_str.as_bytes());
+        // Write the ASCII text representation of the integer/float as the payload
+        buffer.extend_from_slice(n.as_bytes());
 
         Ok(IsNull::No)
     }

--- a/diesel/src/sqlite/types/json.rs
+++ b/diesel/src/sqlite/types/json.rs
@@ -650,7 +650,14 @@ mod tests {
     #[cfg(not(miri))] // ffi call
     fn regression_float_without_a_fraction_is_written_invalid() {
         let conn = &mut connection();
-        for value in [json!(3.0), json!(-0.0), json!(1.5e300)] {
+        for value in [
+            json!(3.0),
+            json!(-0.0),
+            json!(1.5e300),
+            // an exponent and no fraction digit, so the text carries no `.`
+            json!(1e-7),
+            json!(1e300),
+        ] {
             let blob = diesel::select(sql::<sql_types::Binary>("").bind::<Jsonb, _>(value.clone()))
                 .get_result::<Vec<u8>>(conn)
                 .unwrap();
@@ -665,6 +672,10 @@ mod tests {
                 valid, 1,
                 "sqlite rejects the blob written for {value}: {blob:02X?}"
             );
+            let back = diesel::select(sql::<Jsonb>("").bind::<sql_types::Binary, _>(blob.clone()))
+                .get_result::<Value>(conn)
+                .unwrap_or_else(|error| panic!("{value} does not read back: {error}"));
+            assert_eq!(back, value, "{blob:02X?}");
         }
     }
     #[diesel_test_helper::test]


### PR DESCRIPTION
`write_jsonb_float` writes `f64::to_string()` as the `FLOAT` payload, and Rust's `Display` never uses exponent notation and drops a trailing `.0`. The payload becomes plain integer text, which is not a valid JSONB FLOAT: `json!(3.0)` is written as `15 33`, `json_valid(blob, 8)` is 0, and diesel cannot read the value back. `1.5e300` expands to 303 digits with the same outcome, so sqlite's own `json_extract` fails on a column diesel wrote.

A value diesel writes should be valid JSONB, readable both by sqlite's JSON functions and by diesel itself, which needs the payload to always carry a `.` or an exponent.

This came out of a fuzzer I am writing for diesel's deserialization code, and this PR only adds the red test for now.