### PR TITLE
Widen the postgres interval month arithmetic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 * Tighten requirements for `SqliteConnection::deserialize_readonly_database` to closely match the upstream requirements
 * `diesel print-schema` now generates `joinable!` and `allow_tables_to_appear_in_same_query!` for PostgreSQL foreign keys across multiple configured schemas
 * Fixed several Tests using schema modifications for `mysql` and `mariadb`
+* Fixed an overflow while converting a PostgreSQL `Interval` into a `chrono::Duration`, which panicked with debug assertions enabled and silently produced a wrong, sometimes negative, duration without them
 
 ### Changed
 

--- a/diesel/src/pg/types/date_and_time/chrono.rs
+++ b/diesel/src/pg/types/date_and_time/chrono.rs
@@ -167,7 +167,7 @@ impl Defaultable for NaiveDate {
     }
 }
 
-const DAYS_PER_MONTH: i32 = 30;
+const DAYS_PER_MONTH: i64 = 30;
 const SECONDS_PER_DAY: i64 = 60 * 60 * 24;
 const MICROSECONDS_PER_SECOND: i64 = 1_000_000;
 
@@ -204,8 +204,9 @@ impl FromSql<Interval, Pg> for Duration {
         // use those ratios as default when explicitly converted.
         // For reference, please read `justify_interval` from this page.
         // https://www.postgresql.org/docs/current/functions-datetime.html
-        let days = interval.months * DAYS_PER_MONTH + interval.days;
-        Ok(Duration::days(days as i64) + Duration::microseconds(interval.microseconds))
+        // widened, since any `i32` month and day pair fits `i64` days and chrono
+        let days = i64::from(interval.months) * DAYS_PER_MONTH + i64::from(interval.days);
+        Ok(Duration::days(days) + Duration::microseconds(interval.microseconds))
     }
 }
 
@@ -221,6 +222,98 @@ mod tests {
     use crate::select;
     use crate::sql_types::{Date, Interval, Time, Timestamp, Timestamptz};
     use crate::test_helpers::connection;
+
+    #[diesel_test_helper::test]
+    fn regression_interval_months_do_not_overflow() {
+        use crate::pg::value::PgValue;
+
+        let mut offenders = Vec::new();
+        // 71_582_788 months is where the product leaves `i32`
+        for months in [
+            0,
+            1,
+            -1,
+            71_582_787,
+            71_582_788,
+            71_582_789,
+            -71_582_789,
+            i32::MAX,
+            i32::MIN,
+        ] {
+            for days in [0, 1, -1, i32::MAX, i32::MIN] {
+                for microseconds in [0, 1, -1, i64::MAX, i64::MIN] {
+                    let mut buffer = Vec::new();
+                    buffer.extend_from_slice(&microseconds.to_be_bytes());
+                    buffer.extend_from_slice(&days.to_be_bytes());
+                    buffer.extend_from_slice(&months.to_be_bytes());
+
+                    let expected = Duration::days(i64::from(months) * 30 + i64::from(days))
+                        + Duration::microseconds(microseconds);
+                    let read = <Duration as crate::deserialize::FromSql<Interval, crate::pg::Pg>>::from_sql(
+                        PgValue::for_test(&buffer),
+                    );
+                    if read.as_ref().ok() != Some(&expected) {
+                        offenders.push(format!(
+                            "{months} months {days} days {microseconds} us read as {read:?}, not {expected:?}"
+                        ));
+                    }
+                }
+            }
+        }
+        // a deterministic xorshift over the whole three field space
+        let mut state: u64 = 0x2545F4914F6CDD1D;
+        let mut next = move || {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            state
+        };
+        for _ in 0..4096 {
+            let bytes = next().to_ne_bytes();
+            let months = i32::from_ne_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+            let days = i32::from_ne_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]);
+            let microseconds = i64::from_ne_bytes(next().to_ne_bytes());
+            let mut buffer = Vec::new();
+            buffer.extend_from_slice(&microseconds.to_be_bytes());
+            buffer.extend_from_slice(&days.to_be_bytes());
+            buffer.extend_from_slice(&months.to_be_bytes());
+
+            let expected = Duration::days(i64::from(months) * 30 + i64::from(days))
+                + Duration::microseconds(microseconds);
+            let read = <Duration as crate::deserialize::FromSql<Interval, crate::pg::Pg>>::from_sql(
+                PgValue::for_test(&buffer),
+            );
+            if read.as_ref().ok() != Some(&expected) {
+                offenders.push(format!(
+                    "{months} months {days} days {microseconds} us read as {read:?}, not {expected:?}"
+                ));
+            }
+        }
+
+        assert!(
+            offenders.is_empty(),
+            "{} intervals converted wrongly, first {:?}",
+            offenders.len(),
+            &offenders[..offenders.len().min(3)]
+        );
+    }
+
+    #[diesel_test_helper::test]
+    fn regression_interval_from_postgres_does_not_overflow() {
+        let connection = &mut connection();
+        // postgres stores each of these happily, so none is a synthetic blob
+        for (literal, months, days) in [
+            ("178956970 years 7 mons", i32::MAX, 0),
+            ("1 mon 2147483647 days", 1, i32::MAX),
+            ("-178956970 years -8 mons", i32::MIN, 0),
+        ] {
+            let read = select(sql::<Interval>(&format!("'{literal}'::interval")))
+                .get_result::<Duration>(connection)
+                .unwrap();
+            let expected = Duration::days(i64::from(months) * 30 + i64::from(days));
+            assert_eq!(read, expected, "{literal} read as {read:?}");
+        }
+    }
 
     #[diesel_test_helper::test]
     fn unix_epoch_encodes_correctly() {


### PR DESCRIPTION
`FromSql<Interval, Pg> for chrono::Duration` computes `interval.months * DAYS_PER_MONTH + interval.days` in `i32`, and all three fields arrive off the wire, so a well formed 16 byte interval is enough to overflow it. With debug assertions the conversion panics, and without them it wraps and the caller gets a plausible looking duration that is wrong, often with the opposite sign, where one month together with `i32::MAX` days reads as `-185542584681600` seconds where the true value is `185542589692800`.

It does not take an absurd month count either, one month is already enough once the day count is large. This is the arithmetic one line past the length check fixed in #5194, which does not touch it.

Counting the days in `i64` removes the overflow without narrowing what is accepted, as the widest interval is about 66678745079 days, while `chrono::Duration` reaches 106751991167.

This came out of a fuzzer I am writing for diesel's deserialization code.
