### PR TITLE
Root the paths that diesel's macros emit at `::diesel`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Increasing the minimal supported Rust version will always be coupled at least wi
 * `diesel print-schema` now generates `joinable!` and `allow_tables_to_appear_in_same_query!` for PostgreSQL foreign keys across multiple configured schemas
 * Fixed several Tests using schema modifications for `mysql` and `mariadb`
 * Fixed an overflow while converting a PostgreSQL `Interval` into a `chrono::Duration`, which panicked with debug assertions enabled and silently produced a wrong, sometimes negative, duration without them
+* Generated code now reaches diesel through `::diesel`, so the derive macros, `define_sql_function!`, `#[declare_sql_function]`, `#[auto_type]` and `#[derive(MultiConnection)]` all expand correctly in a module where the name `diesel` resolves to something else. `#[auto_type(dsl_path = ...)]` also keeps a leading `::` on the path it is given, which it previously discarded for method derived types.
 
 ### Changed
 

--- a/diesel_derives/src/lib.rs
+++ b/diesel_derives/src/lib.rs
@@ -2124,7 +2124,7 @@ fn auto_type_inner(
         attr,
         input,
         dsl_auto_type::DeriveSettings::builder()
-            .default_dsl_path(parse_quote!(diesel::dsl))
+            .default_dsl_path(parse_quote!(::diesel::dsl))
             .default_generate_type_alias(true)
             .default_method_type_case(AUTO_TYPE_DEFAULT_METHOD_TYPE_CASE)
             .default_function_type_case(AUTO_TYPE_DEFAULT_FUNCTION_TYPE_CASE)

--- a/diesel_derives/src/multiconnection.rs
+++ b/diesel_derives/src/multiconnection.rs
@@ -92,25 +92,25 @@ impl MultiHelper {
         let conn = if is_async {
             quote::quote! { diesel_async::AsyncConnection }
         } else {
-            quote::quote! { diesel::connection::Connection }
+            quote::quote! { ::diesel::connection::Connection }
         };
 
         let conn_backend = if is_async {
             quote::quote! { diesel_async::AsyncConnectionCore }
         } else {
-            quote::quote! { diesel::connection::Connection }
+            quote::quote! { ::diesel::connection::Connection }
         };
 
         let conn_load = if is_async {
             quote::quote! { diesel_async::AsyncConnectionCore }
         } else {
-            quote::quote! { diesel::connection::LoadConnection }
+            quote::quote! { ::diesel::connection::LoadConnection }
         };
 
         let multi_conn_helper = if is_async {
             quote::quote! { diesel_async::AsyncMultiConnectionHelper }
         } else {
-            quote::quote! { diesel::internal::derives::multiconnection::MultiConnectionHelper }
+            quote::quote! { ::diesel::internal::derives::multiconnection::MultiConnectionHelper }
         };
 
         let await_token = if is_async {
@@ -128,13 +128,13 @@ impl MultiHelper {
         let simple_connection = if is_async {
             quote::quote! { diesel_async::SimpleAsyncConnection }
         } else {
-            quote::quote! { diesel::connection::SimpleConnection }
+            quote::quote! { ::diesel::connection::SimpleConnection }
         };
 
         let transaction_manager = if is_async {
             quote::quote! { diesel_async::TransactionManager }
         } else {
-            quote::quote! { diesel::connection::TransactionManager }
+            quote::quote! { ::diesel::connection::TransactionManager }
         };
 
         Self {
@@ -215,7 +215,7 @@ fn generate_connection_impl(
                 source: T,
             ) -> Self::ExecuteFuture<'conn, 'query>
             where
-                T: diesel::query_builder::QueryFragment<Self::Backend> + diesel::query_builder::QueryId + 'query,
+                T: ::diesel::query_builder::QueryFragment<Self::Backend> + ::diesel::query_builder::QueryId + 'query,
             {
                 match self {
                     #(#execute_returning_count_var,)*
@@ -247,9 +247,9 @@ fn generate_connection_impl(
         None
     } else {
         Some(quote::quote! {
-            fn execute_returning_count<T>(&mut self, source: &T) -> diesel::result::QueryResult<usize>
+            fn execute_returning_count<T>(&mut self, source: &T) -> ::diesel::result::QueryResult<usize>
             where
-                T: diesel::query_builder::QueryFragment<Self::Backend> + diesel::query_builder::QueryId,
+                T: ::diesel::query_builder::QueryFragment<Self::Backend> + ::diesel::query_builder::QueryId,
             {
                 match self {
                     #(#execute_returning_count_var,)*
@@ -276,9 +276,9 @@ fn generate_connection_impl(
         });
         quote::quote! {
             impl #conn_load for MultiConnection {
-                type LoadFuture<'conn, 'query> = futures_util::future::BoxFuture<'conn, diesel::QueryResult<Self::Stream<'conn, 'query>>>;
-                type ExecuteFuture<'conn, 'query> = futures_util::future::BoxFuture<'conn, diesel::QueryResult<usize>>;
-                type Stream<'conn, 'query> = futures_util::stream::BoxStream<'conn, diesel::QueryResult<Self::Row<'conn, 'query>>>;
+                type LoadFuture<'conn, 'query> = futures_util::future::BoxFuture<'conn, ::diesel::QueryResult<Self::Stream<'conn, 'query>>>;
+                type ExecuteFuture<'conn, 'query> = futures_util::future::BoxFuture<'conn, ::diesel::QueryResult<usize>>;
+                type Stream<'conn, 'query> = futures_util::stream::BoxStream<'conn, ::diesel::QueryResult<Self::Row<'conn, 'query>>>;
                 type Row<'conn, 'query> = super::MultiRow<'conn, 'query>;
 
                 type Backend = super::MultiBackend;
@@ -288,8 +288,8 @@ fn generate_connection_impl(
                     source: T,
                 ) -> Self::LoadFuture<'conn, 'query>
                 where
-                    T: diesel::query_builder::AsQuery + 'query,
-                    T::Query: diesel::query_builder::QueryFragment<Self::Backend> + diesel::query_builder::QueryId + 'query,
+                    T: ::diesel::query_builder::AsQuery + 'query,
+                    T::Query: ::diesel::query_builder::QueryFragment<Self::Backend> + ::diesel::query_builder::QueryId + 'query,
                 {
                     match self {
                         #(#load_var_impl,)*
@@ -320,10 +320,10 @@ fn generate_connection_impl(
                 fn load<'conn, 'query, T>(
                     &'conn mut self,
                     source: T,
-                ) -> diesel::result::QueryResult<Self::Cursor<'conn, 'query>>
+                ) -> ::diesel::result::QueryResult<Self::Cursor<'conn, 'query>>
                 where
-                    T: diesel::query_builder::Query + diesel::query_builder::QueryFragment<Self::Backend> + diesel::query_builder::QueryId + 'query,
-                    Self::Backend: diesel::expression::QueryMetadata<T::SqlType>,
+                    T: ::diesel::query_builder::Query + ::diesel::query_builder::QueryFragment<Self::Backend> + ::diesel::query_builder::QueryId + 'query,
+                    Self::Backend: ::diesel::expression::QueryMetadata<T::SqlType>,
                 {
                     match self {
                         #(#load_var_impl,)*
@@ -416,11 +416,11 @@ fn generate_connection_impl(
         quote::quote! {
             impl BindParamHelper for #ty {
                 fn handle_inner_pass<'a, 'b: 'a>(
-                    outer_collector: &mut <Self::Backend as diesel::backend::Backend>::BindCollector<'a>,
-                    lookup: &mut <Self::Backend as diesel::sql_types::TypeMetadata>::MetadataLookup,
+                    outer_collector: &mut <Self::Backend as ::diesel::backend::Backend>::BindCollector<'a>,
+                    lookup: &mut <Self::Backend as ::diesel::sql_types::TypeMetadata>::MetadataLookup,
                     backend: &'b MultiBackend,
-                    q: &'b impl diesel::query_builder::QueryFragment<MultiBackend>,
-                ) -> diesel::QueryResult<()> {
+                    q: &'b impl ::diesel::query_builder::QueryFragment<MultiBackend>,
+                ) -> ::diesel::QueryResult<()> {
                     use #multi_conn_helper;
 
                     let mut collector = super::bind_collector::MultiBindCollector::#ident(Default::default());
@@ -442,7 +442,7 @@ fn generate_connection_impl(
             let ident = c.name;
             quote::quote! {
                 Self::#ident(conn) => {
-                    use diesel::migration::MigrationConnection;
+                    use ::diesel::migration::MigrationConnection;
                     conn.setup()
                 }
             }
@@ -451,7 +451,7 @@ fn generate_connection_impl(
             let ident = c.name;
             quote::quote! {
                 Self::#ident(conn) => {
-                    use diesel::migration::MigrationConnection;
+                    use ::diesel::migration::MigrationConnection;
                     conn.read_search_path()
                 }
             }
@@ -461,25 +461,25 @@ fn generate_connection_impl(
             let ident = c.name;
             quote::quote! {
                 Self::#ident(conn) => {
-                    use diesel::migration::MigrationConnection;
+                    use ::diesel::migration::MigrationConnection;
                     conn.set_search_path(search_path)
                 }
             }
         });
         Some(quote::quote! {
-            impl diesel::migration::MigrationConnection for MultiConnection {
-                fn setup(&mut self) -> diesel::QueryResult<usize> {
+            impl ::diesel::migration::MigrationConnection for MultiConnection {
+                fn setup(&mut self) -> ::diesel::QueryResult<usize> {
                     match self {
                         #(#impl_migration_connection_setup,)*
                     }
                 }
-                fn read_search_path(&mut self) -> diesel::QueryResult<Option<String>> {
+                fn read_search_path(&mut self) -> ::diesel::QueryResult<Option<String>> {
                     match self {
                         #(#impl_migration_connection_read,)*
                     }
                 }
 
-                fn set_search_path(&mut self, search_path: &str) -> diesel::QueryResult<()> {
+                fn set_search_path(&mut self, search_path: &str) -> ::diesel::QueryResult<()> {
                     match self {
                         #(#impl_migration_connection_set,)*
                     }
@@ -512,17 +512,17 @@ fn generate_connection_impl(
             }
         });
         Some(quote::quote! {
-            diesel::internal::derives::multiconnection::expand_r2d2! {
-                impl diesel::r2d2::R2D2Connection for MultiConnection {
-                    fn ping(&mut self) -> diesel::QueryResult<()> {
-                        use diesel::r2d2::R2D2Connection;
+            ::diesel::internal::derives::multiconnection::expand_r2d2! {
+                impl ::diesel::r2d2::R2D2Connection for MultiConnection {
+                    fn ping(&mut self) -> ::diesel::QueryResult<()> {
+                        use ::diesel::r2d2::R2D2Connection;
                         match self {
                             #(#impl_ping_r2d2,)*
                         }
                     }
 
                     fn is_broken(&mut self) -> bool {
-                        use diesel::r2d2::R2D2Connection;
+                        use ::diesel::r2d2::R2D2Connection;
                         match self {
                             #(#impl_is_broken_r2d2,)*
                         }
@@ -535,14 +535,14 @@ fn generate_connection_impl(
     let simple_impls = if is_async {
         quote::quote! { diesel_async::expand_pool! { impl diesel_async::pooled_connection::PoolableConnection for MultiConnection {} } }
     } else {
-        quote::quote! { impl diesel::internal::derives::multiconnection::ConnectionSealed for MultiConnection {} }
+        quote::quote! { impl ::diesel::internal::derives::multiconnection::ConnectionSealed for MultiConnection {} }
     };
 
     quote::quote! {
         pub(super) use super::#ident as MultiConnection;
 
         impl #simple_connection for MultiConnection {
-            #async_token fn batch_execute(&mut self, query: &str) -> diesel::result::QueryResult<()> {
+            #async_token fn batch_execute(&mut self, query: &str) -> ::diesel::result::QueryResult<()> {
                 match self {
                     #(#batch_execute_impl,)*
                 }
@@ -560,27 +560,27 @@ fn generate_connection_impl(
 
         trait BindParamHelper: #conn {
             fn handle_inner_pass<'a, 'b: 'a>(
-                collector: &mut <Self::Backend as diesel::backend::Backend>::BindCollector<'a>,
-                lookup: &mut <Self::Backend as diesel::sql_types::TypeMetadata>::MetadataLookup,
+                collector: &mut <Self::Backend as ::diesel::backend::Backend>::BindCollector<'a>,
+                lookup: &mut <Self::Backend as ::diesel::sql_types::TypeMetadata>::MetadataLookup,
                 backend: &'b MultiBackend,
-                q: &'b impl diesel::query_builder::QueryFragment<MultiBackend>,
-            ) -> diesel::QueryResult<()>;
+                q: &'b impl ::diesel::query_builder::QueryFragment<MultiBackend>,
+            ) -> ::diesel::QueryResult<()>;
         }
 
         #(#bind_param_helper_impl)*
 
-        impl<T, DB, C> diesel::query_builder::QueryFragment<DB> for SerializedQuery<T, C>
+        impl<T, DB, C> ::diesel::query_builder::QueryFragment<DB> for SerializedQuery<T, C>
         where
-            DB: diesel::backend::Backend + 'static,
-            T: diesel::query_builder::QueryFragment<MultiBackend>,
+            DB: ::diesel::backend::Backend + 'static,
+            T: ::diesel::query_builder::QueryFragment<MultiBackend>,
             C: #conn_backend<Backend = DB> + BindParamHelper + #multi_conn_helper,
         {
             fn walk_ast<'b>(
                 &'b self,
-                mut pass: diesel::query_builder::AstPass<'_, 'b, DB>,
-            ) -> diesel::QueryResult<()> {
-                use diesel::query_builder::QueryBuilder;
-                use diesel::internal::derives::multiconnection::AstPassHelper;
+                mut pass: ::diesel::query_builder::AstPass<'_, 'b, DB>,
+            ) -> ::diesel::QueryResult<()> {
+                use ::diesel::query_builder::QueryBuilder;
+                use ::diesel::internal::derives::multiconnection::AstPassHelper;
 
                 let mut query_builder = self.query_builder.duplicate();
                 self.inner.to_sql(&mut query_builder, &self.backend)?;
@@ -592,29 +592,29 @@ fn generate_connection_impl(
                     C::handle_inner_pass(outer_collector, lookup, &self.backend, &self.inner)?;
                 }
                 if let Some((formatter, _backend)) = pass.debug_binds() {
-                    let pass = diesel::query_builder::AstPass::<MultiBackend>::collect_debug_binds_pass(formatter, &self.backend);
+                    let pass = ::diesel::query_builder::AstPass::<MultiBackend>::collect_debug_binds_pass(formatter, &self.backend);
                     self.inner.walk_ast(pass)?;
                 }
                 Ok(())
             }
         }
 
-        impl<T, C> diesel::query_builder::QueryId for SerializedQuery<T, C>
+        impl<T, C> ::diesel::query_builder::QueryId for SerializedQuery<T, C>
         where
-            T: diesel::query_builder::QueryId,
+            T: ::diesel::query_builder::QueryId,
         {
-            type QueryId = <T as diesel::query_builder::QueryId>::QueryId;
+            type QueryId = <T as ::diesel::query_builder::QueryId>::QueryId;
 
-            const HAS_STATIC_QUERY_ID: bool = <T as diesel::query_builder::QueryId>::HAS_STATIC_QUERY_ID;
+            const HAS_STATIC_QUERY_ID: bool = <T as ::diesel::query_builder::QueryId>::HAS_STATIC_QUERY_ID;
         }
 
-        impl<T, C> diesel::query_builder::Query for SerializedQuery<T, C>
+        impl<T, C> ::diesel::query_builder::Query for SerializedQuery<T, C>
         where
-            T: diesel::query_builder::Query
+            T: ::diesel::query_builder::Query
         {
             // we use untyped here as this does not really matter
             // + that type is supported for all backends
-            type SqlType = diesel::sql_types::Untyped;
+            type SqlType = ::diesel::sql_types::Untyped;
         }
 
         impl #conn for MultiConnection {
@@ -622,9 +622,9 @@ fn generate_connection_impl(
 
             type TransactionManager = Self;
 
-            #async_token fn establish(database_url: &str) -> diesel::ConnectionResult<Self> {
+            #async_token fn establish(database_url: &str) -> ::diesel::ConnectionResult<Self> {
                 #(#establish_impls)*
-                Err(diesel::ConnectionError::BadConnection("Invalid connection url for multiconnection".into()))
+                Err(::diesel::ConnectionError::BadConnection("Invalid connection url for multiconnection".into()))
             }
             #impl_execute_returning_count
 
@@ -634,25 +634,25 @@ fn generate_connection_impl(
                 self
             }
 
-            fn instrumentation(&mut self) -> &mut dyn diesel::connection::Instrumentation {
+            fn instrumentation(&mut self) -> &mut dyn ::diesel::connection::Instrumentation {
                 match self {
                     #(#get_instrumentation_impl,)*
                 }
             }
 
-            fn set_instrumentation(&mut self, instrumentation: impl diesel::connection::Instrumentation) {
+            fn set_instrumentation(&mut self, instrumentation: impl ::diesel::connection::Instrumentation) {
                 match self {
                     #(#instrumentation_impl,)*
                 }
             }
 
-            fn set_prepared_statement_cache_size(&mut self, size: diesel::connection::CacheSize) {
+            fn set_prepared_statement_cache_size(&mut self, size: ::diesel::connection::CacheSize) {
                 match self {
                     #(#set_cache_impl,)*
                 }
             }
 
-            #async_token fn begin_test_transaction(&mut self) -> diesel::QueryResult<()> {
+            #async_token fn begin_test_transaction(&mut self) -> ::diesel::QueryResult<()> {
                 match self {
                     #(#impl_begin_test_transaction,)*
                 }
@@ -664,25 +664,25 @@ fn generate_connection_impl(
         impl #transaction_manager<MultiConnection> for MultiConnection {
             type TransactionStateData = Self;
 
-            #async_token fn begin_transaction(conn: &mut MultiConnection) -> diesel::QueryResult<()> {
+            #async_token fn begin_transaction(conn: &mut MultiConnection) -> ::diesel::QueryResult<()> {
                 match conn {
                     #(#begin_transaction_impl,)*
                 }
             }
 
-            #async_token fn rollback_transaction(conn: &mut MultiConnection) -> diesel::QueryResult<()> {
+            #async_token fn rollback_transaction(conn: &mut MultiConnection) -> ::diesel::QueryResult<()> {
                 match conn {
                     #(#rollback_transaction_impl,)*
                 }
             }
 
-            #async_token fn commit_transaction(conn: &mut MultiConnection) -> diesel::QueryResult<()> {
+            #async_token fn commit_transaction(conn: &mut MultiConnection) -> ::diesel::QueryResult<()> {
                 match conn {
                     #(#commit_transaction_impl,)*
                 }
             }
 
-            fn transaction_manager_status_mut(conn: &mut MultiConnection) -> &mut diesel::connection::TransactionManagerStatus {
+            fn transaction_manager_status_mut(conn: &mut MultiConnection) -> &mut ::diesel::connection::TransactionManagerStatus {
                 match conn {
                     #(#transaction_manager_status_mut_impl,)*
                 }
@@ -721,7 +721,7 @@ fn generate_row(connection_types: &[ConnectionVariant], helper: &MultiHelper) ->
         let ident = c.name;
         let ty = c.ty;
         quote::quote! {
-            #ident(<<#ty as #conn_load>::Row<'conn, 'query> as diesel::row::Row<'conn, <#ty as #conn_backend>::Backend>>::Field<'query>)
+            #ident(<<#ty as #conn_load>::Row<'conn, 'query> as ::diesel::row::Row<'conn, <#ty as #conn_backend>::Backend>>::Field<'query>)
         }
     });
 
@@ -773,7 +773,7 @@ fn generate_row(connection_types: &[ConnectionVariant], helper: &MultiHelper) ->
             }
 
             impl<'conn, 'query> Iterator for MultiCursor<'conn, 'query> {
-                type Item = diesel::QueryResult<MultiRow<'conn, 'query>>;
+                type Item = ::diesel::QueryResult<MultiRow<'conn, 'query>>;
 
                 fn next(&mut self) -> Option<Self::Item> {
                     match self {
@@ -805,23 +805,23 @@ fn generate_row(connection_types: &[ConnectionVariant], helper: &MultiHelper) ->
 
         }
 
-        impl<'conn, 'query> diesel::internal::derives::multiconnection::RowSealed for MultiRow<'conn, 'query> {}
+        impl<'conn, 'query> ::diesel::internal::derives::multiconnection::RowSealed for MultiRow<'conn, 'query> {}
 
         pub enum MultiField<'conn: 'query, 'query> {
             #(#field_variants,)*
         }
 
-        impl<'conn, 'query> diesel::row::Field<'conn, super::MultiBackend> for MultiField<'conn, 'query> {
+        impl<'conn, 'query> ::diesel::row::Field<'conn, super::MultiBackend> for MultiField<'conn, 'query> {
             fn field_name(&self) -> Option<&str> {
-                use diesel::row::Field;
+                use ::diesel::row::Field;
 
                 match self {
                     #(#field_name_impl,)*
                 }
             }
 
-            fn value(&self) -> Option<<super::MultiBackend as diesel::backend::Backend>::RawValue<'_>> {
-                use diesel::row::Field;
+            fn value(&self) -> Option<<super::MultiBackend as ::diesel::backend::Backend>::RawValue<'_>> {
+                use ::diesel::row::Field;
 
                 match self {
                     #(#field_value_impl,)*
@@ -829,9 +829,9 @@ fn generate_row(connection_types: &[ConnectionVariant], helper: &MultiHelper) ->
             }
         }
 
-        impl<'conn, 'query, 'c> diesel::row::RowIndex<&'c str> for MultiRow<'conn, 'query> {
+        impl<'conn, 'query, 'c> ::diesel::row::RowIndex<&'c str> for MultiRow<'conn, 'query> {
             fn idx(&self, idx: &'c str) -> Option<usize> {
-                use diesel::row::RowIndex;
+                use ::diesel::row::RowIndex;
 
                 match self {
                     #(#row_index_impl,)*
@@ -839,9 +839,9 @@ fn generate_row(connection_types: &[ConnectionVariant], helper: &MultiHelper) ->
             }
         }
 
-        impl<'conn, 'query> diesel::row::RowIndex<usize> for MultiRow<'conn, 'query> {
+        impl<'conn, 'query> ::diesel::row::RowIndex<usize> for MultiRow<'conn, 'query> {
             fn idx(&self, idx: usize) -> Option<usize> {
-                use diesel::row::RowIndex;
+                use ::diesel::row::RowIndex;
 
                 match self {
                     #(#row_index_impl,)*
@@ -849,12 +849,12 @@ fn generate_row(connection_types: &[ConnectionVariant], helper: &MultiHelper) ->
             }
         }
 
-        impl<'conn, 'query> diesel::row::Row<'conn, super::MultiBackend> for MultiRow<'conn, 'query> {
+        impl<'conn, 'query> ::diesel::row::Row<'conn, super::MultiBackend> for MultiRow<'conn, 'query> {
             type Field<'a> = MultiField<'a, 'a> where 'conn: 'a, Self: 'a;
             type InnerPartialRow = Self;
 
             fn field_count(&self) -> usize {
-                use diesel::row::Row;
+                use ::diesel::row::Row;
                 match self {
                     #(#field_count_impl,)*
                 }
@@ -863,9 +863,9 @@ fn generate_row(connection_types: &[ConnectionVariant], helper: &MultiHelper) ->
             fn get<'b, I>(&'b self, idx: I) -> Option<Self::Field<'b>>
             where
                 'conn: 'b,
-                Self: diesel::row::RowIndex<I>,
+                Self: ::diesel::row::RowIndex<I>,
             {
-                use diesel::row::{RowIndex, Row};
+                use ::diesel::row::{RowIndex, Row};
                 let idx = self.idx(idx)?;
 
                 match self {
@@ -876,8 +876,8 @@ fn generate_row(connection_types: &[ConnectionVariant], helper: &MultiHelper) ->
             fn partial_row(
                 &self,
                 range: std::ops::Range<usize>,
-            ) -> diesel::internal::derives::multiconnection::PartialRow<'_, Self::InnerPartialRow> {
-                diesel::internal::derives::multiconnection::PartialRow::new(self, range)
+            ) -> ::diesel::internal::derives::multiconnection::PartialRow<'_, Self::InnerPartialRow> {
+                ::diesel::internal::derives::multiconnection::PartialRow::new(self, range)
             }
         }
         #cursor_impl
@@ -897,151 +897,175 @@ fn generate_bind_collector(
 
     let mut to_sql_impls = [
         (
-            quote::quote!(diesel::sql_types::SmallInt),
+            quote::quote!(::diesel::sql_types::SmallInt),
             quote::quote!(i16),
         ),
         (
-            quote::quote!(diesel::sql_types::Integer),
+            quote::quote!(::diesel::sql_types::Integer),
             quote::quote!(i32),
         ),
-        (quote::quote!(diesel::sql_types::BigInt), quote::quote!(i64)),
-        (quote::quote!(diesel::sql_types::Double), quote::quote!(f64)),
-        (quote::quote!(diesel::sql_types::Float), quote::quote!(f32)),
-        (quote::quote!(diesel::sql_types::Text), quote::quote!(str)),
         (
-            quote::quote!(diesel::sql_types::Binary),
+            quote::quote!(::diesel::sql_types::BigInt),
+            quote::quote!(i64),
+        ),
+        (
+            quote::quote!(::diesel::sql_types::Double),
+            quote::quote!(f64),
+        ),
+        (
+            quote::quote!(::diesel::sql_types::Float),
+            quote::quote!(f32),
+        ),
+        (quote::quote!(::diesel::sql_types::Text), quote::quote!(str)),
+        (
+            quote::quote!(::diesel::sql_types::Binary),
             quote::quote!([u8]),
         ),
-        (quote::quote!(diesel::sql_types::Bool), quote::quote!(bool)),
+        (
+            quote::quote!(::diesel::sql_types::Bool),
+            quote::quote!(bool),
+        ),
     ]
     .into_iter()
     .map(|t| generate_to_sql_impls(t, connection_types))
     .collect::<Vec<_>>();
     let numeric_impl = generate_to_sql_impls(
         (
-            quote::quote!(diesel::sql_types::Numeric),
-            quote::quote!(diesel::internal::derives::multiconnection::bigdecimal::BigDecimal),
+            quote::quote!(::diesel::sql_types::Numeric),
+            quote::quote!(::diesel::internal::derives::multiconnection::bigdecimal::BigDecimal),
         ),
         connection_types,
     );
     to_sql_impls.push(quote::quote! {
-        diesel::internal::derives::multiconnection::expand_numeric! {#numeric_impl}
+        ::diesel::internal::derives::multiconnection::expand_numeric! {#numeric_impl}
     });
     let chrono_impls = [
         (
-            quote::quote!(diesel::sql_types::Timestamp),
-            quote::quote!(diesel::internal::derives::multiconnection::chrono::NaiveDateTime),
+            quote::quote!(::diesel::sql_types::Timestamp),
+            quote::quote!(::diesel::internal::derives::multiconnection::chrono::NaiveDateTime),
         ),
         (
-            quote::quote!(diesel::sql_types::Date),
-            quote::quote!(diesel::internal::derives::multiconnection::chrono::NaiveDate),
+            quote::quote!(::diesel::sql_types::Date),
+            quote::quote!(::diesel::internal::derives::multiconnection::chrono::NaiveDate),
         ),
         (
-            quote::quote!(diesel::sql_types::Time),
-            quote::quote!(diesel::internal::derives::multiconnection::chrono::NaiveTime),
+            quote::quote!(::diesel::sql_types::Time),
+            quote::quote!(::diesel::internal::derives::multiconnection::chrono::NaiveTime),
         ),
     ]
     .into_iter()
     .map(|t| generate_to_sql_impls(t, connection_types))
     .map(|p| {
         quote::quote! {
-            diesel::internal::derives::multiconnection::expand_chrono! {#p}
+            ::diesel::internal::derives::multiconnection::expand_chrono! {#p}
         }
     });
     to_sql_impls.extend(chrono_impls);
 
     let time_impls = [
         (
-            quote::quote!(diesel::sql_types::Timestamp),
-            quote::quote!(diesel::internal::derives::multiconnection::time::PrimitiveDateTime),
+            quote::quote!(::diesel::sql_types::Timestamp),
+            quote::quote!(::diesel::internal::derives::multiconnection::time::PrimitiveDateTime),
         ),
         (
-            quote::quote!(diesel::sql_types::Time),
-            quote::quote!(diesel::internal::derives::multiconnection::time::Time),
+            quote::quote!(::diesel::sql_types::Time),
+            quote::quote!(::diesel::internal::derives::multiconnection::time::Time),
         ),
         (
-            quote::quote!(diesel::sql_types::Date),
-            quote::quote!(diesel::internal::derives::multiconnection::time::Date),
+            quote::quote!(::diesel::sql_types::Date),
+            quote::quote!(::diesel::internal::derives::multiconnection::time::Date),
         ),
     ]
     .into_iter()
     .map(|t| generate_to_sql_impls(t, connection_types))
-    .map(|p| quote::quote! {diesel::internal::derives::multiconnection::expand_time!{#p}});
+    .map(|p| quote::quote! {::diesel::internal::derives::multiconnection::expand_time!{#p}});
     to_sql_impls.extend(time_impls);
 
     let mut from_sql_impls = [
         (
-            quote::quote!(diesel::sql_types::SmallInt),
+            quote::quote!(::diesel::sql_types::SmallInt),
             quote::quote!(i16),
         ),
         (
-            quote::quote!(diesel::sql_types::Integer),
+            quote::quote!(::diesel::sql_types::Integer),
             quote::quote!(i32),
         ),
-        (quote::quote!(diesel::sql_types::BigInt), quote::quote!(i64)),
-        (quote::quote!(diesel::sql_types::Double), quote::quote!(f64)),
-        (quote::quote!(diesel::sql_types::Float), quote::quote!(f32)),
         (
-            quote::quote!(diesel::sql_types::Text),
+            quote::quote!(::diesel::sql_types::BigInt),
+            quote::quote!(i64),
+        ),
+        (
+            quote::quote!(::diesel::sql_types::Double),
+            quote::quote!(f64),
+        ),
+        (
+            quote::quote!(::diesel::sql_types::Float),
+            quote::quote!(f32),
+        ),
+        (
+            quote::quote!(::diesel::sql_types::Text),
             quote::quote!(String),
         ),
         (
-            quote::quote!(diesel::sql_types::Binary),
+            quote::quote!(::diesel::sql_types::Binary),
             quote::quote!(Vec<u8>),
         ),
-        (quote::quote!(diesel::sql_types::Bool), quote::quote!(bool)),
+        (
+            quote::quote!(::diesel::sql_types::Bool),
+            quote::quote!(bool),
+        ),
     ]
     .into_iter()
     .map(generate_from_sql_impls)
     .collect::<Vec<_>>();
     let numeric_impl = generate_from_sql_impls((
-        quote::quote!(diesel::sql_types::Numeric),
-        quote::quote!(diesel::internal::derives::multiconnection::bigdecimal::BigDecimal),
+        quote::quote!(::diesel::sql_types::Numeric),
+        quote::quote!(::diesel::internal::derives::multiconnection::bigdecimal::BigDecimal),
     ));
     from_sql_impls.push(quote::quote! {
-        diesel::internal::derives::multiconnection::expand_numeric! {#numeric_impl}
+        ::diesel::internal::derives::multiconnection::expand_numeric! {#numeric_impl}
     });
     let chrono_impls = [
         (
-            quote::quote!(diesel::sql_types::Timestamp),
-            quote::quote!(diesel::internal::derives::multiconnection::chrono::NaiveDateTime),
+            quote::quote!(::diesel::sql_types::Timestamp),
+            quote::quote!(::diesel::internal::derives::multiconnection::chrono::NaiveDateTime),
         ),
         (
-            quote::quote!(diesel::sql_types::Date),
-            quote::quote!(diesel::internal::derives::multiconnection::chrono::NaiveDate),
+            quote::quote!(::diesel::sql_types::Date),
+            quote::quote!(::diesel::internal::derives::multiconnection::chrono::NaiveDate),
         ),
         (
-            quote::quote!(diesel::sql_types::Time),
-            quote::quote!(diesel::internal::derives::multiconnection::chrono::NaiveTime),
+            quote::quote!(::diesel::sql_types::Time),
+            quote::quote!(::diesel::internal::derives::multiconnection::chrono::NaiveTime),
         ),
     ]
     .into_iter()
     .map(generate_from_sql_impls)
     .map(|p| {
         quote::quote! {
-        diesel::internal::derives::multiconnection::expand_chrono!{#p}}
+        ::diesel::internal::derives::multiconnection::expand_chrono!{#p}}
     });
     from_sql_impls.extend(chrono_impls);
 
     let time_impls = [
         (
-            quote::quote!(diesel::sql_types::Timestamp),
-            quote::quote!(diesel::internal::derives::multiconnection::time::PrimitiveDateTime),
+            quote::quote!(::diesel::sql_types::Timestamp),
+            quote::quote!(::diesel::internal::derives::multiconnection::time::PrimitiveDateTime),
         ),
         (
-            quote::quote!(diesel::sql_types::Time),
-            quote::quote!(diesel::internal::derives::multiconnection::time::Time),
+            quote::quote!(::diesel::sql_types::Time),
+            quote::quote!(::diesel::internal::derives::multiconnection::time::Time),
         ),
         (
-            quote::quote!(diesel::sql_types::Date),
-            quote::quote!(diesel::internal::derives::multiconnection::time::Date),
+            quote::quote!(::diesel::sql_types::Date),
+            quote::quote!(::diesel::internal::derives::multiconnection::time::Date),
         ),
     ]
     .into_iter()
     .map(generate_from_sql_impls)
     .map(|p| {
         quote::quote! {
-            diesel::internal::derives::multiconnection::expand_time!{ #p }
+            ::diesel::internal::derives::multiconnection::expand_time!{ #p }
         }
     });
     from_sql_impls.extend(time_impls);
@@ -1049,14 +1073,14 @@ fn generate_bind_collector(
     let into_bind_value_bounds = connection_types.iter().map(|c| {
         let ty = c.ty;
         quote::quote! {
-            diesel::serialize::ToSql<ST, <#ty as #conn_backend>::Backend>
+            ::diesel::serialize::ToSql<ST, <#ty as #conn_backend>::Backend>
         }
     });
 
     let has_sql_type_bounds = connection_types.iter().map(|c| {
         let ty = c.ty;
         quote::quote! {
-            <#ty as #conn_backend>::Backend: diesel::sql_types::HasSqlType<ST>
+            <#ty as #conn_backend>::Backend: ::diesel::sql_types::HasSqlType<ST>
         }
     });
 
@@ -1064,7 +1088,7 @@ fn generate_bind_collector(
         let ident = c.name;
         let ty = c.ty;
         quote::quote! {
-            #ident(<<#ty as #conn_backend>::Backend as diesel::backend::Backend>::BindCollector<'a>)
+            #ident(<<#ty as #conn_backend>::Backend as ::diesel::backend::Backend>::BindCollector<'a>)
         }
     });
 
@@ -1075,7 +1099,7 @@ fn generate_bind_collector(
         quote::quote! {
             pub(super) fn #lower_ident(
                 &mut self,
-            ) -> &mut <<#ty as #conn_backend>::Backend as diesel::backend::Backend>::BindCollector<'a> {
+            ) -> &mut <<#ty as #conn_backend>::Backend as ::diesel::backend::Backend>::BindCollector<'a> {
                 match self {
                     Self::#ident(bc) => bc,
                     _ => unreachable!(),
@@ -1136,13 +1160,13 @@ fn generate_bind_collector(
             #(#multi_bind_collector_accessor)*
         }
 
-        trait PushBoundValueToCollectorDB<DB: diesel::backend::Backend> {
+        trait PushBoundValueToCollectorDB<DB: ::diesel::backend::Backend> {
             fn push_bound_value<'a: 'b, 'b>(
                 &self,
                 v: InnerBindValueKind<'a>,
-                collector: &mut <DB as diesel::backend::Backend>::BindCollector<'b>,
-                lookup: &mut <DB as diesel::sql_types::TypeMetadata>::MetadataLookup,
-            ) -> diesel::result::QueryResult<()>;
+                collector: &mut <DB as ::diesel::backend::Backend>::BindCollector<'b>,
+                lookup: &mut <DB as ::diesel::sql_types::TypeMetadata>::MetadataLookup,
+            ) -> ::diesel::result::QueryResult<()>;
         }
 
         struct PushBoundValueToCollectorImpl<ST, T: ?Sized> {
@@ -1153,64 +1177,64 @@ fn generate_bind_collector(
         // we need separate impls for `Sized` and `str`/`[u8]` here as
         // we cannot use `Any::downcast_ref` otherwise (which implies `Sized`)
         impl<ST, T, DB> PushBoundValueToCollectorDB<DB> for PushBoundValueToCollectorImpl<ST, T>
-        where DB: diesel::backend::Backend
-                  + diesel::sql_types::HasSqlType<ST>,
-              T: diesel::serialize::ToSql<ST, DB> + 'static,
-              Option<T>: diesel::serialize::ToSql<diesel::sql_types::Nullable<ST>, DB> + 'static,
-              ST: diesel::sql_types::SqlType,
+        where DB: ::diesel::backend::Backend
+                  + ::diesel::sql_types::HasSqlType<ST>,
+              T: ::diesel::serialize::ToSql<ST, DB> + 'static,
+              Option<T>: ::diesel::serialize::ToSql<::diesel::sql_types::Nullable<ST>, DB> + 'static,
+              ST: ::diesel::sql_types::SqlType,
         {
             fn push_bound_value<'a: 'b, 'b>(
                 &self,
                 v: InnerBindValueKind<'a>,
-                collector: &mut <DB as diesel::backend::Backend>::BindCollector<'b>,
-                lookup: &mut <DB as diesel::sql_types::TypeMetadata>::MetadataLookup,
-            ) -> diesel::result::QueryResult<()> {
-                use diesel::query_builder::BindCollector;
+                collector: &mut <DB as ::diesel::backend::Backend>::BindCollector<'b>,
+                lookup: &mut <DB as ::diesel::sql_types::TypeMetadata>::MetadataLookup,
+            ) -> ::diesel::result::QueryResult<()> {
+                use ::diesel::query_builder::BindCollector;
                 match v {
                     InnerBindValueKind::Sized(v) => {
                         let v = v.downcast_ref::<T>().expect("We know the type statically here");
                         collector.push_bound_value::<ST, T>(v, lookup)
                     }
                     InnerBindValueKind::Null => {
-                        collector.push_bound_value::<diesel::sql_types::Nullable<ST>, Option<T>>(&None, lookup)
+                        collector.push_bound_value::<::diesel::sql_types::Nullable<ST>, Option<T>>(&None, lookup)
                     },
                     _ => unreachable!("We set the value to `InnerBindValueKind::Sized` or `InnerBindValueKind::Null`")
                 }
             }
         }
 
-        impl<DB> PushBoundValueToCollectorDB<DB> for PushBoundValueToCollectorImpl<diesel::sql_types::Text, str>
-        where DB: diesel::backend::Backend + diesel::sql_types::HasSqlType<diesel::sql_types::Text>,
-              str: diesel::serialize::ToSql<diesel::sql_types::Text, DB> + 'static,
+        impl<DB> PushBoundValueToCollectorDB<DB> for PushBoundValueToCollectorImpl<::diesel::sql_types::Text, str>
+        where DB: ::diesel::backend::Backend + ::diesel::sql_types::HasSqlType<::diesel::sql_types::Text>,
+              str: ::diesel::serialize::ToSql<::diesel::sql_types::Text, DB> + 'static,
         {
             fn push_bound_value<'a: 'b, 'b>(
                 &self,
                 v: InnerBindValueKind<'a>,
-                collector: &mut <DB as diesel::backend::Backend>::BindCollector<'b>,
-                lookup: &mut <DB as diesel::sql_types::TypeMetadata>::MetadataLookup,
-            ) -> diesel::result::QueryResult<()> {
-                use diesel::query_builder::BindCollector;
+                collector: &mut <DB as ::diesel::backend::Backend>::BindCollector<'b>,
+                lookup: &mut <DB as ::diesel::sql_types::TypeMetadata>::MetadataLookup,
+            ) -> ::diesel::result::QueryResult<()> {
+                use ::diesel::query_builder::BindCollector;
                 if let InnerBindValueKind::Str(v) = v {
-                    collector.push_bound_value::<diesel::sql_types::Text, str>(v, lookup)
+                    collector.push_bound_value::<::diesel::sql_types::Text, str>(v, lookup)
                 } else {
                     unreachable!("We set the value to `InnerBindValueKind::Str`")
                 }
             }
         }
 
-        impl<DB> PushBoundValueToCollectorDB<DB> for PushBoundValueToCollectorImpl<diesel::sql_types::Binary, [u8]>
-        where DB: diesel::backend::Backend + diesel::sql_types::HasSqlType<diesel::sql_types::Binary>,
-              [u8]: diesel::serialize::ToSql<diesel::sql_types::Binary, DB> + 'static,
+        impl<DB> PushBoundValueToCollectorDB<DB> for PushBoundValueToCollectorImpl<::diesel::sql_types::Binary, [u8]>
+        where DB: ::diesel::backend::Backend + ::diesel::sql_types::HasSqlType<::diesel::sql_types::Binary>,
+              [u8]: ::diesel::serialize::ToSql<::diesel::sql_types::Binary, DB> + 'static,
         {
             fn push_bound_value<'a: 'b, 'b>(
                 &self,
                 v: InnerBindValueKind<'a>,
-                collector: &mut <DB as diesel::backend::Backend>::BindCollector<'b>,
-                lookup: &mut <DB as diesel::sql_types::TypeMetadata>::MetadataLookup,
-            ) -> diesel::result::QueryResult<()> {
-                use diesel::query_builder::BindCollector;
+                collector: &mut <DB as ::diesel::backend::Backend>::BindCollector<'b>,
+                lookup: &mut <DB as ::diesel::sql_types::TypeMetadata>::MetadataLookup,
+            ) -> ::diesel::result::QueryResult<()> {
+                use ::diesel::query_builder::BindCollector;
                 if let InnerBindValueKind::Bytes(v) = v {
-                    collector.push_bound_value::<diesel::sql_types::Binary, [u8]>(v, lookup)
+                    collector.push_bound_value::<::diesel::sql_types::Binary, [u8]>(v, lookup)
                 } else {
                     unreachable!("We set the value to `InnerBindValueKind::Binary`")
                 }
@@ -1241,26 +1265,26 @@ fn generate_bind_collector(
             Null,
         }
 
-        impl<'a> From<(diesel::sql_types::Text, &'a str)> for BindValue<'a> {
-            fn from((_, v): (diesel::sql_types::Text, &'a str)) -> Self {
+        impl<'a> From<(::diesel::sql_types::Text, &'a str)> for BindValue<'a> {
+            fn from((_, v): (::diesel::sql_types::Text, &'a str)) -> Self {
                 Self {
                     inner: Some(InnerBindValue{
                         value: InnerBindValueKind::Str(v),
                         push_bound_value_to_collector: &PushBoundValueToCollectorImpl {
-                            p: std::marker::PhantomData::<(diesel::sql_types::Text, str)>
+                            p: std::marker::PhantomData::<(::diesel::sql_types::Text, str)>
                         }
                     })
                 }
             }
         }
 
-        impl<'a> From<(diesel::sql_types::Binary, &'a [u8])> for BindValue<'a> {
-            fn from((_, v): (diesel::sql_types::Binary, &'a [u8])) -> Self {
+        impl<'a> From<(::diesel::sql_types::Binary, &'a [u8])> for BindValue<'a> {
+            fn from((_, v): (::diesel::sql_types::Binary, &'a [u8])) -> Self {
                 Self {
                     inner: Some(InnerBindValue {
                         value: InnerBindValueKind::Bytes(v),
                         push_bound_value_to_collector: &PushBoundValueToCollectorImpl {
-                            p: std::marker::PhantomData::<(diesel::sql_types::Binary, [u8])>
+                            p: std::marker::PhantomData::<(::diesel::sql_types::Binary, [u8])>
                         }
                     })
                 }
@@ -1270,7 +1294,7 @@ fn generate_bind_collector(
         impl<'a, T, ST> From<(ST, &'a T)> for BindValue<'a>
         where
             T: std::any::Any #(+ #into_bind_value_bounds)* + Send + Sync + 'static,
-            ST: Send + diesel::sql_types::SqlType<IsNull = diesel::sql_types::is_nullable::NotNull> + 'static,
+            ST: Send + ::diesel::sql_types::SqlType<IsNull = ::diesel::sql_types::is_nullable::NotNull> + 'static,
             #(#has_sql_type_bounds,)*
         {
             fn from((_, v): (ST, &'a T)) -> Self {
@@ -1285,30 +1309,30 @@ fn generate_bind_collector(
             }
         }
 
-        impl<'a> diesel::query_builder::BindCollector<'a, MultiBackend> for MultiBindCollector<'a> {
+        impl<'a> ::diesel::query_builder::BindCollector<'a, MultiBackend> for MultiBindCollector<'a> {
             type Buffer = multi_connection_impl::bind_collector::BindValue<'a>;
 
             fn push_bound_value<T, U>(
                 &mut self,
                 bind: &'a U,
                 metadata_lookup: &mut (dyn std::any::Any + 'static),
-            ) -> diesel::QueryResult<()>
+            ) -> ::diesel::QueryResult<()>
             where
-                MultiBackend: diesel::sql_types::HasSqlType<T>,
-                U: diesel::serialize::ToSql<T, MultiBackend> + ?Sized + 'a,
+                MultiBackend: ::diesel::sql_types::HasSqlType<T>,
+                U: ::diesel::serialize::ToSql<T, MultiBackend> + ?Sized + 'a,
             {
                 let out = {
                     let out = multi_connection_impl::bind_collector::BindValue::default();
                     let mut out =
-                        diesel::serialize::Output::<MultiBackend>::new(out, metadata_lookup);
-                    let bind_is_null = bind.to_sql(&mut out).map_err(diesel::result::Error::SerializationError)?;
-                    if matches!(bind_is_null, diesel::serialize::IsNull::Yes) {
+                        ::diesel::serialize::Output::<MultiBackend>::new(out, metadata_lookup);
+                    let bind_is_null = bind.to_sql(&mut out).map_err(::diesel::result::Error::SerializationError)?;
+                    if matches!(bind_is_null, ::diesel::serialize::IsNull::Yes) {
                         // nulls are special and need a special handling because
                         // there is a wildcard `ToSql` impl in diesel. That means we won't
                         // set the `inner` field of `BindValue` to something for the `None`
                         // case. Therefore we need to handle that explicitly here.
                         //
-                        let metadata = <MultiBackend as diesel::sql_types::HasSqlType<T>>::metadata(metadata_lookup);
+                        let metadata = <MultiBackend as ::diesel::sql_types::HasSqlType<T>>::metadata(metadata_lookup);
                         match (self, metadata) {
                             #(#push_null_to_inner_collector)*
                             _ => {
@@ -1327,7 +1351,7 @@ fn generate_bind_collector(
                 Ok(())
             }
 
-            fn push_null_value(&mut self, metadata: super::backend::MultiTypeMetadata) -> diesel::QueryResult<()> {
+            fn push_null_value(&mut self, metadata: super::backend::MultiTypeMetadata) -> ::diesel::QueryResult<()> {
                 match (self, metadata) {
                     #(#push_null_to_inner_collector)*
                     _ => unreachable!("We have matching metadata"),
@@ -1339,49 +1363,49 @@ fn generate_bind_collector(
         #(#to_sql_impls)*
         #(#from_sql_impls)*
 
-        impl<T, ST> diesel::internal::derives::multiconnection::EnumMapping<super::MultiBackend> for diesel::internal::derives::multiconnection::IntMapping<T, ST>
+        impl<T, ST> ::diesel::internal::derives::multiconnection::EnumMapping<super::MultiBackend> for ::diesel::internal::derives::multiconnection::IntMapping<T, ST>
         where
              ST: Default,
-             T: diesel::deserialize::FromSql<ST, super::MultiBackend> + 'static + diesel::internal::derives::multiconnection::IntegerMappingHelper,
+             T: ::diesel::deserialize::FromSql<ST, super::MultiBackend> + 'static + ::diesel::internal::derives::multiconnection::IntegerMappingHelper,
              for<'a> BindValue<'a>: From<(ST, &'a T)>,
              i128: TryFrom<T, Error: core::fmt::Display>,
         {
             fn map_to_database_value<'b>(
-                output: &mut diesel::serialize::Output<'b, '_, super::MultiBackend>,
-                variant: &'static diesel::internal::derives::multiconnection::EnumVariant,
-            ) -> diesel::serialize::Result {
-                let v = <T as diesel::internal::derives::multiconnection::IntegerMappingHelper>::as_ref(&variant.discriminant)?;
+                output: &mut ::diesel::serialize::Output<'b, '_, super::MultiBackend>,
+                variant: &'static ::diesel::internal::derives::multiconnection::EnumVariant,
+            ) -> ::diesel::serialize::Result {
+                let v = <T as ::diesel::internal::derives::multiconnection::IntegerMappingHelper>::as_ref(&variant.discriminant)?;
                 output.set_value((ST::default(), v));
-                Ok(diesel::serialize::IsNull::No)
+                Ok(::diesel::serialize::IsNull::No)
             }
 
             fn map_from_database_value(
-                raw: <super::MultiBackend as diesel::backend::Backend>::RawValue<'_>,
+                raw: <super::MultiBackend as ::diesel::backend::Backend>::RawValue<'_>,
                 type_name: &'static str,
-                variants: &'static [diesel::internal::derives::multiconnection::EnumVariant],
-            ) -> diesel::deserialize::Result<usize> {
-                let i = <T as diesel::deserialize::FromSql<ST, super::MultiBackend>>::from_sql(raw)?;
+                variants: &'static [::diesel::internal::derives::multiconnection::EnumVariant],
+            ) -> ::diesel::deserialize::Result<usize> {
+                let i = <T as ::diesel::deserialize::FromSql<ST, super::MultiBackend>>::from_sql(raw)?;
                 Self::from_discriminant(type_name, variants, i)
             }
         }
 
-        impl diesel::internal::derives::multiconnection::EnumMapping<super::MultiBackend> for diesel::internal::derives::multiconnection::StringMapping {
+        impl ::diesel::internal::derives::multiconnection::EnumMapping<super::MultiBackend> for ::diesel::internal::derives::multiconnection::StringMapping {
             fn map_to_database_value<'b>(
-                output: &mut diesel::serialize::Output<'b, '_, super::MultiBackend>,
-                variant: &'static diesel::internal::derives::multiconnection::EnumVariant,
-            ) -> diesel::serialize::Result {
-                <&str as diesel::serialize::ToSql<diesel::sql_types::Text, super::MultiBackend>>::to_sql(
+                output: &mut ::diesel::serialize::Output<'b, '_, super::MultiBackend>,
+                variant: &'static ::diesel::internal::derives::multiconnection::EnumVariant,
+            ) -> ::diesel::serialize::Result {
+                <&str as ::diesel::serialize::ToSql<::diesel::sql_types::Text, super::MultiBackend>>::to_sql(
                     &variant.sql_name,
                     output,
                 )
             }
 
             fn map_from_database_value(
-                raw: <super::MultiBackend as diesel::backend::Backend>::RawValue<'_>,
+                raw: <super::MultiBackend as ::diesel::backend::Backend>::RawValue<'_>,
                 type_name: &'static str,
-                variants: &'static [diesel::internal::derives::multiconnection::EnumVariant],
-            ) -> diesel::deserialize::Result<usize> {
-                let s = <String as diesel::deserialize::FromSql<diesel::sql_types::Text, super::MultiBackend>>::from_sql(raw)?;
+                variants: &'static [::diesel::internal::derives::multiconnection::EnumVariant],
+            ) -> ::diesel::deserialize::Result<usize> {
+                let s = <String as ::diesel::deserialize::FromSql<::diesel::sql_types::Text, super::MultiBackend>>::from_sql(raw)?;
                 Self::from_variant_name(type_name, variants, &s)
             }
         }
@@ -1391,7 +1415,7 @@ fn generate_bind_collector(
 
 fn generate_has_sql_type_impls(sql_type: TokenStream) -> TokenStream {
     quote::quote! {
-        impl diesel::sql_types::HasSqlType<#sql_type> for super::MultiBackend {
+        impl ::diesel::sql_types::HasSqlType<#sql_type> for super::MultiBackend {
             fn metadata(lookup: &mut Self::MetadataLookup) -> Self::TypeMetadata {
                 Self::lookup_sql_type::<#sql_type>(lookup)
             }
@@ -1401,10 +1425,10 @@ fn generate_has_sql_type_impls(sql_type: TokenStream) -> TokenStream {
 
 fn generate_from_sql_impls((sql_type, tpe): (TokenStream, TokenStream)) -> TokenStream {
     quote::quote! {
-        impl diesel::deserialize::FromSql<#sql_type, super::MultiBackend> for #tpe {
+        impl ::diesel::deserialize::FromSql<#sql_type, super::MultiBackend> for #tpe {
             fn from_sql(
-                bytes: <super::MultiBackend as diesel::backend::Backend>::RawValue<'_>,
-            ) -> diesel::deserialize::Result<Self> {
+                bytes: <super::MultiBackend as ::diesel::backend::Backend>::RawValue<'_>,
+            ) -> ::diesel::deserialize::Result<Self> {
                 bytes.from_sql::<Self, #sql_type>()
             }
         }
@@ -1417,13 +1441,13 @@ fn generate_to_sql_impls(
     _connection_types: &[ConnectionVariant],
 ) -> TokenStream {
     quote::quote! {
-        impl diesel::serialize::ToSql<#sql_type, super::MultiBackend> for #tpe {
+        impl ::diesel::serialize::ToSql<#sql_type, super::MultiBackend> for #tpe {
             fn to_sql<'b>(
                 &'b self,
-                out: &mut diesel::serialize::Output<'b, '_, super::MultiBackend>,
-            ) -> diesel::serialize::Result {
+                out: &mut ::diesel::serialize::Output<'b, '_, super::MultiBackend>,
+            ) -> ::diesel::serialize::Result {
                 out.set_value((#sql_type, self));
-                Ok(diesel::serialize::IsNull::No)
+                Ok(::diesel::serialize::IsNull::No)
             }
         }
     }
@@ -1440,8 +1464,8 @@ fn generate_queryfragment_impls(
         {
             fn walk_ast<'b>(
                 &'b self,
-                pass: diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
-            ) -> diesel::QueryResult<()> {
+                pass: ::diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
+            ) -> ::diesel::QueryResult<()> {
                 super::backend::MultiBackend::walk_variant_ast(self, pass)
             }
         }
@@ -1461,7 +1485,7 @@ fn generate_querybuilder(
         let ident = c.name;
         let ty = c.ty;
         quote::quote! {
-            #ident(<<#ty as #conn_backend>::Backend as diesel::backend::Backend>::QueryBuilder)
+            #ident(<<#ty as #conn_backend>::Backend as ::diesel::backend::Backend>::QueryBuilder)
         }
     });
 
@@ -1498,7 +1522,7 @@ fn generate_querybuilder(
         let ident = c.name;
         let lower_ident = syn::Ident::new(&ident.to_string().to_lowercase(), ident.span());
         quote::quote! {
-            pub(super) fn #lower_ident(&mut self) -> &mut <<#ty as #conn_backend>::Backend as diesel::backend::Backend>::QueryBuilder {
+            pub(super) fn #lower_ident(&mut self) -> &mut <<#ty as #conn_backend>::Backend as ::diesel::backend::Backend>::QueryBuilder {
                 match self {
                     Self::#ident(qb) => qb,
                     _ => unreachable!(),
@@ -1512,7 +1536,7 @@ fn generate_querybuilder(
         .map(|c| {
             let ty = c.ty;
             quote::quote! {
-                diesel::query_builder::QueryFragment<<#ty as #conn_backend>::Backend>
+                ::diesel::query_builder::QueryFragment<<#ty as #conn_backend>::Backend>
             }
         })
         .collect::<Vec<_>>();
@@ -1525,60 +1549,60 @@ fn generate_querybuilder(
     });
 
     let query_fragment = quote::quote! {
-        diesel::query_builder::QueryFragment<super::backend::MultiBackend>
+        ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>
     };
 
     let query_fragment_impls = IntoIterator::into_iter([
         quote::quote!{
-            <L, O> #query_fragment for diesel::internal::derives::multiconnection::LimitOffsetClause<L, O>
+            <L, O> #query_fragment for ::diesel::internal::derives::multiconnection::LimitOffsetClause<L, O>
         },
         quote::quote! {
-            <L, R> diesel::query_builder::QueryFragment<super::backend::MultiBackend, super::backend::MultiConcatClauseSyntax>
-                for diesel::internal::derives::multiconnection::Concat<L, R>
+            <L, R> ::diesel::query_builder::QueryFragment<super::backend::MultiBackend, super::backend::MultiConcatClauseSyntax>
+                for ::diesel::internal::derives::multiconnection::Concat<L, R>
         },
         quote::quote! {
-            <T, U> diesel::query_builder::QueryFragment<super::backend::MultiBackend, super::backend::MultiArrayComparisonSyntax>
-                for diesel::internal::derives::multiconnection::array_comparison::In<T, U>
+            <T, U> ::diesel::query_builder::QueryFragment<super::backend::MultiBackend, super::backend::MultiArrayComparisonSyntax>
+                for ::diesel::internal::derives::multiconnection::array_comparison::In<T, U>
         },
         quote::quote! {
-            <T, U> diesel::query_builder::QueryFragment<super::backend::MultiBackend, super::backend::MultiArrayComparisonSyntax>
-                for diesel::internal::derives::multiconnection::array_comparison::NotIn<T, U>
+            <T, U> ::diesel::query_builder::QueryFragment<super::backend::MultiBackend, super::backend::MultiArrayComparisonSyntax>
+                for ::diesel::internal::derives::multiconnection::array_comparison::NotIn<T, U>
         },
         quote::quote! {
-            <ST, I> diesel::query_builder::QueryFragment<super::backend::MultiBackend, super::backend::MultiArrayComparisonSyntax>
-                for diesel::internal::derives::multiconnection::array_comparison::Many<ST, I>
+            <ST, I> ::diesel::query_builder::QueryFragment<super::backend::MultiBackend, super::backend::MultiArrayComparisonSyntax>
+                for ::diesel::internal::derives::multiconnection::array_comparison::Many<ST, I>
         },
         quote::quote! {
-            <T> diesel::query_builder::QueryFragment<super::backend::MultiBackend, super::backend::MultiExistsSyntax>
-                for diesel::internal::derives::multiconnection::Exists<T>
+            <T> ::diesel::query_builder::QueryFragment<super::backend::MultiBackend, super::backend::MultiExistsSyntax>
+                for ::diesel::internal::derives::multiconnection::Exists<T>
         },
         quote::quote! {
-            diesel::query_builder::QueryFragment<super::backend::MultiBackend, super::backend::MultiEmptyFromClauseSyntax>
-                for diesel::internal::derives::multiconnection::NoFromClause
+            ::diesel::query_builder::QueryFragment<super::backend::MultiBackend, super::backend::MultiEmptyFromClauseSyntax>
+                for ::diesel::internal::derives::multiconnection::NoFromClause
         },
         quote::quote! {
-            diesel::query_builder::QueryFragment<super::backend::MultiBackend, super::backend::MultiDefaultValueClauseForInsert>
-                for diesel::internal::derives::multiconnection::DefaultValues
+            ::diesel::query_builder::QueryFragment<super::backend::MultiBackend, super::backend::MultiDefaultValueClauseForInsert>
+                for ::diesel::internal::derives::multiconnection::DefaultValues
         },
         quote::quote! {
-            <Expr> diesel::query_builder::QueryFragment<super::backend::MultiBackend, super::backend::MultiReturningClause>
-                for diesel::internal::derives::multiconnection::ReturningClause<Expr>
+            <Expr> ::diesel::query_builder::QueryFragment<super::backend::MultiBackend, super::backend::MultiReturningClause>
+                for ::diesel::internal::derives::multiconnection::ReturningClause<Expr>
         },
         quote::quote! {
-            <Expr> diesel::query_builder::QueryFragment<super::backend::MultiBackend, super::backend::MultiInsertWithDefaultKeyword>
-                for diesel::insertable::DefaultableColumnInsertValue<Expr>
+            <Expr> ::diesel::query_builder::QueryFragment<super::backend::MultiBackend, super::backend::MultiInsertWithDefaultKeyword>
+                for ::diesel::insertable::DefaultableColumnInsertValue<Expr>
         },
         quote::quote! {
-            <Tab, V, QId, const HAS_STATIC_QUERY_ID: bool> diesel::query_builder::QueryFragment<super::backend::MultiBackend, super::backend::MultiBatchInsertSupport>
-                for diesel::internal::derives::multiconnection::BatchInsert<V, Tab, QId, HAS_STATIC_QUERY_ID>
+            <Tab, V, QId, const HAS_STATIC_QUERY_ID: bool> ::diesel::query_builder::QueryFragment<super::backend::MultiBackend, super::backend::MultiBatchInsertSupport>
+                for ::diesel::internal::derives::multiconnection::BatchInsert<V, Tab, QId, HAS_STATIC_QUERY_ID>
         },
         quote::quote! {
-            <I, C, PK, Tab> diesel::query_builder::QueryFragment<super::backend::MultiBackend, super::backend::MultiBatchUpdateSupport>
-                for diesel::internal::derives::multiconnection::BatchUpdate<I, C, PK, Tab>
+            <I, C, PK, Tab> ::diesel::query_builder::QueryFragment<super::backend::MultiBackend, super::backend::MultiBatchUpdateSupport>
+                for ::diesel::internal::derives::multiconnection::BatchUpdate<I, C, PK, Tab>
         },
         quote::quote! {
-            <S> diesel::query_builder::QueryFragment<super::backend::MultiBackend, super::backend::MultiAliasSyntax>
-                for diesel::query_source::Alias<S>
+            <S> ::diesel::query_builder::QueryFragment<super::backend::MultiBackend, super::backend::MultiAliasSyntax>
+                for ::diesel::query_source::Alias<S>
         },
     ])
     .map(|t| generate_queryfragment_impls(t, &query_fragment_bounds));
@@ -1589,7 +1613,7 @@ fn generate_querybuilder(
         let ty = c.ty;
         quote::quote! {
             super::backend::MultiBackend::#ident(_) => {
-                <Self as diesel::insertable::InsertValues<<#ty as #conn_backend>::Backend, Col::Table>>::column_names(
+                <Self as ::diesel::insertable::InsertValues<<#ty as #conn_backend>::Backend, Col::Table>>::column_names(
                     &self,
                     out.cast_database(
                         super::bind_collector::MultiBindCollector::#lower_ident,
@@ -1608,7 +1632,7 @@ fn generate_querybuilder(
     let insert_values_backend_bounds = connection_types.iter().map(|c| {
         let ty = c.ty;
         quote::quote! {
-            diesel::insertable::DefaultableColumnInsertValue<diesel::insertable::ColumnInsertValue<Col, Expr>>: diesel::insertable::InsertValues<<#ty as #conn_backend>::Backend, Col::Table>
+            ::diesel::insertable::DefaultableColumnInsertValue<::diesel::insertable::ColumnInsertValue<Col, Expr>>: ::diesel::insertable::InsertValues<<#ty as #conn_backend>::Backend, Col::Table>
         }
     });
 
@@ -1629,14 +1653,14 @@ fn generate_querybuilder(
             #(#into_variant_functions)*
         }
 
-        impl diesel::query_builder::QueryBuilder<super::MultiBackend> for MultiQueryBuilder {
+        impl ::diesel::query_builder::QueryBuilder<super::MultiBackend> for MultiQueryBuilder {
             fn push_sql(&mut self, sql: &str) {
                 match self {
                     #(#push_sql_impl,)*
                 }
             }
 
-            fn push_identifier(&mut self, identifier: &str) -> diesel::QueryResult<()> {
+            fn push_identifier(&mut self, identifier: &str) -> ::diesel::QueryResult<()> {
                 match self {
                     #(#push_identifier_impl,)*
                 }
@@ -1658,11 +1682,11 @@ fn generate_querybuilder(
         #(#query_fragment_impls)*
 
         impl<F, S, D, W, O, LOf, G, H, LC>
-            diesel::query_builder::QueryFragment<
+            ::diesel::query_builder::QueryFragment<
                 super::backend::MultiBackend,
                 super::backend::MultiSelectStatementSyntax,
             >
-            for diesel::internal::derives::multiconnection::SelectStatement<
+            for ::diesel::internal::derives::multiconnection::SelectStatement<
                 F,
                 S,
                 D,
@@ -1674,21 +1698,21 @@ fn generate_querybuilder(
                 LC,
             >
         where
-            S: diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
-            F: diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
-            D: diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
-            W: diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
-            O: diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
-            LOf: diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
-            G: diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
-            H: diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
-            LC: diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
+            S: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
+            F: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
+            D: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
+            W: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
+            O: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
+            LOf: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
+            G: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
+            H: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
+            LC: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
         {
             fn walk_ast<'b>(
                 &'b self,
-                mut out: diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
-            ) -> diesel::QueryResult<()> {
-                use diesel::internal::derives::multiconnection::SelectStatementAccessor;
+                mut out: ::diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
+            ) -> ::diesel::QueryResult<()> {
+                use ::diesel::internal::derives::multiconnection::SelectStatementAccessor;
 
                 out.push_sql("SELECT ");
                 self.distinct_clause().walk_ast(out.reborrow())?;
@@ -1705,11 +1729,11 @@ fn generate_querybuilder(
         }
 
         impl<'a, ST, QS, GB>
-            diesel::query_builder::QueryFragment<
+            ::diesel::query_builder::QueryFragment<
             super::backend::MultiBackend,
             super::backend::MultiSelectStatementSyntax,
         >
-            for diesel::internal::derives::multiconnection::BoxedSelectStatement<
+            for ::diesel::internal::derives::multiconnection::BoxedSelectStatement<
                 'a,
                 ST,
                 QS,
@@ -1717,27 +1741,27 @@ fn generate_querybuilder(
                 GB,
             >
         where
-            QS: diesel::query_builder::QueryFragment<super::backend::MultiBackend>
+            QS: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>
         {
             fn walk_ast<'b>(
                 &'b self,
-                pass: diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
-            ) -> diesel::QueryResult<()> {
-                use diesel::internal::derives::multiconnection::BoxedQueryHelper;
+                pass: ::diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
+            ) -> ::diesel::QueryResult<()> {
+                use ::diesel::internal::derives::multiconnection::BoxedQueryHelper;
                 self.build_query(pass, |where_clause, pass| where_clause.walk_ast(pass))
             }
         }
 
-        impl diesel::query_builder::QueryFragment<super::backend::MultiBackend>
-            for diesel::internal::derives::multiconnection::BoxedLimitOffsetClause<
+        impl ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>
+            for ::diesel::internal::derives::multiconnection::BoxedLimitOffsetClause<
                 '_,
                 super::backend::MultiBackend,
             >
         {
             fn walk_ast<'b>(
                 &'b self,
-                mut pass: diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
-            ) -> diesel::QueryResult<()> {
+                mut pass: ::diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
+            ) -> ::diesel::QueryResult<()> {
                 if let Some(limit) = &self.limit {
                     limit.walk_ast(pass.reborrow())?;
                 }
@@ -1748,51 +1772,51 @@ fn generate_querybuilder(
             }
         }
 
-        impl<'a> diesel::query_builder::IntoBoxedClause<'a, super::multi_connection_impl::backend::MultiBackend>
-            for diesel::internal::derives::multiconnection::LimitOffsetClause<diesel::internal::derives::multiconnection::NoLimitClause, diesel::internal::derives::multiconnection::NoOffsetClause>
+        impl<'a> ::diesel::query_builder::IntoBoxedClause<'a, super::multi_connection_impl::backend::MultiBackend>
+            for ::diesel::internal::derives::multiconnection::LimitOffsetClause<::diesel::internal::derives::multiconnection::NoLimitClause, ::diesel::internal::derives::multiconnection::NoOffsetClause>
         {
-            type BoxedClause = diesel::internal::derives::multiconnection::BoxedLimitOffsetClause<'a, super::multi_connection_impl::backend::MultiBackend>;
+            type BoxedClause = ::diesel::internal::derives::multiconnection::BoxedLimitOffsetClause<'a, super::multi_connection_impl::backend::MultiBackend>;
 
             fn into_boxed(self) -> Self::BoxedClause {
-                diesel::internal::derives::multiconnection::BoxedLimitOffsetClause {
+                ::diesel::internal::derives::multiconnection::BoxedLimitOffsetClause {
                     limit: None,
                     offset: None,
                 }
             }
         }
-        impl<'a, L> diesel::query_builder::IntoBoxedClause<'a, super::multi_connection_impl::backend::MultiBackend>
-            for diesel::internal::derives::multiconnection::LimitOffsetClause<diesel::internal::derives::multiconnection::LimitClause<L>, diesel::internal::derives::multiconnection::NoOffsetClause>
-        where diesel::internal::derives::multiconnection::LimitClause<L>: diesel::query_builder::QueryFragment<super::backend::MultiBackend> + Send + 'static,
+        impl<'a, L> ::diesel::query_builder::IntoBoxedClause<'a, super::multi_connection_impl::backend::MultiBackend>
+            for ::diesel::internal::derives::multiconnection::LimitOffsetClause<::diesel::internal::derives::multiconnection::LimitClause<L>, ::diesel::internal::derives::multiconnection::NoOffsetClause>
+        where ::diesel::internal::derives::multiconnection::LimitClause<L>: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend> + Send + 'static,
         {
-            type BoxedClause = diesel::internal::derives::multiconnection::BoxedLimitOffsetClause<'a, super::multi_connection_impl::backend::MultiBackend>;
+            type BoxedClause = ::diesel::internal::derives::multiconnection::BoxedLimitOffsetClause<'a, super::multi_connection_impl::backend::MultiBackend>;
             fn into_boxed(self) -> Self::BoxedClause {
-                diesel::internal::derives::multiconnection::BoxedLimitOffsetClause {
+                ::diesel::internal::derives::multiconnection::BoxedLimitOffsetClause {
                     limit: Some(Box::new(self.limit_clause)),
                     offset: None,
                 }
             }
         }
-        impl<'a, O> diesel::query_builder::IntoBoxedClause<'a, super::multi_connection_impl::backend::MultiBackend>
-            for diesel::internal::derives::multiconnection::LimitOffsetClause<diesel::internal::derives::multiconnection::NoLimitClause, diesel::internal::derives::multiconnection::OffsetClause<O>>
-        where diesel::internal::derives::multiconnection::OffsetClause<O>: diesel::query_builder::QueryFragment<super::backend::MultiBackend> + Send + 'static,
+        impl<'a, O> ::diesel::query_builder::IntoBoxedClause<'a, super::multi_connection_impl::backend::MultiBackend>
+            for ::diesel::internal::derives::multiconnection::LimitOffsetClause<::diesel::internal::derives::multiconnection::NoLimitClause, ::diesel::internal::derives::multiconnection::OffsetClause<O>>
+        where ::diesel::internal::derives::multiconnection::OffsetClause<O>: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend> + Send + 'static,
 
         {
-            type BoxedClause = diesel::internal::derives::multiconnection::BoxedLimitOffsetClause<'a, super::multi_connection_impl::backend::MultiBackend>;
+            type BoxedClause = ::diesel::internal::derives::multiconnection::BoxedLimitOffsetClause<'a, super::multi_connection_impl::backend::MultiBackend>;
             fn into_boxed(self) -> Self::BoxedClause {
-                diesel::internal::derives::multiconnection::BoxedLimitOffsetClause {
+                ::diesel::internal::derives::multiconnection::BoxedLimitOffsetClause {
                     limit: None,
                     offset: Some(Box::new(self.offset_clause)),
                 }
             }
         }
-        impl<'a, L, O> diesel::query_builder::IntoBoxedClause<'a, super::multi_connection_impl::backend::MultiBackend>
-            for diesel::internal::derives::multiconnection::LimitOffsetClause<diesel::internal::derives::multiconnection::LimitClause<L>, diesel::internal::derives::multiconnection::OffsetClause<O>>
-        where diesel::internal::derives::multiconnection::LimitClause<L>: diesel::query_builder::QueryFragment<super::backend::MultiBackend> + Send + 'static,
-              diesel::internal::derives::multiconnection::OffsetClause<O>: diesel::query_builder::QueryFragment<super::backend::MultiBackend> + Send + 'static,
+        impl<'a, L, O> ::diesel::query_builder::IntoBoxedClause<'a, super::multi_connection_impl::backend::MultiBackend>
+            for ::diesel::internal::derives::multiconnection::LimitOffsetClause<::diesel::internal::derives::multiconnection::LimitClause<L>, ::diesel::internal::derives::multiconnection::OffsetClause<O>>
+        where ::diesel::internal::derives::multiconnection::LimitClause<L>: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend> + Send + 'static,
+              ::diesel::internal::derives::multiconnection::OffsetClause<O>: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend> + Send + 'static,
         {
-            type BoxedClause = diesel::internal::derives::multiconnection::BoxedLimitOffsetClause<'a, super::multi_connection_impl::backend::MultiBackend>;
+            type BoxedClause = ::diesel::internal::derives::multiconnection::BoxedLimitOffsetClause<'a, super::multi_connection_impl::backend::MultiBackend>;
             fn into_boxed(self) -> Self::BoxedClause {
-                diesel::internal::derives::multiconnection::BoxedLimitOffsetClause {
+                ::diesel::internal::derives::multiconnection::BoxedLimitOffsetClause {
                     limit: Some(Box::new(self.limit_clause)),
                     offset: Some(Box::new(self.offset_clause)),
                 }
@@ -1800,11 +1824,11 @@ fn generate_querybuilder(
         }
 
         impl<'a, ST, QS, GB>
-            diesel::query_builder::QueryFragment<
+            ::diesel::query_builder::QueryFragment<
             super::backend::MultiBackend,
             super::backend::MultiSelectStatementSyntax,
         >
-            for diesel::internal::derives::multiconnection::BoxedCloneSelectStatement<
+            for ::diesel::internal::derives::multiconnection::BoxedCloneSelectStatement<
                 'a,
                 ST,
                 QS,
@@ -1812,27 +1836,27 @@ fn generate_querybuilder(
                 GB,
             >
         where
-            QS: diesel::query_builder::QueryFragment<super::backend::MultiBackend>
+            QS: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>
         {
             fn walk_ast<'b>(
                 &'b self,
-                pass: diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
-            ) -> diesel::QueryResult<()> {
-                use diesel::internal::derives::multiconnection::BoxedCloneQueryHelper;
+                pass: ::diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
+            ) -> ::diesel::QueryResult<()> {
+                use ::diesel::internal::derives::multiconnection::BoxedCloneQueryHelper;
                 self.build_query(pass, |where_clause, pass| where_clause.walk_ast(pass))
             }
         }
 
-        impl diesel::query_builder::QueryFragment<super::backend::MultiBackend>
-            for diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause<
+        impl ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>
+            for ::diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause<
                 '_,
                 super::backend::MultiBackend,
             >
         {
             fn walk_ast<'b>(
                 &'b self,
-                mut pass: diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
-            ) -> diesel::QueryResult<()> {
+                mut pass: ::diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
+            ) -> ::diesel::QueryResult<()> {
                 if let Some(limit) = &self.limit {
                     limit.walk_ast(pass.reborrow())?;
                 }
@@ -1843,73 +1867,73 @@ fn generate_querybuilder(
             }
         }
 
-        impl<'a> diesel::query_builder::IntoBoxedCloneClause<'a, super::multi_connection_impl::backend::MultiBackend>
-            for diesel::internal::derives::multiconnection::LimitOffsetClause<diesel::internal::derives::multiconnection::NoLimitClause, diesel::internal::derives::multiconnection::NoOffsetClause>
+        impl<'a> ::diesel::query_builder::IntoBoxedCloneClause<'a, super::multi_connection_impl::backend::MultiBackend>
+            for ::diesel::internal::derives::multiconnection::LimitOffsetClause<::diesel::internal::derives::multiconnection::NoLimitClause, ::diesel::internal::derives::multiconnection::NoOffsetClause>
         {
-            type BoxedCloneClause = diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause<'a, super::multi_connection_impl::backend::MultiBackend>;
+            type BoxedCloneClause = ::diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause<'a, super::multi_connection_impl::backend::MultiBackend>;
 
             fn into_boxed_clone(self) -> Self::BoxedCloneClause {
-                diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause {
+                ::diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause {
                     limit: None,
                     offset: None,
                 }
             }
         }
-        impl<'a, L> diesel::query_builder::IntoBoxedCloneClause<'a, super::multi_connection_impl::backend::MultiBackend>
-            for diesel::internal::derives::multiconnection::LimitOffsetClause<diesel::internal::derives::multiconnection::LimitClause<L>, diesel::internal::derives::multiconnection::NoOffsetClause>
-        where diesel::internal::derives::multiconnection::LimitClause<L>: diesel::query_builder::QueryFragment<super::backend::MultiBackend> + Send + Sync + 'static,
+        impl<'a, L> ::diesel::query_builder::IntoBoxedCloneClause<'a, super::multi_connection_impl::backend::MultiBackend>
+            for ::diesel::internal::derives::multiconnection::LimitOffsetClause<::diesel::internal::derives::multiconnection::LimitClause<L>, ::diesel::internal::derives::multiconnection::NoOffsetClause>
+        where ::diesel::internal::derives::multiconnection::LimitClause<L>: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend> + Send + Sync + 'static,
         {
-            type BoxedCloneClause = diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause<'a, super::multi_connection_impl::backend::MultiBackend>;
+            type BoxedCloneClause = ::diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause<'a, super::multi_connection_impl::backend::MultiBackend>;
             fn into_boxed_clone(self) -> Self::BoxedCloneClause {
-                diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause {
+                ::diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause {
                     limit: Some(std::sync::Arc::new(self.limit_clause)),
                     offset: None,
                 }
             }
         }
-        impl<'a, O> diesel::query_builder::IntoBoxedCloneClause<'a, super::multi_connection_impl::backend::MultiBackend>
-            for diesel::internal::derives::multiconnection::LimitOffsetClause<diesel::internal::derives::multiconnection::NoLimitClause, diesel::internal::derives::multiconnection::OffsetClause<O>>
-        where diesel::internal::derives::multiconnection::OffsetClause<O>: diesel::query_builder::QueryFragment<super::backend::MultiBackend> + Send + Sync + 'static,
+        impl<'a, O> ::diesel::query_builder::IntoBoxedCloneClause<'a, super::multi_connection_impl::backend::MultiBackend>
+            for ::diesel::internal::derives::multiconnection::LimitOffsetClause<::diesel::internal::derives::multiconnection::NoLimitClause, ::diesel::internal::derives::multiconnection::OffsetClause<O>>
+        where ::diesel::internal::derives::multiconnection::OffsetClause<O>: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend> + Send + Sync + 'static,
 
         {
-            type BoxedCloneClause = diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause<'a, super::multi_connection_impl::backend::MultiBackend>;
+            type BoxedCloneClause = ::diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause<'a, super::multi_connection_impl::backend::MultiBackend>;
             fn into_boxed_clone(self) -> Self::BoxedCloneClause {
-                diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause {
+                ::diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause {
                     limit: None,
                     offset: Some(std::sync::Arc::new(self.offset_clause)),
                 }
             }
         }
-        impl<'a, L, O> diesel::query_builder::IntoBoxedCloneClause<'a, super::multi_connection_impl::backend::MultiBackend>
-            for diesel::internal::derives::multiconnection::LimitOffsetClause<diesel::internal::derives::multiconnection::LimitClause<L>, diesel::internal::derives::multiconnection::OffsetClause<O>>
-        where L: diesel::query_builder::QueryFragment<super::backend::MultiBackend> + Send + Sync + 'a,
-              O: diesel::query_builder::QueryFragment<super::backend::MultiBackend> + Send + Sync + 'a,
-              diesel::internal::derives::multiconnection::LimitClause<L>: diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
-              diesel::internal::derives::multiconnection::OffsetClause<O>: diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
+        impl<'a, L, O> ::diesel::query_builder::IntoBoxedCloneClause<'a, super::multi_connection_impl::backend::MultiBackend>
+            for ::diesel::internal::derives::multiconnection::LimitOffsetClause<::diesel::internal::derives::multiconnection::LimitClause<L>, ::diesel::internal::derives::multiconnection::OffsetClause<O>>
+        where L: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend> + Send + Sync + 'a,
+              O: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend> + Send + Sync + 'a,
+              ::diesel::internal::derives::multiconnection::LimitClause<L>: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
+              ::diesel::internal::derives::multiconnection::OffsetClause<O>: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
         {
-            type BoxedCloneClause = diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause<'a, super::multi_connection_impl::backend::MultiBackend>;
+            type BoxedCloneClause = ::diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause<'a, super::multi_connection_impl::backend::MultiBackend>;
             fn into_boxed_clone(self) -> Self::BoxedCloneClause {
-                diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause {
+                ::diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause {
                     limit: Some(std::sync::Arc::new(self.limit_clause)),
                     offset: Some(std::sync::Arc::new(self.offset_clause)),
                 }
             }
         }
 
-        impl<Col, Expr> diesel::insertable::InsertValues<super::multi_connection_impl::backend::MultiBackend, Col::Table>
-            for diesel::insertable::DefaultableColumnInsertValue<diesel::insertable::ColumnInsertValue<Col, Expr>>
+        impl<Col, Expr> ::diesel::insertable::InsertValues<super::multi_connection_impl::backend::MultiBackend, Col::Table>
+            for ::diesel::insertable::DefaultableColumnInsertValue<::diesel::insertable::ColumnInsertValue<Col, Expr>>
         where
-            Col: diesel::prelude::Column,
-            Expr: diesel::prelude::Expression<SqlType = Col::SqlType>,
-            Expr: diesel::prelude::AppearsOnTable<diesel::internal::derives::multiconnection::NoFromClause>,
-            Self: diesel::query_builder::QueryFragment<super::multi_connection_impl::backend::MultiBackend>,
+            Col: ::diesel::prelude::Column,
+            Expr: ::diesel::prelude::Expression<SqlType = Col::SqlType>,
+            Expr: ::diesel::prelude::AppearsOnTable<::diesel::internal::derives::multiconnection::NoFromClause>,
+            Self: ::diesel::query_builder::QueryFragment<super::multi_connection_impl::backend::MultiBackend>,
             #(#insert_values_backend_bounds,)*
         {
             fn column_names(
                 &self,
-                mut out: diesel::query_builder::AstPass<'_, '_, super::multi_connection_impl::backend::MultiBackend>
-            ) -> diesel::QueryResult<()> {
-                use diesel::internal::derives::multiconnection::AstPassHelper;
+                mut out: ::diesel::query_builder::AstPass<'_, '_, super::multi_connection_impl::backend::MultiBackend>
+            ) -> ::diesel::QueryResult<()> {
+                use ::diesel::internal::derives::multiconnection::AstPassHelper;
 
                 match out.backend() {
                     #(#insert_values_impl_variants,)*
@@ -1937,7 +1961,7 @@ fn generate_backend(connection_types: &[ConnectionVariant], helper: &MultiHelper
         let ident = c.name;
         let ty = c.ty;
         quote::quote! {
-            #ident(<<#ty as #conn_backend>::Backend as diesel::backend::Backend>::RawValue<'a>)
+            #ident(<<#ty as #conn_backend>::Backend as ::diesel::backend::Backend>::RawValue<'a>)
         }
     });
 
@@ -1945,23 +1969,23 @@ fn generate_backend(connection_types: &[ConnectionVariant], helper: &MultiHelper
         let ident = c.name;
         let ty = c.ty;
         quote::quote! {
-            pub(super) #ident: Option<<<#ty as #conn_backend>::Backend as diesel::sql_types::TypeMetadata>::TypeMetadata>
+            pub(super) #ident: Option<<<#ty as #conn_backend>::Backend as ::diesel::sql_types::TypeMetadata>::TypeMetadata>
         }
     });
 
     let has_sql_type_impls = [
-        quote::quote!(diesel::sql_types::SmallInt),
-        quote::quote!(diesel::sql_types::Integer),
-        quote::quote!(diesel::sql_types::BigInt),
-        quote::quote!(diesel::sql_types::Double),
-        quote::quote!(diesel::sql_types::Float),
-        quote::quote!(diesel::sql_types::Text),
-        quote::quote!(diesel::sql_types::Binary),
-        quote::quote!(diesel::sql_types::Date),
-        quote::quote!(diesel::sql_types::Time),
-        quote::quote!(diesel::sql_types::Timestamp),
-        quote::quote!(diesel::sql_types::Bool),
-        quote::quote!(diesel::sql_types::Numeric),
+        quote::quote!(::diesel::sql_types::SmallInt),
+        quote::quote!(::diesel::sql_types::Integer),
+        quote::quote!(::diesel::sql_types::BigInt),
+        quote::quote!(::diesel::sql_types::Double),
+        quote::quote!(::diesel::sql_types::Float),
+        quote::quote!(::diesel::sql_types::Text),
+        quote::quote!(::diesel::sql_types::Binary),
+        quote::quote!(::diesel::sql_types::Date),
+        quote::quote!(::diesel::sql_types::Time),
+        quote::quote!(::diesel::sql_types::Timestamp),
+        quote::quote!(::diesel::sql_types::Bool),
+        quote::quote!(::diesel::sql_types::Numeric),
     ]
     .into_iter()
     .map(generate_has_sql_type_impls);
@@ -1985,7 +2009,7 @@ fn generate_backend(connection_types: &[ConnectionVariant], helper: &MultiHelper
         let ty = v.ty;
         quote::quote!{
             Self::#ident(b) => {
-                <T as diesel::deserialize::FromSql<ST, <#ty as #conn_backend>::Backend>>::from_sql(b)
+                <T as ::diesel::deserialize::FromSql<ST, <#ty as #conn_backend>::Backend>>::from_sql(b)
             }
         }
     });
@@ -1993,7 +2017,7 @@ fn generate_backend(connection_types: &[ConnectionVariant], helper: &MultiHelper
     let backend_from_sql_bounds = connection_types.iter().map(|v| {
         let ty = v.ty;
         quote::quote! {
-            T: diesel::deserialize::FromSql<ST, <#ty as #conn_backend>::Backend>
+            T: ::diesel::deserialize::FromSql<ST, <#ty as #conn_backend>::Backend>
         }
     });
 
@@ -2003,7 +2027,7 @@ fn generate_backend(connection_types: &[ConnectionVariant], helper: &MultiHelper
         let ty = c.ty;
         quote::quote! {
             super::backend::MultiBackend::#ident(_) => {
-                <T as diesel::query_builder::QueryFragment<<#ty as #conn_backend>::Backend>>::walk_ast(
+                <T as ::diesel::query_builder::QueryFragment<<#ty as #conn_backend>::Backend>>::walk_ast(
                     ast_node,
                     pass.cast_database(
                         super::bind_collector::MultiBindCollector::#lower_ident,
@@ -2023,7 +2047,7 @@ fn generate_backend(connection_types: &[ConnectionVariant], helper: &MultiHelper
         let ty = c.ty;
 
         quote::quote! {
-            T: diesel::query_builder::QueryFragment<<#ty as #conn_backend>::Backend>
+            T: ::diesel::query_builder::QueryFragment<<#ty as #conn_backend>::Backend>
         }
     });
 
@@ -2033,7 +2057,7 @@ fn generate_backend(connection_types: &[ConnectionVariant], helper: &MultiHelper
 
         quote::quote!{
             if let Some(lookup) = <#ty as #multi_conn_helper>::from_any(lookup) {
-                ret.#name = Some(<<#ty as #conn_backend>::Backend as diesel::sql_types::HasSqlType<ST>>::metadata(lookup));
+                ret.#name = Some(<<#ty as #conn_backend>::Backend as ::diesel::sql_types::HasSqlType<ST>>::metadata(lookup));
             }
         }
 
@@ -2042,7 +2066,7 @@ fn generate_backend(connection_types: &[ConnectionVariant], helper: &MultiHelper
     let lookup_sql_type_bounds = connection_types.iter().map(|c| {
         let ty = c.ty;
         quote::quote! {
-            <#ty as #conn_backend>::Backend: diesel::sql_types::HasSqlType<ST>
+            <#ty as #conn_backend>::Backend: ::diesel::sql_types::HasSqlType<ST>
         }
     });
 
@@ -2066,11 +2090,11 @@ fn generate_backend(connection_types: &[ConnectionVariant], helper: &MultiHelper
         impl MultiBackend {
             pub fn walk_variant_ast<'b, T>(
                 ast_node: &'b T,
-                pass: diesel::query_builder::AstPass<'_, 'b, Self>,
-            ) -> diesel::QueryResult<()>
+                pass: ::diesel::query_builder::AstPass<'_, 'b, Self>,
+            ) -> ::diesel::QueryResult<()>
             where #(#query_fragment_impl_bounds,)*
             {
-                use diesel::internal::derives::multiconnection::AstPassHelper;
+                use ::diesel::internal::derives::multiconnection::AstPassHelper;
                 match pass.backend() {
                     #(#query_fragment_impl_variants,)*
                 }
@@ -2082,7 +2106,7 @@ fn generate_backend(connection_types: &[ConnectionVariant], helper: &MultiHelper
         }
 
         impl MultiRawValue<'_> {
-            pub fn from_sql<T, ST>(self) -> diesel::deserialize::Result<T>
+            pub fn from_sql<T, ST>(self) -> ::diesel::deserialize::Result<T>
             where #(#backend_from_sql_bounds,)*
             {
                 match self {
@@ -2091,7 +2115,7 @@ fn generate_backend(connection_types: &[ConnectionVariant], helper: &MultiHelper
             }
         }
 
-        impl diesel::backend::Backend for MultiBackend {
+        impl ::diesel::backend::Backend for MultiBackend {
             type QueryBuilder = super::query_builder::MultiQueryBuilder;
             type RawValue<'a> = MultiRawValue<'a>;
             type BindCollector<'a> = super::bind_collector::MultiBindCollector<'a>;
@@ -2103,7 +2127,7 @@ fn generate_backend(connection_types: &[ConnectionVariant], helper: &MultiHelper
             #(#type_metadata_variants,)*
         }
 
-        impl diesel::sql_types::TypeMetadata for MultiBackend {
+        impl ::diesel::sql_types::TypeMetadata for MultiBackend {
             type TypeMetadata = MultiTypeMetadata;
 
             type MetadataLookup = dyn std::any::Any;
@@ -2126,10 +2150,10 @@ fn generate_backend(connection_types: &[ConnectionVariant], helper: &MultiHelper
         pub struct MultiAggregateFunctionExpressions;
         pub struct MultiBuiltInWindowFunctionRequireOrder;
 
-        impl diesel::backend::SqlDialect for MultiBackend {
+        impl ::diesel::backend::SqlDialect for MultiBackend {
             type ReturningClause = MultiReturningClause;
             // no on conflict support is also the default
-            type OnConflictClause = diesel::internal::derives::multiconnection::sql_dialect::on_conflict_clause::DoesNotSupportOnConflictClause;
+            type OnConflictClause = ::diesel::internal::derives::multiconnection::sql_dialect::on_conflict_clause::DoesNotSupportOnConflictClause;
             type InsertWithDefaultKeyword = MultiInsertWithDefaultKeyword;
             type BatchInsertSupport = MultiBatchInsertSupport;
             type BatchUpdateSupport = MultiBatchUpdateSupport;
@@ -2146,8 +2170,8 @@ fn generate_backend(connection_types: &[ConnectionVariant], helper: &MultiHelper
             type BuiltInWindowFunctionRequireOrder = MultiBuiltInWindowFunctionRequireOrder;
         }
 
-        impl diesel::internal::derives::multiconnection::TrustedBackend for MultiBackend {}
-        impl diesel::internal::derives::multiconnection::DieselReserveSpecialization for MultiBackend {}
+        impl ::diesel::internal::derives::multiconnection::TrustedBackend for MultiBackend {}
+        impl ::diesel::internal::derives::multiconnection::DieselReserveSpecialization for MultiBackend {}
 
         #(#has_sql_type_impls)*
     }

--- a/diesel_derives/src/sql_function.rs
+++ b/diesel_derives/src/sql_function.rs
@@ -458,7 +458,7 @@ fn expand_nonvariadic(
         numeric_derive = None;
     } else {
         sql_type = Some(quote!((#(#arg_name),*): Expression,));
-        numeric_derive = Some(quote!(#[derive(diesel::sql_types::DieselNumericOps)]));
+        numeric_derive = Some(quote!(#[derive(::diesel::sql_types::DieselNumericOps)]));
     }
 
     let helper_type_doc = format!("The return type of [`{fn_name}()`](fn@{fn_name})");
@@ -472,14 +472,14 @@ fn expand_nonvariadic(
 
     let args_iter = args.iter();
     let mut tokens = quote! {
-        use diesel::{self, QueryResult};
-        use diesel::expression::{AsExpression, Expression, SelectableExpression, AppearsOnTable, ValidGrouping};
-        use diesel::query_builder::{QueryFragment, AstPass};
-        use diesel::sql_types::*;
-        use diesel::internal::sql_functions::*;
+        use ::diesel::QueryResult;
+        use ::diesel::expression::{AsExpression, Expression, SelectableExpression, AppearsOnTable, ValidGrouping};
+        use ::diesel::query_builder::{QueryFragment, AstPass};
+        use ::diesel::sql_types::*;
+        use ::diesel::internal::sql_functions::*;
         use super::*;
 
-        #[derive(Debug, Clone, Copy, diesel::query_builder::QueryId)]
+        #[derive(Debug, Clone, Copy, ::diesel::query_builder::QueryId)]
         #numeric_derive
         pub struct #fn_name #ty_generics {
             #(pub(in super) #args_iter,)*
@@ -520,7 +520,7 @@ fn expand_nonvariadic(
         impl #impl_generics_internal FunctionFragment<__DieselInternal>
             for #fn_name #ty_generics
         where
-            __DieselInternal: diesel::backend::Backend,
+            __DieselInternal: ::diesel::backend::Backend,
             #(#arg_name: QueryFragment<__DieselInternal>,)*
         {
             const FUNCTION_NAME: &'static str = #sql_name;
@@ -600,7 +600,7 @@ fn expand_nonvariadic(
                     #[doc = #helper_type_doc]
                     pub type #fn_name #ty_generics = #internals_module_name::#fn_name <
                         #(#type_args,)*
-                        #(<#arg_name as diesel::expression::AsExpression<#arg_type>>::Expression,)*
+                        #(<#arg_name as ::diesel::expression::AsExpression<#arg_type>>::Expression,)*
                     >;
                 }),
                 quote! { #fn_name },
@@ -651,7 +651,7 @@ fn expand_nonvariadic(
                     pub type #fn_name<
                         #(#arg_names_iter,)*
                     > = super::#fn_name<
-                        #( <#auto_derived_types as diesel::expression::Expression>::SqlType, )*
+                        #( <#auto_derived_types as ::diesel::expression::Expression>::SqlType, )*
                         #(#arg_names_iter,)*
                     >;
                 }
@@ -670,7 +670,7 @@ fn expand_nonvariadic(
         pub #fn_token #fn_name #impl_generics (#(#args_iter,)*)
             -> #return_type_path #ty_generics
         #where_clause
-            #(#arg_name: diesel::expression::AsExpression<#arg_type>,)*
+            #(#arg_name: ::diesel::expression::AsExpression<#arg_type>,)*
         {
             #internals_module_name::#fn_name {
                 #(#arg_struct_assign,)*
@@ -751,7 +751,7 @@ fn generate_tokens_for_non_aggregate_functions(
         tokens = quote! {
             #tokens
 
-            diesel::internal::sql_functions::expand_sqlite_function!{
+            ::diesel::internal::sql_functions::expand_sqlite_function!{
                 [#(#types_for_sqlite_impl,)*],
 
                 #[allow(dead_code)]
@@ -765,23 +765,23 @@ fn generate_tokens_for_non_aggregate_functions(
                 /// instead, or [`register_impl_with_behavior`](self::register_impl_with_behavior)
                 /// for full control over the SQLite behavior flags.
                 pub fn register_impl<F, Ret, #(#arg_name,)*>(
-                    conn: &mut diesel::sqlite::SqliteConnection,
+                    conn: &mut ::diesel::sqlite::SqliteConnection,
                     f: F,
-                ) -> diesel::result::QueryResult<()>
+                ) -> ::diesel::result::QueryResult<()>
                 where
                     F: Fn(#(#arg_name,)*) -> Ret + ::core::panic::UnwindSafe + Send + 'static,
-                (#(#arg_name,)*): diesel::deserialize::FromSqlRow<(#(#arg_type,)*), diesel::sqlite::Sqlite> +
-                    diesel::deserialize::StaticallySizedRow<(#(#arg_type,)*), diesel::sqlite::Sqlite>,
-                    Ret: diesel::serialize::ToSql<#return_type, diesel::sqlite::Sqlite>,
+                (#(#arg_name,)*): ::diesel::deserialize::FromSqlRow<(#(#arg_type,)*), ::diesel::sqlite::Sqlite> +
+                    ::diesel::deserialize::StaticallySizedRow<(#(#arg_type,)*), ::diesel::sqlite::Sqlite>,
+                    Ret: ::diesel::serialize::ToSql<#return_type, ::diesel::sqlite::Sqlite>,
                 {
                     register_impl_with_behavior(
                         conn,
-                        diesel::sqlite::SqliteFunctionBehavior::DETERMINISTIC,
+                        ::diesel::sqlite::SqliteFunctionBehavior::DETERMINISTIC,
                         f,
                     )
                 }
             }
-            diesel::internal::sql_functions::expand_sqlite_function!{
+            ::diesel::internal::sql_functions::expand_sqlite_function!{
                 [#(#types_for_sqlite_impl,)*],
 
                 #[allow(dead_code)]
@@ -797,23 +797,23 @@ fn generate_tokens_for_non_aggregate_functions(
                 /// the SQLite behavior flags, use
                 /// [`register_impl_with_behavior`](self::register_impl_with_behavior).
                 pub fn register_nondeterministic_impl<F, Ret, #(#arg_name,)*>(
-                    conn: &mut diesel::sqlite::SqliteConnection,
+                    conn: &mut ::diesel::sqlite::SqliteConnection,
                     f: F,
-                ) -> diesel::result::QueryResult<()>
+                ) -> ::diesel::result::QueryResult<()>
                 where
                     F: FnMut(#(#arg_name,)*) -> Ret + ::core::panic::UnwindSafe + Send + 'static,
-                (#(#arg_name,)*): diesel::deserialize::FromSqlRow<(#(#arg_type,)*), diesel::sqlite::Sqlite> +
-                    diesel::deserialize::StaticallySizedRow<(#(#arg_type,)*), diesel::sqlite::Sqlite>,
-                    Ret: diesel::serialize::ToSql<#return_type, diesel::sqlite::Sqlite>,
+                (#(#arg_name,)*): ::diesel::deserialize::FromSqlRow<(#(#arg_type,)*), ::diesel::sqlite::Sqlite> +
+                    ::diesel::deserialize::StaticallySizedRow<(#(#arg_type,)*), ::diesel::sqlite::Sqlite>,
+                    Ret: ::diesel::serialize::ToSql<#return_type, ::diesel::sqlite::Sqlite>,
                 {
                     register_impl_with_behavior(
                         conn,
-                        diesel::sqlite::SqliteFunctionBehavior::empty(),
+                        ::diesel::sqlite::SqliteFunctionBehavior::empty(),
                         f,
                     )
                 }
             }
-            diesel::internal::sql_functions::expand_sqlite_function!{
+            ::diesel::internal::sql_functions::expand_sqlite_function!{
                 [#(#types_for_sqlite_impl,)*],
 
                 #[allow(dead_code)]
@@ -827,15 +827,15 @@ fn generate_tokens_for_non_aggregate_functions(
                 /// unless you need to set behavior flags explicitly. See
                 /// [`SqliteFunctionBehavior`] for the available flags.
                 pub fn register_impl_with_behavior<F, Ret, #(#arg_name,)*>(
-                    conn: &mut diesel::sqlite::SqliteConnection,
-                    behavior: diesel::sqlite::SqliteFunctionBehavior,
+                    conn: &mut ::diesel::sqlite::SqliteConnection,
+                    behavior: ::diesel::sqlite::SqliteFunctionBehavior,
                     mut f: F,
-                ) -> diesel::result::QueryResult<()>
+                ) -> ::diesel::result::QueryResult<()>
                 where
                     F: FnMut(#(#arg_name,)*) -> Ret + ::core::panic::UnwindSafe + Send + 'static,
-                (#(#arg_name,)*): diesel::deserialize::FromSqlRow<(#(#arg_type,)*), diesel::sqlite::Sqlite> +
-                    diesel::deserialize::StaticallySizedRow<(#(#arg_type,)*), diesel::sqlite::Sqlite>,
-                    Ret: diesel::serialize::ToSql<#return_type, diesel::sqlite::Sqlite>,
+                (#(#arg_name,)*): ::diesel::deserialize::FromSqlRow<(#(#arg_type,)*), ::diesel::sqlite::Sqlite> +
+                    ::diesel::deserialize::StaticallySizedRow<(#(#arg_type,)*), ::diesel::sqlite::Sqlite>,
+                    Ret: ::diesel::serialize::ToSql<#return_type, ::diesel::sqlite::Sqlite>,
                 {
                     conn.register_sql_function::<(#(#arg_type,)*), #return_type, _, _, _>(
                         #sql_name,
@@ -850,7 +850,7 @@ fn generate_tokens_for_non_aggregate_functions(
     if !contains_none && arg_name.is_empty() {
         tokens = quote! {
             #tokens
-            diesel::internal::sql_functions::expand_sqlite_function!{
+            ::diesel::internal::sql_functions::expand_sqlite_function!{
                 [#(#types_for_sqlite_impl,)*],
 
                 #[allow(dead_code)]
@@ -864,21 +864,21 @@ fn generate_tokens_for_non_aggregate_functions(
                 /// instead, or [`register_impl_with_behavior`](self::register_impl_with_behavior)
                 /// for full control over the SQLite behavior flags.
                 pub fn register_impl<F, Ret>(
-                    conn: &mut diesel::sqlite::SqliteConnection,
+                    conn: &mut ::diesel::sqlite::SqliteConnection,
                     f: F,
-                ) -> diesel::result::QueryResult<()>
+                ) -> ::diesel::result::QueryResult<()>
                 where
                     F: Fn() -> Ret + ::core::panic::UnwindSafe + Send + 'static,
-                    Ret: diesel::serialize::ToSql<#return_type, diesel::sqlite::Sqlite>,
+                    Ret: ::diesel::serialize::ToSql<#return_type, ::diesel::sqlite::Sqlite>,
                 {
                     register_impl_with_behavior(
                         conn,
-                        diesel::sqlite::SqliteFunctionBehavior::DETERMINISTIC,
+                        ::diesel::sqlite::SqliteFunctionBehavior::DETERMINISTIC,
                         f,
                     )
                 }
             }
-            diesel::internal::sql_functions::expand_sqlite_function!{
+            ::diesel::internal::sql_functions::expand_sqlite_function!{
                 [#(#types_for_sqlite_impl,)*],
 
                 #[allow(dead_code)]
@@ -894,21 +894,21 @@ fn generate_tokens_for_non_aggregate_functions(
                 /// the SQLite behavior flags, use
                 /// [`register_impl_with_behavior`](self::register_impl_with_behavior).
                 pub fn register_nondeterministic_impl<F, Ret>(
-                    conn: &mut diesel::sqlite::SqliteConnection,
+                    conn: &mut ::diesel::sqlite::SqliteConnection,
                     f: F,
-                ) -> diesel::result::QueryResult<()>
+                ) -> ::diesel::result::QueryResult<()>
                 where
                     F: FnMut() -> Ret + ::core::panic::UnwindSafe + Send + 'static,
-                    Ret: diesel::serialize::ToSql<#return_type, diesel::sqlite::Sqlite>,
+                    Ret: ::diesel::serialize::ToSql<#return_type, ::diesel::sqlite::Sqlite>,
                 {
                     register_impl_with_behavior(
                         conn,
-                        diesel::sqlite::SqliteFunctionBehavior::empty(),
+                        ::diesel::sqlite::SqliteFunctionBehavior::empty(),
                         f,
                     )
                 }
             }
-            diesel::internal::sql_functions::expand_sqlite_function!{
+            ::diesel::internal::sql_functions::expand_sqlite_function!{
                 [#(#types_for_sqlite_impl,)*],
 
                 #[allow(dead_code)]
@@ -922,13 +922,13 @@ fn generate_tokens_for_non_aggregate_functions(
                 /// unless you need to set behavior flags explicitly. See
                 /// [`SqliteFunctionBehavior`] for the available flags.
                 pub fn register_impl_with_behavior<F, Ret>(
-                    conn: &mut diesel::sqlite::SqliteConnection,
-                    behavior: diesel::sqlite::SqliteFunctionBehavior,
+                    conn: &mut ::diesel::sqlite::SqliteConnection,
+                    behavior: ::diesel::sqlite::SqliteFunctionBehavior,
                     f: F,
-                ) -> diesel::result::QueryResult<()>
+                ) -> ::diesel::result::QueryResult<()>
                 where
                     F: FnMut() -> Ret + ::core::panic::UnwindSafe + Send + 'static,
-                    Ret: diesel::serialize::ToSql<#return_type, diesel::sqlite::Sqlite>,
+                    Ret: ::diesel::serialize::ToSql<#return_type, ::diesel::sqlite::Sqlite>,
                 {
                     conn.register_noarg_sql_function::<#return_type, _, _>(
                         #sql_name,
@@ -977,7 +977,7 @@ fn generate_tokens_for_aggregate_functions(
         impl #impl_generics_internal ValidGrouping<__DieselInternal>
             for #fn_name #ty_generics
         {
-            type IsAggregate = diesel::expression::is_aggregate::Yes;
+            type IsAggregate = ::diesel::expression::is_aggregate::Yes;
         }
 
         impl #impl_generics IsAggregateFunction for #fn_name #ty_generics {}
@@ -1006,7 +1006,7 @@ fn generate_tokens_for_aggregate_functions(
             x if x > 1 => {
                 tokens = quote! {
                     #tokens
-                    diesel::internal::sql_functions::expand_sqlite_function! {
+                    ::diesel::internal::sql_functions::expand_sqlite_function! {
                         [#(#types_for_sqlite_impl,)*],
                         #[allow(dead_code)]
                         /// Registers an implementation for this aggregate function on the given connection.
@@ -1016,26 +1016,26 @@ fn generate_tokens_for_aggregate_functions(
                         /// the SQLite behavior flags, use
                         /// [`register_impl_with_behavior`](self::register_impl_with_behavior).
                         pub fn register_impl<A, #(#arg_name,)*>(
-                            conn: &mut diesel::sqlite::SqliteConnection,
-                        ) -> diesel::result::QueryResult<()>
+                            conn: &mut ::diesel::sqlite::SqliteConnection,
+                        ) -> ::diesel::result::QueryResult<()>
                         where
-                            A: diesel::sqlite::SqliteAggregateFunction<(#(#arg_name,)*)>
+                            A: ::diesel::sqlite::SqliteAggregateFunction<(#(#arg_name,)*)>
                             + Send
                             + 'static
                             + ::core::panic::UnwindSafe
                             + ::core::panic::RefUnwindSafe,
-                            A::Output: diesel::serialize::ToSql<#return_type, diesel::sqlite::Sqlite>,
-                        (#(#arg_name,)*): diesel::deserialize::FromSqlRow<(#(#arg_type,)*), diesel::sqlite::Sqlite> +
-                            diesel::deserialize::StaticallySizedRow<(#(#arg_type,)*), diesel::sqlite::Sqlite> +
+                            A::Output: ::diesel::serialize::ToSql<#return_type, ::diesel::sqlite::Sqlite>,
+                        (#(#arg_name,)*): ::diesel::deserialize::FromSqlRow<(#(#arg_type,)*), ::diesel::sqlite::Sqlite> +
+                            ::diesel::deserialize::StaticallySizedRow<(#(#arg_type,)*), ::diesel::sqlite::Sqlite> +
                             ::core::panic::UnwindSafe,
                         {
                             register_impl_with_behavior::<A, #(#arg_name,)*>(
                                 conn,
-                                diesel::sqlite::SqliteFunctionBehavior::empty(),
+                                ::diesel::sqlite::SqliteFunctionBehavior::empty(),
                             )
                         }
                     }
-                    diesel::internal::sql_functions::expand_sqlite_function! {
+                    ::diesel::internal::sql_functions::expand_sqlite_function! {
                         [#(#types_for_sqlite_impl,)*],
                         #[allow(dead_code)]
                         /// Registers an implementation for this aggregate function on the
@@ -1047,18 +1047,18 @@ fn generate_tokens_for_aggregate_functions(
                         /// behavior flags explicitly. See [`SqliteFunctionBehavior`] for the
                         /// available flags.
                         pub fn register_impl_with_behavior<A, #(#arg_name,)*>(
-                            conn: &mut diesel::sqlite::SqliteConnection,
-                            behavior: diesel::sqlite::SqliteFunctionBehavior,
-                        ) -> diesel::result::QueryResult<()>
+                            conn: &mut ::diesel::sqlite::SqliteConnection,
+                            behavior: ::diesel::sqlite::SqliteFunctionBehavior,
+                        ) -> ::diesel::result::QueryResult<()>
                         where
-                            A: diesel::sqlite::SqliteAggregateFunction<(#(#arg_name,)*)>
+                            A: ::diesel::sqlite::SqliteAggregateFunction<(#(#arg_name,)*)>
                             + Send
                             + 'static
                             + ::core::panic::UnwindSafe
                             + ::core::panic::RefUnwindSafe,
-                            A::Output: diesel::serialize::ToSql<#return_type, diesel::sqlite::Sqlite>,
-                        (#(#arg_name,)*): diesel::deserialize::FromSqlRow<(#(#arg_type,)*), diesel::sqlite::Sqlite> +
-                            diesel::deserialize::StaticallySizedRow<(#(#arg_type,)*), diesel::sqlite::Sqlite> +
+                            A::Output: ::diesel::serialize::ToSql<#return_type, ::diesel::sqlite::Sqlite>,
+                        (#(#arg_name,)*): ::diesel::deserialize::FromSqlRow<(#(#arg_type,)*), ::diesel::sqlite::Sqlite> +
+                            ::diesel::deserialize::StaticallySizedRow<(#(#arg_type,)*), ::diesel::sqlite::Sqlite> +
                             ::core::panic::UnwindSafe,
                         {
                             conn.register_aggregate_function::<(#(#arg_type,)*), #return_type, _, _, A>(#sql_name, behavior)
@@ -1073,7 +1073,7 @@ fn generate_tokens_for_aggregate_functions(
                 tokens = quote! {
                     #tokens
 
-                    diesel::internal::sql_functions::expand_sqlite_function! {
+                    ::diesel::internal::sql_functions::expand_sqlite_function! {
                         [#(#types_for_sqlite_impl,)*],
                         #[allow(dead_code)]
                         /// Registers an implementation for this aggregate function on the given connection.
@@ -1083,26 +1083,26 @@ fn generate_tokens_for_aggregate_functions(
                         /// the SQLite behavior flags, use
                         /// [`register_impl_with_behavior`](self::register_impl_with_behavior).
                         pub fn register_impl<A, #arg_name>(
-                            conn: &mut diesel::sqlite::SqliteConnection,
-                        ) -> diesel::result::QueryResult<()>
+                            conn: &mut ::diesel::sqlite::SqliteConnection,
+                        ) -> ::diesel::result::QueryResult<()>
                         where
-                            A: diesel::sqlite::SqliteAggregateFunction<#arg_name>
+                            A: ::diesel::sqlite::SqliteAggregateFunction<#arg_name>
                             + Send
                             + 'static
                             + ::core::panic::UnwindSafe
                             + ::core::panic::RefUnwindSafe,
-                            A::Output: diesel::serialize::ToSql<#return_type, diesel::sqlite::Sqlite>,
-                        #arg_name: diesel::deserialize::FromSqlRow<#arg_type, diesel::sqlite::Sqlite> +
-                            diesel::deserialize::StaticallySizedRow<#arg_type, diesel::sqlite::Sqlite> +
+                            A::Output: ::diesel::serialize::ToSql<#return_type, ::diesel::sqlite::Sqlite>,
+                        #arg_name: ::diesel::deserialize::FromSqlRow<#arg_type, ::diesel::sqlite::Sqlite> +
+                            ::diesel::deserialize::StaticallySizedRow<#arg_type, ::diesel::sqlite::Sqlite> +
                             ::core::panic::UnwindSafe,
                         {
                             register_impl_with_behavior::<A, #arg_name>(
                                 conn,
-                                diesel::sqlite::SqliteFunctionBehavior::empty(),
+                                ::diesel::sqlite::SqliteFunctionBehavior::empty(),
                             )
                         }
                     }
-                    diesel::internal::sql_functions::expand_sqlite_function! {
+                    ::diesel::internal::sql_functions::expand_sqlite_function! {
                         [#(#types_for_sqlite_impl,)*],
                         #[allow(dead_code)]
                         /// Registers an implementation for this aggregate function on the
@@ -1114,18 +1114,18 @@ fn generate_tokens_for_aggregate_functions(
                         /// behavior flags explicitly. See [`SqliteFunctionBehavior`] for the
                         /// available flags.
                         pub fn register_impl_with_behavior<A, #arg_name>(
-                            conn: &mut diesel::sqlite::SqliteConnection,
-                            behavior: diesel::sqlite::SqliteFunctionBehavior,
-                        ) -> diesel::result::QueryResult<()>
+                            conn: &mut ::diesel::sqlite::SqliteConnection,
+                            behavior: ::diesel::sqlite::SqliteFunctionBehavior,
+                        ) -> ::diesel::result::QueryResult<()>
                         where
-                            A: diesel::sqlite::SqliteAggregateFunction<#arg_name>
+                            A: ::diesel::sqlite::SqliteAggregateFunction<#arg_name>
                             + Send
                             + 'static
                             + ::core::panic::UnwindSafe
                             + ::core::panic::RefUnwindSafe,
-                            A::Output: diesel::serialize::ToSql<#return_type, diesel::sqlite::Sqlite>,
-                        #arg_name: diesel::deserialize::FromSqlRow<#arg_type, diesel::sqlite::Sqlite> +
-                            diesel::deserialize::StaticallySizedRow<#arg_type, diesel::sqlite::Sqlite> +
+                            A::Output: ::diesel::serialize::ToSql<#return_type, ::diesel::sqlite::Sqlite>,
+                        #arg_name: ::diesel::deserialize::FromSqlRow<#arg_type, ::diesel::sqlite::Sqlite> +
+                            ::diesel::deserialize::StaticallySizedRow<#arg_type, ::diesel::sqlite::Sqlite> +
                             ::core::panic::UnwindSafe,
                         {
                             conn.register_aggregate_function::<#arg_type, #return_type, _, _, A>(#sql_name, behavior)
@@ -1315,7 +1315,7 @@ impl Parse for SqlFunctionDecl {
                 })
             })
         } else {
-            parse_quote!(diesel::expression::expression_types::NotSelectable)
+            parse_quote!(::diesel::expression::expression_types::NotSelectable)
         };
         let _semi = Option::<Token![;]>::parse(input).unwrap_or_else(|e| {
             combine_error(e);
@@ -1616,7 +1616,7 @@ impl BackendRestriction {
         generics.params.push(parse_quote!(__F));
         let order = if require_order {
             quote::quote! {
-                diesel::internal::sql_functions::Order<__O, true>
+                ::diesel::internal::sql_functions::Order<__O, true>
             }
         } else {
             quote::quote! {__O}
@@ -1627,7 +1627,7 @@ impl BackendRestriction {
                 let (impl_generics, _, _) = generics.split_for_impl();
                 Self::generate_window_fragment_impl(
                     parse_quote!(__DieselInternal),
-                    Some(parse_quote!(__DieselInternal: diesel::backend::Backend,)),
+                    Some(parse_quote!(__DieselInternal: ::diesel::backend::Backend,)),
                     &impl_generics,
                     ty_generics,
                     fn_name,
@@ -1642,8 +1642,8 @@ impl BackendRestriction {
                     impl #impl_generics WindowFunctionFragment<#fn_name #ty_generics, __DieselInternal>
                         for OverClause<__P, #order, __F>
                     where
-                        Self: WindowFunctionFragment<#fn_name #ty_generics, __DieselInternal, <__DieselInternal as diesel::backend::SqlDialect>::#dialect>,
-                        __DieselInternal: diesel::backend::Backend,
+                        Self: WindowFunctionFragment<#fn_name #ty_generics, __DieselInternal, <__DieselInternal as ::diesel::backend::SqlDialect>::#dialect>,
+                        __DieselInternal: ::diesel::backend::Backend,
                     {
                     }
 
@@ -1651,7 +1651,7 @@ impl BackendRestriction {
                 let specific_impl = Self::generate_window_fragment_impl(
                     parse_quote!(__DieselInternal),
                     Some(
-                        parse_quote!(__DieselInternal: diesel::backend::Backend + diesel::backend::SqlDialect<#dialect = #dialect_type>,),
+                        parse_quote!(__DieselInternal: ::diesel::backend::Backend + ::diesel::backend::SqlDialect<#dialect = #dialect_type>,),
                     ),
                     &impl_generics,
                     ty_generics,
@@ -1667,7 +1667,9 @@ impl BackendRestriction {
                 let (impl_generics, _, _) = generics.split_for_impl();
                 Self::generate_window_fragment_impl(
                     parse_quote!(__DieselInternal),
-                    Some(parse_quote!(__DieselInternal: diesel::backend::Backend + #restriction,)),
+                    Some(
+                        parse_quote!(__DieselInternal: ::diesel::backend::Backend + #restriction,),
+                    ),
                     &impl_generics,
                     ty_generics,
                     fn_name,
@@ -1734,7 +1736,7 @@ impl BackendRestriction {
                 let (impl_generics, _, _) = generics.split_for_impl();
                 Self::generate_queryfragment_impl(
                     parse_quote!(__DieselInternal),
-                    Some(parse_quote!(__DieselInternal: diesel::backend::Backend,)),
+                    Some(parse_quote!(__DieselInternal: ::diesel::backend::Backend,)),
                     &impl_generics,
                     ty_generics,
                     arg_name,
@@ -1747,7 +1749,9 @@ impl BackendRestriction {
                 let (impl_generics, _, _) = generics.split_for_impl();
                 Self::generate_queryfragment_impl(
                     parse_quote!(__DieselInternal),
-                    Some(parse_quote!(__DieselInternal: diesel::backend::Backend + #restriction,)),
+                    Some(
+                        parse_quote!(__DieselInternal: ::diesel::backend::Backend + #restriction,),
+                    ),
                     &impl_generics,
                     ty_generics,
                     arg_name,
@@ -1761,7 +1765,7 @@ impl BackendRestriction {
                 let specific_impl = Self::generate_queryfragment_impl(
                     parse_quote!(__DieselInternal),
                     Some(
-                        parse_quote!(__DieselInternal: diesel::backend::Backend + diesel::backend::SqlDialect<#dialect = #dialect_type>,),
+                        parse_quote!(__DieselInternal: ::diesel::backend::Backend + ::diesel::backend::SqlDialect<#dialect = #dialect_type>,),
                     ),
                     &impl_generics,
                     ty_generics,
@@ -1773,11 +1777,11 @@ impl BackendRestriction {
                     impl #impl_generics QueryFragment<__DieselInternal>
                         for #fn_name #ty_generics
                     where
-                        Self: QueryFragment<__DieselInternal, <__DieselInternal as diesel::backend::SqlDialect>::#dialect>,
-                        __DieselInternal: diesel::backend::Backend,
+                        Self: QueryFragment<__DieselInternal, <__DieselInternal as ::diesel::backend::SqlDialect>::#dialect>,
+                        __DieselInternal: ::diesel::backend::Backend,
                     {
                         fn walk_ast<'__b>(&'__b self, mut out: AstPass<'_, '__b, __DieselInternal>) -> QueryResult<()> {
-                            <Self as QueryFragment<__DieselInternal, <__DieselInternal as diesel::backend::SqlDialect>::#dialect>>::walk_ast(self, out)
+                            <Self as QueryFragment<__DieselInternal, <__DieselInternal as ::diesel::backend::SqlDialect>::#dialect>>::walk_ast(self, out)
                         }
 
                     }
@@ -1950,16 +1954,16 @@ impl SqlFunctionAttribute {
             let _ = input.parse::<Token![,]>()?;
             let wrap_macro = match feature_value.as_str() {
                 "postgres_backend" => Some(syn::parse_quote!(
-                    diesel::internal::sql_functions::expand_pg
+                    ::diesel::internal::sql_functions::expand_pg
                 )),
                 "sqlite" | "__sqlite_shared" => Some(syn::parse_quote!(
-                    diesel::internal::sql_functions::expand_sqlite
+                    ::diesel::internal::sql_functions::expand_sqlite
                 )),
                 "mysql_backend" => Some(syn::parse_quote!(
-                    diesel::internal::sql_functions::expand_mysql
+                    ::diesel::internal::sql_functions::expand_mysql
                 )),
                 "mariadb_backend" => Some(syn::parse_quote!(
-                    diesel::internal::sql_functions::expand_mariadb
+                    ::diesel::internal::sql_functions::expand_mariadb
                 )),
                 feature => {
                     return Err(syn::Error::new(

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_changeset_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_changeset_1.snap
@@ -5,7 +5,7 @@ info:
   input: "#[derive(AsChangeset)]\nstruct User {\n    id: i32,\n    name: String,\n}\n"
 ---
 const _: () = {
-    use diesel;
+    use ::diesel;
     fn _check_owned()
     where
         String: diesel::expression::AsExpression<

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_changeset_change_field_type_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_changeset_change_field_type_1.snap
@@ -5,7 +5,7 @@ info:
   input: "#[derive(AsChangeset)]\nstruct User {\n    id: i32,\n    name: String,\n    #[diesel(serialize_as = String)]\n    age: i32,\n}\n"
 ---
 const _: () = {
-    use diesel;
+    use ::diesel;
     fn _check_owned()
     where
         String: diesel::expression::AsExpression<

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_changeset_column_name_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_changeset_column_name_1.snap
@@ -5,7 +5,7 @@ info:
   input: "#[derive(AsChangeset)]\nstruct User {\n    id: i32,\n    #[diesel(column_name = username)]\n    name: String,\n}\n"
 ---
 const _: () = {
-    use diesel;
+    use ::diesel;
     fn _check_owned()
     where
         String: diesel::expression::AsExpression<

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_changeset_embed_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_changeset_embed_1.snap
@@ -5,7 +5,7 @@ info:
   input: "#[derive(AsChangeset)]\nstruct User {\n    id: i32,\n    name: String,\n    #[diesel(embed)]\n    post: Post,\n}\n"
 ---
 const _: () = {
-    use diesel;
+    use ::diesel;
     fn _check_owned()
     where
         String: diesel::expression::AsExpression<

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_changeset_primary_key_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_changeset_primary_key_1.snap
@@ -5,7 +5,7 @@ info:
   input: "#[derive(AsChangeset)]\n#[diesel(primary_key(id, short_code))]\nstruct User {\n    id: i32,\n    short_code: String,\n    name: String,\n}\n"
 ---
 const _: () = {
-    use diesel;
+    use ::diesel;
     fn _check_owned()
     where
         String: diesel::expression::AsExpression<

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_changeset_table_name_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_changeset_table_name_1.snap
@@ -5,7 +5,7 @@ info:
   input: "#[derive(AsChangeset)]\n#[diesel(table_name = crate::schema::admin_users)]\nstruct User {\n    id: i32,\n    name: String,\n}\n"
 ---
 const _: () = {
-    use diesel;
+    use ::diesel;
     fn _check_owned()
     where
         String: diesel::expression::AsExpression<

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_changeset_treat_none_as_null_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_changeset_treat_none_as_null_1.snap
@@ -5,7 +5,7 @@ info:
   input: "#[derive(AsChangeset)]\n#[diesel(treat_none_as_null = true)]\nstruct User {\n    id: i32,\n    name: Option<String>,\n}\n"
 ---
 const _: () = {
-    use diesel;
+    use ::diesel;
     fn _check_owned()
     where
         String: diesel::expression::AsExpression<

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_changeset_treat_none_field_as_null_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_changeset_treat_none_field_as_null_1.snap
@@ -5,7 +5,7 @@ info:
   input: "#[derive(AsChangeset)]\nstruct User {\n    id: i32,\n    #[diesel(treat_none_as_null = true)]\n    name: Option<String>,\n}\n"
 ---
 const _: () = {
-    use diesel;
+    use ::diesel;
     fn _check_owned()
     where
         String: diesel::expression::AsExpression<

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_changeset_treat_skip_update_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_changeset_treat_skip_update_1.snap
@@ -5,7 +5,7 @@ info:
   input: "#[derive(AsChangeset)]\nstruct User {\n    id: i32,\n    #[diesel(skip_update)]\n    name: String,\n}\n"
 ---
 const _: () = {
-    use diesel;
+    use ::diesel;
     fn _check_owned() {}
     impl diesel::query_builder::AsChangeset for User {
         type Target = users::table;

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_expression_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_expression_1.snap
@@ -5,7 +5,7 @@ info:
   input: "#[derive(AsExpression)]\n#[diesel(sql_type = diesel::sql_type::Integer)]\nenum Foo {\n    Bar,\n    Baz,\n}\n"
 ---
 const _: () = {
-    use diesel;
+    use ::diesel;
     impl<'__expr> diesel::expression::AsExpression<diesel::sql_type::Integer>
     for &'__expr Foo {
         type Expression = diesel::internal::derives::as_expression::Bound<

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_expression_not_sized_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__as_expression_not_sized_1.snap
@@ -5,7 +5,7 @@ info:
   input: "#[derive(AsExpression)]\n#[diesel(sql_type = diesel::sql_type::Text)]\n#[diesel(not_sized)]\nstruct StringSlice(str);\n"
 ---
 const _: () = {
-    use diesel;
+    use ::diesel;
     impl<'__expr> diesel::expression::AsExpression<diesel::sql_type::Text>
     for &'__expr StringSlice {
         type Expression = diesel::internal::derives::as_expression::Bound<

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__associations_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__associations_1.snap
@@ -5,7 +5,7 @@ info:
   input: "#[derive(Associations)]\n#[diesel(belongs_to(User))]\nstruct Post {\n    id: i32,\n    title: String,\n    user_id: i32,\n}\n"
 ---
 const _: () = {
-    use diesel;
+    use ::diesel;
     impl<__FK> diesel::associations::BelongsTo<User> for Post
     where
         __FK: std::hash::Hash + std::cmp::Eq,

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__associations_column_name_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__associations_column_name_1.snap
@@ -5,7 +5,7 @@ info:
   input: "#[derive(Associations)]\n#[diesel(belongs_to(User))]\nstruct Post {\n    id: i32,\n    title: String,\n    #[diesel(column_name = user_id)]\n    author_id: i32,\n}\n"
 ---
 const _: () = {
-    use diesel;
+    use ::diesel;
     impl<__FK> diesel::associations::BelongsTo<User> for Post
     where
         __FK: std::hash::Hash + std::cmp::Eq,

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__associations_table_name_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__associations_table_name_1.snap
@@ -5,7 +5,7 @@ info:
   input: "#[derive(Associations)]\n#[diesel(belongs_to(User))]\n#[diesel(table_name = crate::schema::secret_posts)]\nstruct Post {\n    id: i32,\n    title: String,\n    user_id: i32,\n}\n"
 ---
 const _: () = {
-    use diesel;
+    use ::diesel;
     impl<__FK> diesel::associations::BelongsTo<User> for Post
     where
         __FK: std::hash::Hash + std::cmp::Eq,

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__auto_type_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__auto_type_1.snap
@@ -5,7 +5,7 @@ info:
   input: "#[diesel::dsl::auto_type]\nfn foo() -> _ {\n    users::table.select(users::id)\n}\n"
 ---
 #[allow(non_camel_case_types)]
-type foo = diesel::dsl::Select<users::table, users::id>;
+type foo = ::diesel::dsl::Select<users::table, users::id>;
 #[allow(clippy::needless_lifetimes)]
 fn foo() -> foo {
     users::table.select(users::id)

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__declare_sql_function_1 (sqlite).snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__declare_sql_function_1 (sqlite).snap
@@ -7,7 +7,7 @@ info:
 #[allow(non_camel_case_types)]
 pub fn lower<input>(input: input) -> lower<input>
 where
-    input: diesel::expression::AsExpression<Text>,
+    input: ::diesel::expression::AsExpression<Text>,
 {
     lower_utils::lower {
         input: input.as_expression(),
@@ -16,21 +16,21 @@ where
 #[allow(non_camel_case_types, non_snake_case)]
 ///The return type of [`lower()`](fn@lower)
 pub type lower<input> = lower_utils::lower<
-    <input as diesel::expression::AsExpression<Text>>::Expression,
+    <input as ::diesel::expression::AsExpression<Text>>::Expression,
 >;
 #[doc(hidden)]
 #[allow(non_camel_case_types, non_snake_case, unused_imports)]
 pub(crate) mod lower_utils {
-    use diesel::{self, QueryResult};
-    use diesel::expression::{
+    use ::diesel::QueryResult;
+    use ::diesel::expression::{
         AsExpression, Expression, SelectableExpression, AppearsOnTable, ValidGrouping,
     };
-    use diesel::query_builder::{QueryFragment, AstPass};
-    use diesel::sql_types::*;
-    use diesel::internal::sql_functions::*;
+    use ::diesel::query_builder::{QueryFragment, AstPass};
+    use ::diesel::sql_types::*;
+    use ::diesel::internal::sql_functions::*;
     use super::*;
-    #[derive(Debug, Clone, Copy, diesel::query_builder::QueryId)]
-    #[derive(diesel::sql_types::DieselNumericOps)]
+    #[derive(Debug, Clone, Copy, ::diesel::query_builder::QueryId)]
+    #[derive(::diesel::sql_types::DieselNumericOps)]
     pub struct lower<input> {
         pub(super) input: input,
     }
@@ -54,7 +54,7 @@ pub(crate) mod lower_utils {
     {}
     impl<input, __DieselInternal> FunctionFragment<__DieselInternal> for lower<input>
     where
-        __DieselInternal: diesel::backend::Backend,
+        __DieselInternal: ::diesel::backend::Backend,
         input: QueryFragment<__DieselInternal>,
     {
         const FUNCTION_NAME: &'static str = "lower";
@@ -76,7 +76,7 @@ pub(crate) mod lower_utils {
     }
     impl<input, __DieselInternal> QueryFragment<__DieselInternal> for lower<input>
     where
-        __DieselInternal: diesel::backend::Backend,
+        __DieselInternal: ::diesel::backend::Backend,
         input: QueryFragment<__DieselInternal>,
     {
         fn walk_ast<'__b>(
@@ -111,20 +111,23 @@ pub(crate) mod lower_utils {
     /// instead, or [`register_impl_with_behavior`](self::register_impl_with_behavior)
     /// for full control over the SQLite behavior flags.
     pub fn register_impl<F, Ret, input>(
-        conn: &mut diesel::sqlite::SqliteConnection,
+        conn: &mut ::diesel::sqlite::SqliteConnection,
         f: F,
-    ) -> diesel::result::QueryResult<()>
+    ) -> ::diesel::result::QueryResult<()>
     where
         F: Fn(input) -> Ret + ::core::panic::UnwindSafe + Send + 'static,
         (
             input,
-        ): diesel::deserialize::FromSqlRow<(Text,), diesel::sqlite::Sqlite>
-            + diesel::deserialize::StaticallySizedRow<(Text,), diesel::sqlite::Sqlite>,
-        Ret: diesel::serialize::ToSql<Text, diesel::sqlite::Sqlite>,
+        ): ::diesel::deserialize::FromSqlRow<(Text,), ::diesel::sqlite::Sqlite>
+            + ::diesel::deserialize::StaticallySizedRow<
+                (Text,),
+                ::diesel::sqlite::Sqlite,
+            >,
+        Ret: ::diesel::serialize::ToSql<Text, ::diesel::sqlite::Sqlite>,
     {
         register_impl_with_behavior(
             conn,
-            diesel::sqlite::SqliteFunctionBehavior::DETERMINISTIC,
+            ::diesel::sqlite::SqliteFunctionBehavior::DETERMINISTIC,
             f,
         )
     }
@@ -141,20 +144,23 @@ pub(crate) mod lower_utils {
     /// the SQLite behavior flags, use
     /// [`register_impl_with_behavior`](self::register_impl_with_behavior).
     pub fn register_nondeterministic_impl<F, Ret, input>(
-        conn: &mut diesel::sqlite::SqliteConnection,
+        conn: &mut ::diesel::sqlite::SqliteConnection,
         f: F,
-    ) -> diesel::result::QueryResult<()>
+    ) -> ::diesel::result::QueryResult<()>
     where
         F: FnMut(input) -> Ret + ::core::panic::UnwindSafe + Send + 'static,
         (
             input,
-        ): diesel::deserialize::FromSqlRow<(Text,), diesel::sqlite::Sqlite>
-            + diesel::deserialize::StaticallySizedRow<(Text,), diesel::sqlite::Sqlite>,
-        Ret: diesel::serialize::ToSql<Text, diesel::sqlite::Sqlite>,
+        ): ::diesel::deserialize::FromSqlRow<(Text,), ::diesel::sqlite::Sqlite>
+            + ::diesel::deserialize::StaticallySizedRow<
+                (Text,),
+                ::diesel::sqlite::Sqlite,
+            >,
+        Ret: ::diesel::serialize::ToSql<Text, ::diesel::sqlite::Sqlite>,
     {
         register_impl_with_behavior(
             conn,
-            diesel::sqlite::SqliteFunctionBehavior::empty(),
+            ::diesel::sqlite::SqliteFunctionBehavior::empty(),
             f,
         )
     }
@@ -169,17 +175,20 @@ pub(crate) mod lower_utils {
     /// unless you need to set behavior flags explicitly. See
     /// [`SqliteFunctionBehavior`] for the available flags.
     pub fn register_impl_with_behavior<F, Ret, input>(
-        conn: &mut diesel::sqlite::SqliteConnection,
-        behavior: diesel::sqlite::SqliteFunctionBehavior,
+        conn: &mut ::diesel::sqlite::SqliteConnection,
+        behavior: ::diesel::sqlite::SqliteFunctionBehavior,
         mut f: F,
-    ) -> diesel::result::QueryResult<()>
+    ) -> ::diesel::result::QueryResult<()>
     where
         F: FnMut(input) -> Ret + ::core::panic::UnwindSafe + Send + 'static,
         (
             input,
-        ): diesel::deserialize::FromSqlRow<(Text,), diesel::sqlite::Sqlite>
-            + diesel::deserialize::StaticallySizedRow<(Text,), diesel::sqlite::Sqlite>,
-        Ret: diesel::serialize::ToSql<Text, diesel::sqlite::Sqlite>,
+        ): ::diesel::deserialize::FromSqlRow<(Text,), ::diesel::sqlite::Sqlite>
+            + ::diesel::deserialize::StaticallySizedRow<
+                (Text,),
+                ::diesel::sqlite::Sqlite,
+            >,
+        Ret: ::diesel::serialize::ToSql<Text, ::diesel::sqlite::Sqlite>,
     {
         conn.register_sql_function::<
                 (Text,),

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__declare_sql_function_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__declare_sql_function_1.snap
@@ -7,7 +7,7 @@ info:
 #[allow(non_camel_case_types)]
 pub fn lower<input>(input: input) -> lower<input>
 where
-    input: diesel::expression::AsExpression<Text>,
+    input: ::diesel::expression::AsExpression<Text>,
 {
     lower_utils::lower {
         input: input.as_expression(),
@@ -16,21 +16,21 @@ where
 #[allow(non_camel_case_types, non_snake_case)]
 ///The return type of [`lower()`](fn@lower)
 pub type lower<input> = lower_utils::lower<
-    <input as diesel::expression::AsExpression<Text>>::Expression,
+    <input as ::diesel::expression::AsExpression<Text>>::Expression,
 >;
 #[doc(hidden)]
 #[allow(non_camel_case_types, non_snake_case, unused_imports)]
 pub(crate) mod lower_utils {
-    use diesel::{self, QueryResult};
-    use diesel::expression::{
+    use ::diesel::QueryResult;
+    use ::diesel::expression::{
         AsExpression, Expression, SelectableExpression, AppearsOnTable, ValidGrouping,
     };
-    use diesel::query_builder::{QueryFragment, AstPass};
-    use diesel::sql_types::*;
-    use diesel::internal::sql_functions::*;
+    use ::diesel::query_builder::{QueryFragment, AstPass};
+    use ::diesel::sql_types::*;
+    use ::diesel::internal::sql_functions::*;
     use super::*;
-    #[derive(Debug, Clone, Copy, diesel::query_builder::QueryId)]
-    #[derive(diesel::sql_types::DieselNumericOps)]
+    #[derive(Debug, Clone, Copy, ::diesel::query_builder::QueryId)]
+    #[derive(::diesel::sql_types::DieselNumericOps)]
     pub struct lower<input> {
         pub(super) input: input,
     }
@@ -54,7 +54,7 @@ pub(crate) mod lower_utils {
     {}
     impl<input, __DieselInternal> FunctionFragment<__DieselInternal> for lower<input>
     where
-        __DieselInternal: diesel::backend::Backend,
+        __DieselInternal: ::diesel::backend::Backend,
         input: QueryFragment<__DieselInternal>,
     {
         const FUNCTION_NAME: &'static str = "lower";
@@ -76,7 +76,7 @@ pub(crate) mod lower_utils {
     }
     impl<input, __DieselInternal> QueryFragment<__DieselInternal> for lower<input>
     where
-        __DieselInternal: diesel::backend::Backend,
+        __DieselInternal: ::diesel::backend::Backend,
         input: QueryFragment<__DieselInternal>,
     {
         fn walk_ast<'__b>(

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__define_sql_function_1 (sqlite).snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__define_sql_function_1 (sqlite).snap
@@ -7,7 +7,7 @@ info:
 #[allow(non_camel_case_types)]
 pub fn lower<input>(input: input) -> lower<input>
 where
-    input: diesel::expression::AsExpression<Text>,
+    input: ::diesel::expression::AsExpression<Text>,
 {
     lower_utils::lower {
         input: input.as_expression(),
@@ -16,21 +16,21 @@ where
 #[allow(non_camel_case_types, non_snake_case)]
 ///The return type of [`lower()`](fn@lower)
 pub type lower<input> = lower_utils::lower<
-    <input as diesel::expression::AsExpression<Text>>::Expression,
+    <input as ::diesel::expression::AsExpression<Text>>::Expression,
 >;
 #[doc(hidden)]
 #[allow(non_camel_case_types, non_snake_case, unused_imports)]
 pub(crate) mod lower_utils {
-    use diesel::{self, QueryResult};
-    use diesel::expression::{
+    use ::diesel::QueryResult;
+    use ::diesel::expression::{
         AsExpression, Expression, SelectableExpression, AppearsOnTable, ValidGrouping,
     };
-    use diesel::query_builder::{QueryFragment, AstPass};
-    use diesel::sql_types::*;
-    use diesel::internal::sql_functions::*;
+    use ::diesel::query_builder::{QueryFragment, AstPass};
+    use ::diesel::sql_types::*;
+    use ::diesel::internal::sql_functions::*;
     use super::*;
-    #[derive(Debug, Clone, Copy, diesel::query_builder::QueryId)]
-    #[derive(diesel::sql_types::DieselNumericOps)]
+    #[derive(Debug, Clone, Copy, ::diesel::query_builder::QueryId)]
+    #[derive(::diesel::sql_types::DieselNumericOps)]
     pub struct lower<input> {
         pub(super) input: input,
     }
@@ -54,7 +54,7 @@ pub(crate) mod lower_utils {
     {}
     impl<input, __DieselInternal> FunctionFragment<__DieselInternal> for lower<input>
     where
-        __DieselInternal: diesel::backend::Backend,
+        __DieselInternal: ::diesel::backend::Backend,
         input: QueryFragment<__DieselInternal>,
     {
         const FUNCTION_NAME: &'static str = "lower";
@@ -76,7 +76,7 @@ pub(crate) mod lower_utils {
     }
     impl<input, __DieselInternal> QueryFragment<__DieselInternal> for lower<input>
     where
-        __DieselInternal: diesel::backend::Backend,
+        __DieselInternal: ::diesel::backend::Backend,
         input: QueryFragment<__DieselInternal>,
     {
         fn walk_ast<'__b>(
@@ -111,20 +111,23 @@ pub(crate) mod lower_utils {
     /// instead, or [`register_impl_with_behavior`](self::register_impl_with_behavior)
     /// for full control over the SQLite behavior flags.
     pub fn register_impl<F, Ret, input>(
-        conn: &mut diesel::sqlite::SqliteConnection,
+        conn: &mut ::diesel::sqlite::SqliteConnection,
         f: F,
-    ) -> diesel::result::QueryResult<()>
+    ) -> ::diesel::result::QueryResult<()>
     where
         F: Fn(input) -> Ret + ::core::panic::UnwindSafe + Send + 'static,
         (
             input,
-        ): diesel::deserialize::FromSqlRow<(Text,), diesel::sqlite::Sqlite>
-            + diesel::deserialize::StaticallySizedRow<(Text,), diesel::sqlite::Sqlite>,
-        Ret: diesel::serialize::ToSql<Text, diesel::sqlite::Sqlite>,
+        ): ::diesel::deserialize::FromSqlRow<(Text,), ::diesel::sqlite::Sqlite>
+            + ::diesel::deserialize::StaticallySizedRow<
+                (Text,),
+                ::diesel::sqlite::Sqlite,
+            >,
+        Ret: ::diesel::serialize::ToSql<Text, ::diesel::sqlite::Sqlite>,
     {
         register_impl_with_behavior(
             conn,
-            diesel::sqlite::SqliteFunctionBehavior::DETERMINISTIC,
+            ::diesel::sqlite::SqliteFunctionBehavior::DETERMINISTIC,
             f,
         )
     }
@@ -141,20 +144,23 @@ pub(crate) mod lower_utils {
     /// the SQLite behavior flags, use
     /// [`register_impl_with_behavior`](self::register_impl_with_behavior).
     pub fn register_nondeterministic_impl<F, Ret, input>(
-        conn: &mut diesel::sqlite::SqliteConnection,
+        conn: &mut ::diesel::sqlite::SqliteConnection,
         f: F,
-    ) -> diesel::result::QueryResult<()>
+    ) -> ::diesel::result::QueryResult<()>
     where
         F: FnMut(input) -> Ret + ::core::panic::UnwindSafe + Send + 'static,
         (
             input,
-        ): diesel::deserialize::FromSqlRow<(Text,), diesel::sqlite::Sqlite>
-            + diesel::deserialize::StaticallySizedRow<(Text,), diesel::sqlite::Sqlite>,
-        Ret: diesel::serialize::ToSql<Text, diesel::sqlite::Sqlite>,
+        ): ::diesel::deserialize::FromSqlRow<(Text,), ::diesel::sqlite::Sqlite>
+            + ::diesel::deserialize::StaticallySizedRow<
+                (Text,),
+                ::diesel::sqlite::Sqlite,
+            >,
+        Ret: ::diesel::serialize::ToSql<Text, ::diesel::sqlite::Sqlite>,
     {
         register_impl_with_behavior(
             conn,
-            diesel::sqlite::SqliteFunctionBehavior::empty(),
+            ::diesel::sqlite::SqliteFunctionBehavior::empty(),
             f,
         )
     }
@@ -169,17 +175,20 @@ pub(crate) mod lower_utils {
     /// unless you need to set behavior flags explicitly. See
     /// [`SqliteFunctionBehavior`] for the available flags.
     pub fn register_impl_with_behavior<F, Ret, input>(
-        conn: &mut diesel::sqlite::SqliteConnection,
-        behavior: diesel::sqlite::SqliteFunctionBehavior,
+        conn: &mut ::diesel::sqlite::SqliteConnection,
+        behavior: ::diesel::sqlite::SqliteFunctionBehavior,
         mut f: F,
-    ) -> diesel::result::QueryResult<()>
+    ) -> ::diesel::result::QueryResult<()>
     where
         F: FnMut(input) -> Ret + ::core::panic::UnwindSafe + Send + 'static,
         (
             input,
-        ): diesel::deserialize::FromSqlRow<(Text,), diesel::sqlite::Sqlite>
-            + diesel::deserialize::StaticallySizedRow<(Text,), diesel::sqlite::Sqlite>,
-        Ret: diesel::serialize::ToSql<Text, diesel::sqlite::Sqlite>,
+        ): ::diesel::deserialize::FromSqlRow<(Text,), ::diesel::sqlite::Sqlite>
+            + ::diesel::deserialize::StaticallySizedRow<
+                (Text,),
+                ::diesel::sqlite::Sqlite,
+            >,
+        Ret: ::diesel::serialize::ToSql<Text, ::diesel::sqlite::Sqlite>,
     {
         conn.register_sql_function::<
                 (Text,),

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__define_sql_function_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__define_sql_function_1.snap
@@ -7,7 +7,7 @@ info:
 #[allow(non_camel_case_types)]
 pub fn lower<input>(input: input) -> lower<input>
 where
-    input: diesel::expression::AsExpression<Text>,
+    input: ::diesel::expression::AsExpression<Text>,
 {
     lower_utils::lower {
         input: input.as_expression(),
@@ -16,21 +16,21 @@ where
 #[allow(non_camel_case_types, non_snake_case)]
 ///The return type of [`lower()`](fn@lower)
 pub type lower<input> = lower_utils::lower<
-    <input as diesel::expression::AsExpression<Text>>::Expression,
+    <input as ::diesel::expression::AsExpression<Text>>::Expression,
 >;
 #[doc(hidden)]
 #[allow(non_camel_case_types, non_snake_case, unused_imports)]
 pub(crate) mod lower_utils {
-    use diesel::{self, QueryResult};
-    use diesel::expression::{
+    use ::diesel::QueryResult;
+    use ::diesel::expression::{
         AsExpression, Expression, SelectableExpression, AppearsOnTable, ValidGrouping,
     };
-    use diesel::query_builder::{QueryFragment, AstPass};
-    use diesel::sql_types::*;
-    use diesel::internal::sql_functions::*;
+    use ::diesel::query_builder::{QueryFragment, AstPass};
+    use ::diesel::sql_types::*;
+    use ::diesel::internal::sql_functions::*;
     use super::*;
-    #[derive(Debug, Clone, Copy, diesel::query_builder::QueryId)]
-    #[derive(diesel::sql_types::DieselNumericOps)]
+    #[derive(Debug, Clone, Copy, ::diesel::query_builder::QueryId)]
+    #[derive(::diesel::sql_types::DieselNumericOps)]
     pub struct lower<input> {
         pub(super) input: input,
     }
@@ -54,7 +54,7 @@ pub(crate) mod lower_utils {
     {}
     impl<input, __DieselInternal> FunctionFragment<__DieselInternal> for lower<input>
     where
-        __DieselInternal: diesel::backend::Backend,
+        __DieselInternal: ::diesel::backend::Backend,
         input: QueryFragment<__DieselInternal>,
     {
         const FUNCTION_NAME: &'static str = "lower";
@@ -76,7 +76,7 @@ pub(crate) mod lower_utils {
     }
     impl<input, __DieselInternal> QueryFragment<__DieselInternal> for lower<input>
     where
-        __DieselInternal: diesel::backend::Backend,
+        __DieselInternal: ::diesel::backend::Backend,
         input: QueryFragment<__DieselInternal>,
     {
         fn walk_ast<'__b>(

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__diesel_numeric_ops_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__diesel_numeric_ops_1.snap
@@ -5,7 +5,7 @@ info:
   input: "#[derive(DieselNumericOps)]\nstruct NumericColumn;\n"
 ---
 const _: () = {
-    use diesel;
+    use ::diesel;
     use diesel::internal::derives::numeric_ops as ops;
     use diesel::expression::{Expression, AsExpression};
     use diesel::sql_types::ops::{Add, Sub, Mul, Div};

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__enum_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__enum_1.snap
@@ -5,7 +5,7 @@ info:
   input: "#[derive(Enum)]\n#[derive(Debug, diesel::Enum)]\n#[diesel(sql_type = schema::sql_types::Color)]\nenum Color {\n    Red,\n    Green,\n    Blue,\n}\n"
 ---
 const _: () = {
-    use diesel;
+    use ::diesel;
     impl<__DB> diesel::deserialize::FromSql<schema::sql_types::Color, __DB> for Color
     where
         __DB: diesel::backend::Backend,

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__enum_2.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__enum_2.snap
@@ -5,7 +5,7 @@ info:
   input: "#[derive(Enum)]\n#[derive(Debug, diesel::Enum)]\n#[diesel(sql_type = diesel::sql_types::Integer)]\nenum Color {\n    Red = 1,\n    Green = 2,\n    Blue = 3,\n}\n"
 ---
 const _: () = {
-    use diesel;
+    use ::diesel;
     impl<__DB> diesel::deserialize::FromSql<diesel::sql_types::Integer, __DB> for Color
     where
         __DB: diesel::backend::Backend,

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__enum_rename_all.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__enum_rename_all.snap
@@ -5,7 +5,7 @@ info:
   input: "#[derive(Enum)]\n#[derive(Debug, diesel::Enum)]\n#[diesel(sql_type = diesel::sql_types::Text)]\n#[diesel(rename_all = \"snake_case\")]\nenum Color {\n    RedColor,\n    GreenColor,\n    BlueColor,\n}\n"
 ---
 const _: () = {
-    use diesel;
+    use ::diesel;
     impl<__DB> diesel::deserialize::FromSql<diesel::sql_types::Text, __DB> for Color
     where
         __DB: diesel::backend::Backend,

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__enum_rename_single.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__enum_rename_single.snap
@@ -5,7 +5,7 @@ info:
   input: "#[derive(Enum)]\n#[derive(Debug, diesel::Enum)]\n#[diesel(sql_type = diesel::sql_types::Text)]\nenum Color {\n    #[diesel(rename = \"ReD\")]\n    Red,\n    #[diesel(rename = \"GreeN\")]\n    Green,\n    #[diesel(rename = \"BluE\")]\n    Blue,\n}\n"
 ---
 const _: () = {
-    use diesel;
+    use ::diesel;
     impl<__DB> diesel::deserialize::FromSql<diesel::sql_types::Text, __DB> for Color
     where
         __DB: diesel::backend::Backend,

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__from_sql_row_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__from_sql_row_1.snap
@@ -5,7 +5,7 @@ info:
   input: "#[derive(FromSqlRow)]\nenum Foo {\n    Bar,\n    Baz,\n}\n"
 ---
 const _: () = {
-    use diesel;
+    use ::diesel;
     impl<__DB, __ST> diesel::deserialize::Queryable<__ST, __DB> for Foo
     where
         __DB: diesel::backend::Backend,

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__has_query_1 (mariadb).snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__has_query_1 (mariadb).snap
@@ -5,7 +5,7 @@ info:
   input: "#[derive(HasQuery)]\nstruct User {\n    id: i32,\n    name: String,\n}\n"
 ---
 const _: () = {
-    use diesel;
+    use ::diesel;
     impl<__DB: diesel::backend::Backend> diesel::HasQuery<__DB> for User {
         type BaseQuery = <users::table as diesel::query_builder::AsQuery>::Query;
         fn base_query() -> Self::BaseQuery {
@@ -14,7 +14,7 @@ const _: () = {
     }
 };
 const _: () = {
-    use diesel;
+    use ::diesel;
     use diesel::expression::Selectable;
     impl<__DB: diesel::backend::Backend> Selectable<__DB> for User {
         type SelectExpression = (users::r#id, users::r#name);
@@ -38,7 +38,7 @@ const _: () = {
     {}
 };
 const _: () = {
-    use diesel;
+    use ::diesel;
     use diesel::row::{Row as _, Field as _};
     impl<
         __DB: diesel::backend::Backend,

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__has_query_1 (mysql).snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__has_query_1 (mysql).snap
@@ -5,7 +5,7 @@ info:
   input: "#[derive(HasQuery)]\nstruct User {\n    id: i32,\n    name: String,\n}\n"
 ---
 const _: () = {
-    use diesel;
+    use ::diesel;
     impl<__DB: diesel::backend::Backend> diesel::HasQuery<__DB> for User {
         type BaseQuery = <users::table as diesel::query_builder::AsQuery>::Query;
         fn base_query() -> Self::BaseQuery {
@@ -14,7 +14,7 @@ const _: () = {
     }
 };
 const _: () = {
-    use diesel;
+    use ::diesel;
     use diesel::expression::Selectable;
     impl<__DB: diesel::backend::Backend> Selectable<__DB> for User {
         type SelectExpression = (users::r#id, users::r#name);
@@ -38,7 +38,7 @@ const _: () = {
 
 };
 const _: () = {
-    use diesel;
+    use ::diesel;
     use diesel::row::{Row as _, Field as _};
     impl<
         __DB: diesel::backend::Backend,

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__has_query_1 (postgres).snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__has_query_1 (postgres).snap
@@ -5,7 +5,7 @@ info:
   input: "#[derive(HasQuery)]\nstruct User {\n    id: i32,\n    name: String,\n}\n"
 ---
 const _: () = {
-    use diesel;
+    use ::diesel;
     impl<__DB: diesel::backend::Backend> diesel::HasQuery<__DB> for User {
         type BaseQuery = <users::table as diesel::query_builder::AsQuery>::Query;
         fn base_query() -> Self::BaseQuery {
@@ -14,7 +14,7 @@ const _: () = {
     }
 };
 const _: () = {
-    use diesel;
+    use ::diesel;
     use diesel::expression::Selectable;
     impl<__DB: diesel::backend::Backend> Selectable<__DB> for User {
         type SelectExpression = (users::r#id, users::r#name);
@@ -38,7 +38,7 @@ const _: () = {
 
 };
 const _: () = {
-    use diesel;
+    use ::diesel;
     use diesel::row::{Row as _, Field as _};
     impl<
         __DB: diesel::backend::Backend,

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__has_query_1 (sqlite).snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__has_query_1 (sqlite).snap
@@ -5,7 +5,7 @@ info:
   input: "#[derive(HasQuery)]\nstruct User {\n    id: i32,\n    name: String,\n}\n"
 ---
 const _: () = {
-    use diesel;
+    use ::diesel;
     impl<__DB: diesel::backend::Backend> diesel::HasQuery<__DB> for User {
         type BaseQuery = <users::table as diesel::query_builder::AsQuery>::Query;
         fn base_query() -> Self::BaseQuery {
@@ -14,7 +14,7 @@ const _: () = {
     }
 };
 const _: () = {
-    use diesel;
+    use ::diesel;
     use diesel::expression::Selectable;
     impl<__DB: diesel::backend::Backend> Selectable<__DB> for User {
         type SelectExpression = (users::r#id, users::r#name);
@@ -38,7 +38,7 @@ const _: () = {
 
 };
 const _: () = {
-    use diesel;
+    use ::diesel;
     use diesel::row::{Row as _, Field as _};
     impl<
         __DB: diesel::backend::Backend,

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__identifiable_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__identifiable_1.snap
@@ -5,7 +5,7 @@ info:
   input: "#[derive(Identifiable)]\nstruct User {\n    id: i32,\n    name: String,\n}\n"
 ---
 const _: () = {
-    use diesel;
+    use ::diesel;
     impl diesel::associations::HasTable for User {
         type Table = users::table;
         fn table() -> <Self as diesel::associations::HasTable>::Table {

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__identifiable_column_name_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__identifiable_column_name_1.snap
@@ -5,7 +5,7 @@ info:
   input: "#[derive(Identifiable)]\n#[diesel(primary_key(user_id))]\nstruct User {\n    #[diesel(column_name = user_id)]\n    id: i32,\n    name: String,\n}\n"
 ---
 const _: () = {
-    use diesel;
+    use ::diesel;
     impl diesel::associations::HasTable for User {
         type Table = users::table;
         fn table() -> <Self as diesel::associations::HasTable>::Table {

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__identifiable_primary_key_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__identifiable_primary_key_1.snap
@@ -5,7 +5,7 @@ info:
   input: "#[derive(Identifiable)]\n#[diesel(primary_key(id, short_code))]\nstruct User {\n    id: i32,\n    short_code: String,\n    name: String,\n}\n"
 ---
 const _: () = {
-    use diesel;
+    use ::diesel;
     impl diesel::associations::HasTable for User {
         type Table = users::table;
         fn table() -> <Self as diesel::associations::HasTable>::Table {

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__identifiable_table_name_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__identifiable_table_name_1.snap
@@ -5,7 +5,7 @@ info:
   input: "#[derive(Identifiable)]\n#[diesel(table_name = crate::schema::admin_users)]\nstruct User {\n    id: i32,\n    name: String,\n}\n"
 ---
 const _: () = {
-    use diesel;
+    use ::diesel;
     impl diesel::associations::HasTable for User {
         type Table = crate::schema::admin_users::table;
         fn table() -> <Self as diesel::associations::HasTable>::Table {

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__insertable_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__insertable_1.snap
@@ -5,7 +5,7 @@ info:
   input: "#[derive(Insertable)]\nstruct User {\n    id: i32,\n    name: String,\n}\n"
 ---
 const _: () = {
-    use diesel;
+    use ::diesel;
     impl diesel::insertable::Insertable<users::table> for User
     where
         i32: diesel::expression::AsExpression<

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__insertable_table_name_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__insertable_table_name_1.snap
@@ -5,7 +5,7 @@ info:
   input: "#[derive(Insertable)]\n#[diesel(table_name = crate::schema::admin_users)]\nstruct User {\n    id: i32,\n    name: String,\n}\n"
 ---
 const _: () = {
-    use diesel;
+    use ::diesel;
     impl diesel::insertable::Insertable<crate::schema::admin_users::table> for User
     where
         i32: diesel::expression::AsExpression<

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__multiconnection_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__multiconnection_1.snap
@@ -9,15 +9,15 @@ mod multi_connection_impl {
     mod backend {
         use super::*;
         pub enum MultiBackend {
-            Pg(<PgConnection as diesel::connection::Connection>::Backend),
+            Pg(<PgConnection as ::diesel::connection::Connection>::Backend),
             Sqlite(
-                <diesel::SqliteConnection as diesel::connection::Connection>::Backend,
+                <diesel::SqliteConnection as ::diesel::connection::Connection>::Backend,
             ),
         }
         impl MultiBackend {
             pub(super) fn pg(
                 &self,
-            ) -> &<PgConnection as diesel::connection::Connection>::Backend {
+            ) -> &<PgConnection as ::diesel::connection::Connection>::Backend {
                 match self {
                     Self::Pg(b) => b,
                     _ => unreachable!(),
@@ -25,7 +25,7 @@ mod multi_connection_impl {
             }
             pub(super) fn sqlite(
                 &self,
-            ) -> &<diesel::SqliteConnection as diesel::connection::Connection>::Backend {
+            ) -> &<diesel::SqliteConnection as ::diesel::connection::Connection>::Backend {
                 match self {
                     Self::Sqlite(b) => b,
                     _ => unreachable!(),
@@ -35,28 +35,28 @@ mod multi_connection_impl {
                 lookup: &mut dyn std::any::Any,
             ) -> MultiTypeMetadata
             where
-                <PgConnection as diesel::connection::Connection>::Backend: diesel::sql_types::HasSqlType<
+                <PgConnection as ::diesel::connection::Connection>::Backend: ::diesel::sql_types::HasSqlType<
                     ST,
                 >,
-                <diesel::SqliteConnection as diesel::connection::Connection>::Backend: diesel::sql_types::HasSqlType<
+                <diesel::SqliteConnection as ::diesel::connection::Connection>::Backend: ::diesel::sql_types::HasSqlType<
                     ST,
                 >,
             {
                 let mut ret = MultiTypeMetadata::default();
-                if let Some(lookup) = <PgConnection as diesel::internal::derives::multiconnection::MultiConnectionHelper>::from_any(
+                if let Some(lookup) = <PgConnection as ::diesel::internal::derives::multiconnection::MultiConnectionHelper>::from_any(
                     lookup,
                 ) {
                     ret.Pg = Some(
-                        <<PgConnection as diesel::connection::Connection>::Backend as diesel::sql_types::HasSqlType<
+                        <<PgConnection as ::diesel::connection::Connection>::Backend as ::diesel::sql_types::HasSqlType<
                             ST,
                         >>::metadata(lookup),
                     );
                 }
-                if let Some(lookup) = <diesel::SqliteConnection as diesel::internal::derives::multiconnection::MultiConnectionHelper>::from_any(
+                if let Some(lookup) = <diesel::SqliteConnection as ::diesel::internal::derives::multiconnection::MultiConnectionHelper>::from_any(
                     lookup,
                 ) {
                     ret.Sqlite = Some(
-                        <<diesel::SqliteConnection as diesel::connection::Connection>::Backend as diesel::sql_types::HasSqlType<
+                        <<diesel::SqliteConnection as ::diesel::connection::Connection>::Backend as ::diesel::sql_types::HasSqlType<
                             ST,
                         >>::metadata(lookup),
                     );
@@ -67,21 +67,21 @@ mod multi_connection_impl {
         impl MultiBackend {
             pub fn walk_variant_ast<'b, T>(
                 ast_node: &'b T,
-                pass: diesel::query_builder::AstPass<'_, 'b, Self>,
-            ) -> diesel::QueryResult<()>
+                pass: ::diesel::query_builder::AstPass<'_, 'b, Self>,
+            ) -> ::diesel::QueryResult<()>
             where
-                T: diesel::query_builder::QueryFragment<
-                    <PgConnection as diesel::connection::Connection>::Backend,
+                T: ::diesel::query_builder::QueryFragment<
+                    <PgConnection as ::diesel::connection::Connection>::Backend,
                 >,
-                T: diesel::query_builder::QueryFragment<
-                    <diesel::SqliteConnection as diesel::connection::Connection>::Backend,
+                T: ::diesel::query_builder::QueryFragment<
+                    <diesel::SqliteConnection as ::diesel::connection::Connection>::Backend,
                 >,
             {
-                use diesel::internal::derives::multiconnection::AstPassHelper;
+                use ::diesel::internal::derives::multiconnection::AstPassHelper;
                 match pass.backend() {
                     super::backend::MultiBackend::Pg(_) => {
-                        <T as diesel::query_builder::QueryFragment<
-                            <PgConnection as diesel::connection::Connection>::Backend,
+                        <T as ::diesel::query_builder::QueryFragment<
+                            <PgConnection as ::diesel::connection::Connection>::Backend,
                         >>::walk_ast(
                             ast_node,
                             pass
@@ -90,7 +90,7 @@ mod multi_connection_impl {
                                     super::query_builder::MultiQueryBuilder::pg,
                                     super::backend::MultiBackend::pg,
                                     |l| {
-                                        <PgConnection as diesel::internal::derives::multiconnection::MultiConnectionHelper>::from_any(
+                                        <PgConnection as ::diesel::internal::derives::multiconnection::MultiConnectionHelper>::from_any(
                                                 l,
                                             )
                                             .expect(
@@ -101,8 +101,8 @@ mod multi_connection_impl {
                         )
                     }
                     super::backend::MultiBackend::Sqlite(_) => {
-                        <T as diesel::query_builder::QueryFragment<
-                            <diesel::SqliteConnection as diesel::connection::Connection>::Backend,
+                        <T as ::diesel::query_builder::QueryFragment<
+                            <diesel::SqliteConnection as ::diesel::connection::Connection>::Backend,
                         >>::walk_ast(
                             ast_node,
                             pass
@@ -111,7 +111,7 @@ mod multi_connection_impl {
                                     super::query_builder::MultiQueryBuilder::sqlite,
                                     super::backend::MultiBackend::sqlite,
                                     |l| {
-                                        <diesel::SqliteConnection as diesel::internal::derives::multiconnection::MultiConnectionHelper>::from_any(
+                                        <diesel::SqliteConnection as ::diesel::internal::derives::multiconnection::MultiConnectionHelper>::from_any(
                                                 l,
                                             )
                                             .expect(
@@ -126,45 +126,45 @@ mod multi_connection_impl {
         }
         pub enum MultiRawValue<'a> {
             Pg(
-                <<PgConnection as diesel::connection::Connection>::Backend as diesel::backend::Backend>::RawValue<
+                <<PgConnection as ::diesel::connection::Connection>::Backend as ::diesel::backend::Backend>::RawValue<
                     'a,
                 >,
             ),
             Sqlite(
-                <<diesel::SqliteConnection as diesel::connection::Connection>::Backend as diesel::backend::Backend>::RawValue<
+                <<diesel::SqliteConnection as ::diesel::connection::Connection>::Backend as ::diesel::backend::Backend>::RawValue<
                     'a,
                 >,
             ),
         }
         impl MultiRawValue<'_> {
-            pub fn from_sql<T, ST>(self) -> diesel::deserialize::Result<T>
+            pub fn from_sql<T, ST>(self) -> ::diesel::deserialize::Result<T>
             where
-                T: diesel::deserialize::FromSql<
+                T: ::diesel::deserialize::FromSql<
                     ST,
-                    <PgConnection as diesel::connection::Connection>::Backend,
+                    <PgConnection as ::diesel::connection::Connection>::Backend,
                 >,
-                T: diesel::deserialize::FromSql<
+                T: ::diesel::deserialize::FromSql<
                     ST,
-                    <diesel::SqliteConnection as diesel::connection::Connection>::Backend,
+                    <diesel::SqliteConnection as ::diesel::connection::Connection>::Backend,
                 >,
             {
                 match self {
                     Self::Pg(b) => {
-                        <T as diesel::deserialize::FromSql<
+                        <T as ::diesel::deserialize::FromSql<
                             ST,
-                            <PgConnection as diesel::connection::Connection>::Backend,
+                            <PgConnection as ::diesel::connection::Connection>::Backend,
                         >>::from_sql(b)
                     }
                     Self::Sqlite(b) => {
-                        <T as diesel::deserialize::FromSql<
+                        <T as ::diesel::deserialize::FromSql<
                             ST,
-                            <diesel::SqliteConnection as diesel::connection::Connection>::Backend,
+                            <diesel::SqliteConnection as ::diesel::connection::Connection>::Backend,
                         >>::from_sql(b)
                     }
                 }
             }
         }
-        impl diesel::backend::Backend for MultiBackend {
+        impl ::diesel::backend::Backend for MultiBackend {
             type QueryBuilder = super::query_builder::MultiQueryBuilder;
             type RawValue<'a> = MultiRawValue<'a>;
             type BindCollector<'a> = super::bind_collector::MultiBindCollector<'a>;
@@ -173,13 +173,13 @@ mod multi_connection_impl {
         #[allow(non_snake_case)]
         pub struct MultiTypeMetadata {
             pub(super) Pg: Option<
-                <<PgConnection as diesel::connection::Connection>::Backend as diesel::sql_types::TypeMetadata>::TypeMetadata,
+                <<PgConnection as ::diesel::connection::Connection>::Backend as ::diesel::sql_types::TypeMetadata>::TypeMetadata,
             >,
             pub(super) Sqlite: Option<
-                <<diesel::SqliteConnection as diesel::connection::Connection>::Backend as diesel::sql_types::TypeMetadata>::TypeMetadata,
+                <<diesel::SqliteConnection as ::diesel::connection::Connection>::Backend as ::diesel::sql_types::TypeMetadata>::TypeMetadata,
             >,
         }
-        impl diesel::sql_types::TypeMetadata for MultiBackend {
+        impl ::diesel::sql_types::TypeMetadata for MultiBackend {
             type TypeMetadata = MultiTypeMetadata;
             type MetadataLookup = dyn std::any::Any;
         }
@@ -198,9 +198,9 @@ mod multi_connection_impl {
         pub struct MultiWindowFrameExclusionSupport;
         pub struct MultiAggregateFunctionExpressions;
         pub struct MultiBuiltInWindowFunctionRequireOrder;
-        impl diesel::backend::SqlDialect for MultiBackend {
+        impl ::diesel::backend::SqlDialect for MultiBackend {
             type ReturningClause = MultiReturningClause;
-            type OnConflictClause = diesel::internal::derives::multiconnection::sql_dialect::on_conflict_clause::DoesNotSupportOnConflictClause;
+            type OnConflictClause = ::diesel::internal::derives::multiconnection::sql_dialect::on_conflict_clause::DoesNotSupportOnConflictClause;
             type InsertWithDefaultKeyword = MultiInsertWithDefaultKeyword;
             type BatchInsertSupport = MultiBatchInsertSupport;
             type BatchUpdateSupport = MultiBatchUpdateSupport;
@@ -216,80 +216,80 @@ mod multi_connection_impl {
             type AggregateFunctionExpressions = MultiAggregateFunctionExpressions;
             type BuiltInWindowFunctionRequireOrder = MultiBuiltInWindowFunctionRequireOrder;
         }
-        impl diesel::internal::derives::multiconnection::TrustedBackend
+        impl ::diesel::internal::derives::multiconnection::TrustedBackend
         for MultiBackend {}
-        impl diesel::internal::derives::multiconnection::DieselReserveSpecialization
+        impl ::diesel::internal::derives::multiconnection::DieselReserveSpecialization
         for MultiBackend {}
-        impl diesel::sql_types::HasSqlType<diesel::sql_types::SmallInt>
+        impl ::diesel::sql_types::HasSqlType<::diesel::sql_types::SmallInt>
         for super::MultiBackend {
             fn metadata(lookup: &mut Self::MetadataLookup) -> Self::TypeMetadata {
-                Self::lookup_sql_type::<diesel::sql_types::SmallInt>(lookup)
+                Self::lookup_sql_type::<::diesel::sql_types::SmallInt>(lookup)
             }
         }
-        impl diesel::sql_types::HasSqlType<diesel::sql_types::Integer>
+        impl ::diesel::sql_types::HasSqlType<::diesel::sql_types::Integer>
         for super::MultiBackend {
             fn metadata(lookup: &mut Self::MetadataLookup) -> Self::TypeMetadata {
-                Self::lookup_sql_type::<diesel::sql_types::Integer>(lookup)
+                Self::lookup_sql_type::<::diesel::sql_types::Integer>(lookup)
             }
         }
-        impl diesel::sql_types::HasSqlType<diesel::sql_types::BigInt>
+        impl ::diesel::sql_types::HasSqlType<::diesel::sql_types::BigInt>
         for super::MultiBackend {
             fn metadata(lookup: &mut Self::MetadataLookup) -> Self::TypeMetadata {
-                Self::lookup_sql_type::<diesel::sql_types::BigInt>(lookup)
+                Self::lookup_sql_type::<::diesel::sql_types::BigInt>(lookup)
             }
         }
-        impl diesel::sql_types::HasSqlType<diesel::sql_types::Double>
+        impl ::diesel::sql_types::HasSqlType<::diesel::sql_types::Double>
         for super::MultiBackend {
             fn metadata(lookup: &mut Self::MetadataLookup) -> Self::TypeMetadata {
-                Self::lookup_sql_type::<diesel::sql_types::Double>(lookup)
+                Self::lookup_sql_type::<::diesel::sql_types::Double>(lookup)
             }
         }
-        impl diesel::sql_types::HasSqlType<diesel::sql_types::Float>
+        impl ::diesel::sql_types::HasSqlType<::diesel::sql_types::Float>
         for super::MultiBackend {
             fn metadata(lookup: &mut Self::MetadataLookup) -> Self::TypeMetadata {
-                Self::lookup_sql_type::<diesel::sql_types::Float>(lookup)
+                Self::lookup_sql_type::<::diesel::sql_types::Float>(lookup)
             }
         }
-        impl diesel::sql_types::HasSqlType<diesel::sql_types::Text>
+        impl ::diesel::sql_types::HasSqlType<::diesel::sql_types::Text>
         for super::MultiBackend {
             fn metadata(lookup: &mut Self::MetadataLookup) -> Self::TypeMetadata {
-                Self::lookup_sql_type::<diesel::sql_types::Text>(lookup)
+                Self::lookup_sql_type::<::diesel::sql_types::Text>(lookup)
             }
         }
-        impl diesel::sql_types::HasSqlType<diesel::sql_types::Binary>
+        impl ::diesel::sql_types::HasSqlType<::diesel::sql_types::Binary>
         for super::MultiBackend {
             fn metadata(lookup: &mut Self::MetadataLookup) -> Self::TypeMetadata {
-                Self::lookup_sql_type::<diesel::sql_types::Binary>(lookup)
+                Self::lookup_sql_type::<::diesel::sql_types::Binary>(lookup)
             }
         }
-        impl diesel::sql_types::HasSqlType<diesel::sql_types::Date>
+        impl ::diesel::sql_types::HasSqlType<::diesel::sql_types::Date>
         for super::MultiBackend {
             fn metadata(lookup: &mut Self::MetadataLookup) -> Self::TypeMetadata {
-                Self::lookup_sql_type::<diesel::sql_types::Date>(lookup)
+                Self::lookup_sql_type::<::diesel::sql_types::Date>(lookup)
             }
         }
-        impl diesel::sql_types::HasSqlType<diesel::sql_types::Time>
+        impl ::diesel::sql_types::HasSqlType<::diesel::sql_types::Time>
         for super::MultiBackend {
             fn metadata(lookup: &mut Self::MetadataLookup) -> Self::TypeMetadata {
-                Self::lookup_sql_type::<diesel::sql_types::Time>(lookup)
+                Self::lookup_sql_type::<::diesel::sql_types::Time>(lookup)
             }
         }
-        impl diesel::sql_types::HasSqlType<diesel::sql_types::Timestamp>
+        impl ::diesel::sql_types::HasSqlType<::diesel::sql_types::Timestamp>
         for super::MultiBackend {
             fn metadata(lookup: &mut Self::MetadataLookup) -> Self::TypeMetadata {
-                Self::lookup_sql_type::<diesel::sql_types::Timestamp>(lookup)
+                Self::lookup_sql_type::<::diesel::sql_types::Timestamp>(lookup)
             }
         }
-        impl diesel::sql_types::HasSqlType<diesel::sql_types::Bool>
+        impl ::diesel::sql_types::HasSqlType<::diesel::sql_types::Bool>
         for super::MultiBackend {
             fn metadata(lookup: &mut Self::MetadataLookup) -> Self::TypeMetadata {
-                Self::lookup_sql_type::<diesel::sql_types::Bool>(lookup)
+                Self::lookup_sql_type::<::diesel::sql_types::Bool>(lookup)
             }
         }
-        impl diesel::sql_types::HasSqlType<diesel::sql_types::Numeric>
+        impl ::diesel::sql_types::HasSqlType<::diesel::sql_types::Numeric>
         for super::MultiBackend {
             fn metadata(lookup: &mut Self::MetadataLookup) -> Self::TypeMetadata {
-                Self::lookup_sql_type::<diesel::sql_types::Numeric>(lookup)
+                Self::lookup_sql_type::<::diesel::sql_types::Numeric>(lookup)
             }
         }
     }
@@ -297,10 +297,10 @@ mod multi_connection_impl {
         use super::*;
         pub enum MultiQueryBuilder {
             Pg(
-                <<PgConnection as diesel::connection::Connection>::Backend as diesel::backend::Backend>::QueryBuilder,
+                <<PgConnection as ::diesel::connection::Connection>::Backend as ::diesel::backend::Backend>::QueryBuilder,
             ),
             Sqlite(
-                <<diesel::SqliteConnection as diesel::connection::Connection>::Backend as diesel::backend::Backend>::QueryBuilder,
+                <<diesel::SqliteConnection as ::diesel::connection::Connection>::Backend as ::diesel::backend::Backend>::QueryBuilder,
             ),
         }
         impl MultiQueryBuilder {
@@ -314,7 +314,7 @@ mod multi_connection_impl {
         impl MultiQueryBuilder {
             pub(super) fn pg(
                 &mut self,
-            ) -> &mut <<PgConnection as diesel::connection::Connection>::Backend as diesel::backend::Backend>::QueryBuilder {
+            ) -> &mut <<PgConnection as ::diesel::connection::Connection>::Backend as ::diesel::backend::Backend>::QueryBuilder {
                 match self {
                     Self::Pg(qb) => qb,
                     _ => unreachable!(),
@@ -322,14 +322,14 @@ mod multi_connection_impl {
             }
             pub(super) fn sqlite(
                 &mut self,
-            ) -> &mut <<diesel::SqliteConnection as diesel::connection::Connection>::Backend as diesel::backend::Backend>::QueryBuilder {
+            ) -> &mut <<diesel::SqliteConnection as ::diesel::connection::Connection>::Backend as ::diesel::backend::Backend>::QueryBuilder {
                 match self {
                     Self::Sqlite(qb) => qb,
                     _ => unreachable!(),
                 }
             }
         }
-        impl diesel::query_builder::QueryBuilder<super::MultiBackend>
+        impl ::diesel::query_builder::QueryBuilder<super::MultiBackend>
         for MultiQueryBuilder {
             fn push_sql(&mut self, sql: &str) {
                 match self {
@@ -337,7 +337,10 @@ mod multi_connection_impl {
                     Self::Sqlite(q) => q.push_sql(sql),
                 }
             }
-            fn push_identifier(&mut self, identifier: &str) -> diesel::QueryResult<()> {
+            fn push_identifier(
+                &mut self,
+                identifier: &str,
+            ) -> ::diesel::QueryResult<()> {
                 match self {
                     Self::Pg(q) => q.push_identifier(identifier),
                     Self::Sqlite(q) => q.push_identifier(identifier),
@@ -356,209 +359,209 @@ mod multi_connection_impl {
                 }
             }
         }
-        impl<L, O> diesel::query_builder::QueryFragment<super::backend::MultiBackend>
-        for diesel::internal::derives::multiconnection::LimitOffsetClause<L, O>
+        impl<L, O> ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>
+        for ::diesel::internal::derives::multiconnection::LimitOffsetClause<L, O>
         where
-            Self: diesel::query_builder::QueryFragment<
-                    <PgConnection as diesel::connection::Connection>::Backend,
+            Self: ::diesel::query_builder::QueryFragment<
+                    <PgConnection as ::diesel::connection::Connection>::Backend,
                 >
-                + diesel::query_builder::QueryFragment<
-                    <diesel::SqliteConnection as diesel::connection::Connection>::Backend,
+                + ::diesel::query_builder::QueryFragment<
+                    <diesel::SqliteConnection as ::diesel::connection::Connection>::Backend,
                 >,
         {
             fn walk_ast<'b>(
                 &'b self,
-                pass: diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
-            ) -> diesel::QueryResult<()> {
+                pass: ::diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
+            ) -> ::diesel::QueryResult<()> {
                 super::backend::MultiBackend::walk_variant_ast(self, pass)
             }
         }
         impl<
             L,
             R,
-        > diesel::query_builder::QueryFragment<
+        > ::diesel::query_builder::QueryFragment<
             super::backend::MultiBackend,
             super::backend::MultiConcatClauseSyntax,
-        > for diesel::internal::derives::multiconnection::Concat<L, R>
+        > for ::diesel::internal::derives::multiconnection::Concat<L, R>
         where
-            Self: diesel::query_builder::QueryFragment<
-                    <PgConnection as diesel::connection::Connection>::Backend,
+            Self: ::diesel::query_builder::QueryFragment<
+                    <PgConnection as ::diesel::connection::Connection>::Backend,
                 >
-                + diesel::query_builder::QueryFragment<
-                    <diesel::SqliteConnection as diesel::connection::Connection>::Backend,
+                + ::diesel::query_builder::QueryFragment<
+                    <diesel::SqliteConnection as ::diesel::connection::Connection>::Backend,
                 >,
         {
             fn walk_ast<'b>(
                 &'b self,
-                pass: diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
-            ) -> diesel::QueryResult<()> {
+                pass: ::diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
+            ) -> ::diesel::QueryResult<()> {
                 super::backend::MultiBackend::walk_variant_ast(self, pass)
             }
         }
         impl<
             T,
             U,
-        > diesel::query_builder::QueryFragment<
+        > ::diesel::query_builder::QueryFragment<
             super::backend::MultiBackend,
             super::backend::MultiArrayComparisonSyntax,
-        > for diesel::internal::derives::multiconnection::array_comparison::In<T, U>
+        > for ::diesel::internal::derives::multiconnection::array_comparison::In<T, U>
         where
-            Self: diesel::query_builder::QueryFragment<
-                    <PgConnection as diesel::connection::Connection>::Backend,
+            Self: ::diesel::query_builder::QueryFragment<
+                    <PgConnection as ::diesel::connection::Connection>::Backend,
                 >
-                + diesel::query_builder::QueryFragment<
-                    <diesel::SqliteConnection as diesel::connection::Connection>::Backend,
+                + ::diesel::query_builder::QueryFragment<
+                    <diesel::SqliteConnection as ::diesel::connection::Connection>::Backend,
                 >,
         {
             fn walk_ast<'b>(
                 &'b self,
-                pass: diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
-            ) -> diesel::QueryResult<()> {
+                pass: ::diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
+            ) -> ::diesel::QueryResult<()> {
                 super::backend::MultiBackend::walk_variant_ast(self, pass)
             }
         }
         impl<
             T,
             U,
-        > diesel::query_builder::QueryFragment<
+        > ::diesel::query_builder::QueryFragment<
             super::backend::MultiBackend,
             super::backend::MultiArrayComparisonSyntax,
-        > for diesel::internal::derives::multiconnection::array_comparison::NotIn<T, U>
+        > for ::diesel::internal::derives::multiconnection::array_comparison::NotIn<T, U>
         where
-            Self: diesel::query_builder::QueryFragment<
-                    <PgConnection as diesel::connection::Connection>::Backend,
+            Self: ::diesel::query_builder::QueryFragment<
+                    <PgConnection as ::diesel::connection::Connection>::Backend,
                 >
-                + diesel::query_builder::QueryFragment<
-                    <diesel::SqliteConnection as diesel::connection::Connection>::Backend,
+                + ::diesel::query_builder::QueryFragment<
+                    <diesel::SqliteConnection as ::diesel::connection::Connection>::Backend,
                 >,
         {
             fn walk_ast<'b>(
                 &'b self,
-                pass: diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
-            ) -> diesel::QueryResult<()> {
+                pass: ::diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
+            ) -> ::diesel::QueryResult<()> {
                 super::backend::MultiBackend::walk_variant_ast(self, pass)
             }
         }
         impl<
             ST,
             I,
-        > diesel::query_builder::QueryFragment<
+        > ::diesel::query_builder::QueryFragment<
             super::backend::MultiBackend,
             super::backend::MultiArrayComparisonSyntax,
-        > for diesel::internal::derives::multiconnection::array_comparison::Many<ST, I>
+        > for ::diesel::internal::derives::multiconnection::array_comparison::Many<ST, I>
         where
-            Self: diesel::query_builder::QueryFragment<
-                    <PgConnection as diesel::connection::Connection>::Backend,
+            Self: ::diesel::query_builder::QueryFragment<
+                    <PgConnection as ::diesel::connection::Connection>::Backend,
                 >
-                + diesel::query_builder::QueryFragment<
-                    <diesel::SqliteConnection as diesel::connection::Connection>::Backend,
+                + ::diesel::query_builder::QueryFragment<
+                    <diesel::SqliteConnection as ::diesel::connection::Connection>::Backend,
                 >,
         {
             fn walk_ast<'b>(
                 &'b self,
-                pass: diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
-            ) -> diesel::QueryResult<()> {
+                pass: ::diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
+            ) -> ::diesel::QueryResult<()> {
                 super::backend::MultiBackend::walk_variant_ast(self, pass)
             }
         }
         impl<
             T,
-        > diesel::query_builder::QueryFragment<
+        > ::diesel::query_builder::QueryFragment<
             super::backend::MultiBackend,
             super::backend::MultiExistsSyntax,
-        > for diesel::internal::derives::multiconnection::Exists<T>
+        > for ::diesel::internal::derives::multiconnection::Exists<T>
         where
-            Self: diesel::query_builder::QueryFragment<
-                    <PgConnection as diesel::connection::Connection>::Backend,
+            Self: ::diesel::query_builder::QueryFragment<
+                    <PgConnection as ::diesel::connection::Connection>::Backend,
                 >
-                + diesel::query_builder::QueryFragment<
-                    <diesel::SqliteConnection as diesel::connection::Connection>::Backend,
+                + ::diesel::query_builder::QueryFragment<
+                    <diesel::SqliteConnection as ::diesel::connection::Connection>::Backend,
                 >,
         {
             fn walk_ast<'b>(
                 &'b self,
-                pass: diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
-            ) -> diesel::QueryResult<()> {
+                pass: ::diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
+            ) -> ::diesel::QueryResult<()> {
                 super::backend::MultiBackend::walk_variant_ast(self, pass)
             }
         }
-        impl diesel::query_builder::QueryFragment<
+        impl ::diesel::query_builder::QueryFragment<
             super::backend::MultiBackend,
             super::backend::MultiEmptyFromClauseSyntax,
-        > for diesel::internal::derives::multiconnection::NoFromClause
+        > for ::diesel::internal::derives::multiconnection::NoFromClause
         where
-            Self: diesel::query_builder::QueryFragment<
-                    <PgConnection as diesel::connection::Connection>::Backend,
+            Self: ::diesel::query_builder::QueryFragment<
+                    <PgConnection as ::diesel::connection::Connection>::Backend,
                 >
-                + diesel::query_builder::QueryFragment<
-                    <diesel::SqliteConnection as diesel::connection::Connection>::Backend,
+                + ::diesel::query_builder::QueryFragment<
+                    <diesel::SqliteConnection as ::diesel::connection::Connection>::Backend,
                 >,
         {
             fn walk_ast<'b>(
                 &'b self,
-                pass: diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
-            ) -> diesel::QueryResult<()> {
+                pass: ::diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
+            ) -> ::diesel::QueryResult<()> {
                 super::backend::MultiBackend::walk_variant_ast(self, pass)
             }
         }
-        impl diesel::query_builder::QueryFragment<
+        impl ::diesel::query_builder::QueryFragment<
             super::backend::MultiBackend,
             super::backend::MultiDefaultValueClauseForInsert,
-        > for diesel::internal::derives::multiconnection::DefaultValues
+        > for ::diesel::internal::derives::multiconnection::DefaultValues
         where
-            Self: diesel::query_builder::QueryFragment<
-                    <PgConnection as diesel::connection::Connection>::Backend,
+            Self: ::diesel::query_builder::QueryFragment<
+                    <PgConnection as ::diesel::connection::Connection>::Backend,
                 >
-                + diesel::query_builder::QueryFragment<
-                    <diesel::SqliteConnection as diesel::connection::Connection>::Backend,
+                + ::diesel::query_builder::QueryFragment<
+                    <diesel::SqliteConnection as ::diesel::connection::Connection>::Backend,
                 >,
         {
             fn walk_ast<'b>(
                 &'b self,
-                pass: diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
-            ) -> diesel::QueryResult<()> {
+                pass: ::diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
+            ) -> ::diesel::QueryResult<()> {
                 super::backend::MultiBackend::walk_variant_ast(self, pass)
             }
         }
         impl<
             Expr,
-        > diesel::query_builder::QueryFragment<
+        > ::diesel::query_builder::QueryFragment<
             super::backend::MultiBackend,
             super::backend::MultiReturningClause,
-        > for diesel::internal::derives::multiconnection::ReturningClause<Expr>
+        > for ::diesel::internal::derives::multiconnection::ReturningClause<Expr>
         where
-            Self: diesel::query_builder::QueryFragment<
-                    <PgConnection as diesel::connection::Connection>::Backend,
+            Self: ::diesel::query_builder::QueryFragment<
+                    <PgConnection as ::diesel::connection::Connection>::Backend,
                 >
-                + diesel::query_builder::QueryFragment<
-                    <diesel::SqliteConnection as diesel::connection::Connection>::Backend,
+                + ::diesel::query_builder::QueryFragment<
+                    <diesel::SqliteConnection as ::diesel::connection::Connection>::Backend,
                 >,
         {
             fn walk_ast<'b>(
                 &'b self,
-                pass: diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
-            ) -> diesel::QueryResult<()> {
+                pass: ::diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
+            ) -> ::diesel::QueryResult<()> {
                 super::backend::MultiBackend::walk_variant_ast(self, pass)
             }
         }
         impl<
             Expr,
-        > diesel::query_builder::QueryFragment<
+        > ::diesel::query_builder::QueryFragment<
             super::backend::MultiBackend,
             super::backend::MultiInsertWithDefaultKeyword,
-        > for diesel::insertable::DefaultableColumnInsertValue<Expr>
+        > for ::diesel::insertable::DefaultableColumnInsertValue<Expr>
         where
-            Self: diesel::query_builder::QueryFragment<
-                    <PgConnection as diesel::connection::Connection>::Backend,
+            Self: ::diesel::query_builder::QueryFragment<
+                    <PgConnection as ::diesel::connection::Connection>::Backend,
                 >
-                + diesel::query_builder::QueryFragment<
-                    <diesel::SqliteConnection as diesel::connection::Connection>::Backend,
+                + ::diesel::query_builder::QueryFragment<
+                    <diesel::SqliteConnection as ::diesel::connection::Connection>::Backend,
                 >,
         {
             fn walk_ast<'b>(
                 &'b self,
-                pass: diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
-            ) -> diesel::QueryResult<()> {
+                pass: ::diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
+            ) -> ::diesel::QueryResult<()> {
                 super::backend::MultiBackend::walk_variant_ast(self, pass)
             }
         }
@@ -567,28 +570,28 @@ mod multi_connection_impl {
             V,
             QId,
             const HAS_STATIC_QUERY_ID: bool,
-        > diesel::query_builder::QueryFragment<
+        > ::diesel::query_builder::QueryFragment<
             super::backend::MultiBackend,
             super::backend::MultiBatchInsertSupport,
         >
-        for diesel::internal::derives::multiconnection::BatchInsert<
+        for ::diesel::internal::derives::multiconnection::BatchInsert<
             V,
             Tab,
             QId,
             HAS_STATIC_QUERY_ID,
         >
         where
-            Self: diesel::query_builder::QueryFragment<
-                    <PgConnection as diesel::connection::Connection>::Backend,
+            Self: ::diesel::query_builder::QueryFragment<
+                    <PgConnection as ::diesel::connection::Connection>::Backend,
                 >
-                + diesel::query_builder::QueryFragment<
-                    <diesel::SqliteConnection as diesel::connection::Connection>::Backend,
+                + ::diesel::query_builder::QueryFragment<
+                    <diesel::SqliteConnection as ::diesel::connection::Connection>::Backend,
                 >,
         {
             fn walk_ast<'b>(
                 &'b self,
-                pass: diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
-            ) -> diesel::QueryResult<()> {
+                pass: ::diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
+            ) -> ::diesel::QueryResult<()> {
                 super::backend::MultiBackend::walk_variant_ast(self, pass)
             }
         }
@@ -597,43 +600,43 @@ mod multi_connection_impl {
             C,
             PK,
             Tab,
-        > diesel::query_builder::QueryFragment<
+        > ::diesel::query_builder::QueryFragment<
             super::backend::MultiBackend,
             super::backend::MultiBatchUpdateSupport,
-        > for diesel::internal::derives::multiconnection::BatchUpdate<I, C, PK, Tab>
+        > for ::diesel::internal::derives::multiconnection::BatchUpdate<I, C, PK, Tab>
         where
-            Self: diesel::query_builder::QueryFragment<
-                    <PgConnection as diesel::connection::Connection>::Backend,
+            Self: ::diesel::query_builder::QueryFragment<
+                    <PgConnection as ::diesel::connection::Connection>::Backend,
                 >
-                + diesel::query_builder::QueryFragment<
-                    <diesel::SqliteConnection as diesel::connection::Connection>::Backend,
+                + ::diesel::query_builder::QueryFragment<
+                    <diesel::SqliteConnection as ::diesel::connection::Connection>::Backend,
                 >,
         {
             fn walk_ast<'b>(
                 &'b self,
-                pass: diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
-            ) -> diesel::QueryResult<()> {
+                pass: ::diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
+            ) -> ::diesel::QueryResult<()> {
                 super::backend::MultiBackend::walk_variant_ast(self, pass)
             }
         }
         impl<
             S,
-        > diesel::query_builder::QueryFragment<
+        > ::diesel::query_builder::QueryFragment<
             super::backend::MultiBackend,
             super::backend::MultiAliasSyntax,
-        > for diesel::query_source::Alias<S>
+        > for ::diesel::query_source::Alias<S>
         where
-            Self: diesel::query_builder::QueryFragment<
-                    <PgConnection as diesel::connection::Connection>::Backend,
+            Self: ::diesel::query_builder::QueryFragment<
+                    <PgConnection as ::diesel::connection::Connection>::Backend,
                 >
-                + diesel::query_builder::QueryFragment<
-                    <diesel::SqliteConnection as diesel::connection::Connection>::Backend,
+                + ::diesel::query_builder::QueryFragment<
+                    <diesel::SqliteConnection as ::diesel::connection::Connection>::Backend,
                 >,
         {
             fn walk_ast<'b>(
                 &'b self,
-                pass: diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
-            ) -> diesel::QueryResult<()> {
+                pass: ::diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
+            ) -> ::diesel::QueryResult<()> {
                 super::backend::MultiBackend::walk_variant_ast(self, pass)
             }
         }
@@ -647,11 +650,11 @@ mod multi_connection_impl {
             G,
             H,
             LC,
-        > diesel::query_builder::QueryFragment<
+        > ::diesel::query_builder::QueryFragment<
             super::backend::MultiBackend,
             super::backend::MultiSelectStatementSyntax,
         >
-        for diesel::internal::derives::multiconnection::SelectStatement<
+        for ::diesel::internal::derives::multiconnection::SelectStatement<
             F,
             S,
             D,
@@ -663,21 +666,21 @@ mod multi_connection_impl {
             LC,
         >
         where
-            S: diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
-            F: diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
-            D: diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
-            W: diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
-            O: diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
-            LOf: diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
-            G: diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
-            H: diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
-            LC: diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
+            S: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
+            F: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
+            D: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
+            W: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
+            O: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
+            LOf: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
+            G: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
+            H: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
+            LC: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
         {
             fn walk_ast<'b>(
                 &'b self,
-                mut out: diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
-            ) -> diesel::QueryResult<()> {
-                use diesel::internal::derives::multiconnection::SelectStatementAccessor;
+                mut out: ::diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
+            ) -> ::diesel::QueryResult<()> {
+                use ::diesel::internal::derives::multiconnection::SelectStatementAccessor;
                 out.push_sql("SELECT ");
                 self.distinct_clause().walk_ast(out.reborrow())?;
                 self.select_clause().walk_ast(out.reborrow())?;
@@ -696,11 +699,11 @@ mod multi_connection_impl {
             ST,
             QS,
             GB,
-        > diesel::query_builder::QueryFragment<
+        > ::diesel::query_builder::QueryFragment<
             super::backend::MultiBackend,
             super::backend::MultiSelectStatementSyntax,
         >
-        for diesel::internal::derives::multiconnection::BoxedSelectStatement<
+        for ::diesel::internal::derives::multiconnection::BoxedSelectStatement<
             'a,
             ST,
             QS,
@@ -708,25 +711,25 @@ mod multi_connection_impl {
             GB,
         >
         where
-            QS: diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
+            QS: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
         {
             fn walk_ast<'b>(
                 &'b self,
-                pass: diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
-            ) -> diesel::QueryResult<()> {
-                use diesel::internal::derives::multiconnection::BoxedQueryHelper;
+                pass: ::diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
+            ) -> ::diesel::QueryResult<()> {
+                use ::diesel::internal::derives::multiconnection::BoxedQueryHelper;
                 self.build_query(pass, |where_clause, pass| where_clause.walk_ast(pass))
             }
         }
-        impl diesel::query_builder::QueryFragment<super::backend::MultiBackend>
-        for diesel::internal::derives::multiconnection::BoxedLimitOffsetClause<
+        impl ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>
+        for ::diesel::internal::derives::multiconnection::BoxedLimitOffsetClause<
             '_,
             super::backend::MultiBackend,
         > {
             fn walk_ast<'b>(
                 &'b self,
-                mut pass: diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
-            ) -> diesel::QueryResult<()> {
+                mut pass: ::diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
+            ) -> ::diesel::QueryResult<()> {
                 if let Some(limit) = &self.limit {
                     limit.walk_ast(pass.reborrow())?;
                 }
@@ -738,20 +741,20 @@ mod multi_connection_impl {
         }
         impl<
             'a,
-        > diesel::query_builder::IntoBoxedClause<
+        > ::diesel::query_builder::IntoBoxedClause<
             'a,
             super::multi_connection_impl::backend::MultiBackend,
         >
-        for diesel::internal::derives::multiconnection::LimitOffsetClause<
-            diesel::internal::derives::multiconnection::NoLimitClause,
-            diesel::internal::derives::multiconnection::NoOffsetClause,
+        for ::diesel::internal::derives::multiconnection::LimitOffsetClause<
+            ::diesel::internal::derives::multiconnection::NoLimitClause,
+            ::diesel::internal::derives::multiconnection::NoOffsetClause,
         > {
-            type BoxedClause = diesel::internal::derives::multiconnection::BoxedLimitOffsetClause<
+            type BoxedClause = ::diesel::internal::derives::multiconnection::BoxedLimitOffsetClause<
                 'a,
                 super::multi_connection_impl::backend::MultiBackend,
             >;
             fn into_boxed(self) -> Self::BoxedClause {
-                diesel::internal::derives::multiconnection::BoxedLimitOffsetClause {
+                ::diesel::internal::derives::multiconnection::BoxedLimitOffsetClause {
                     limit: None,
                     offset: None,
                 }
@@ -760,26 +763,26 @@ mod multi_connection_impl {
         impl<
             'a,
             L,
-        > diesel::query_builder::IntoBoxedClause<
+        > ::diesel::query_builder::IntoBoxedClause<
             'a,
             super::multi_connection_impl::backend::MultiBackend,
         >
-        for diesel::internal::derives::multiconnection::LimitOffsetClause<
-            diesel::internal::derives::multiconnection::LimitClause<L>,
-            diesel::internal::derives::multiconnection::NoOffsetClause,
+        for ::diesel::internal::derives::multiconnection::LimitOffsetClause<
+            ::diesel::internal::derives::multiconnection::LimitClause<L>,
+            ::diesel::internal::derives::multiconnection::NoOffsetClause,
         >
         where
-            diesel::internal::derives::multiconnection::LimitClause<
+            ::diesel::internal::derives::multiconnection::LimitClause<
                 L,
-            >: diesel::query_builder::QueryFragment<super::backend::MultiBackend> + Send
-                + 'static,
+            >: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>
+                + Send + 'static,
         {
-            type BoxedClause = diesel::internal::derives::multiconnection::BoxedLimitOffsetClause<
+            type BoxedClause = ::diesel::internal::derives::multiconnection::BoxedLimitOffsetClause<
                 'a,
                 super::multi_connection_impl::backend::MultiBackend,
             >;
             fn into_boxed(self) -> Self::BoxedClause {
-                diesel::internal::derives::multiconnection::BoxedLimitOffsetClause {
+                ::diesel::internal::derives::multiconnection::BoxedLimitOffsetClause {
                     limit: Some(Box::new(self.limit_clause)),
                     offset: None,
                 }
@@ -788,26 +791,26 @@ mod multi_connection_impl {
         impl<
             'a,
             O,
-        > diesel::query_builder::IntoBoxedClause<
+        > ::diesel::query_builder::IntoBoxedClause<
             'a,
             super::multi_connection_impl::backend::MultiBackend,
         >
-        for diesel::internal::derives::multiconnection::LimitOffsetClause<
-            diesel::internal::derives::multiconnection::NoLimitClause,
-            diesel::internal::derives::multiconnection::OffsetClause<O>,
+        for ::diesel::internal::derives::multiconnection::LimitOffsetClause<
+            ::diesel::internal::derives::multiconnection::NoLimitClause,
+            ::diesel::internal::derives::multiconnection::OffsetClause<O>,
         >
         where
-            diesel::internal::derives::multiconnection::OffsetClause<
+            ::diesel::internal::derives::multiconnection::OffsetClause<
                 O,
-            >: diesel::query_builder::QueryFragment<super::backend::MultiBackend> + Send
-                + 'static,
+            >: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>
+                + Send + 'static,
         {
-            type BoxedClause = diesel::internal::derives::multiconnection::BoxedLimitOffsetClause<
+            type BoxedClause = ::diesel::internal::derives::multiconnection::BoxedLimitOffsetClause<
                 'a,
                 super::multi_connection_impl::backend::MultiBackend,
             >;
             fn into_boxed(self) -> Self::BoxedClause {
-                diesel::internal::derives::multiconnection::BoxedLimitOffsetClause {
+                ::diesel::internal::derives::multiconnection::BoxedLimitOffsetClause {
                     limit: None,
                     offset: Some(Box::new(self.offset_clause)),
                 }
@@ -817,30 +820,30 @@ mod multi_connection_impl {
             'a,
             L,
             O,
-        > diesel::query_builder::IntoBoxedClause<
+        > ::diesel::query_builder::IntoBoxedClause<
             'a,
             super::multi_connection_impl::backend::MultiBackend,
         >
-        for diesel::internal::derives::multiconnection::LimitOffsetClause<
-            diesel::internal::derives::multiconnection::LimitClause<L>,
-            diesel::internal::derives::multiconnection::OffsetClause<O>,
+        for ::diesel::internal::derives::multiconnection::LimitOffsetClause<
+            ::diesel::internal::derives::multiconnection::LimitClause<L>,
+            ::diesel::internal::derives::multiconnection::OffsetClause<O>,
         >
         where
-            diesel::internal::derives::multiconnection::LimitClause<
+            ::diesel::internal::derives::multiconnection::LimitClause<
                 L,
-            >: diesel::query_builder::QueryFragment<super::backend::MultiBackend> + Send
-                + 'static,
-            diesel::internal::derives::multiconnection::OffsetClause<
+            >: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>
+                + Send + 'static,
+            ::diesel::internal::derives::multiconnection::OffsetClause<
                 O,
-            >: diesel::query_builder::QueryFragment<super::backend::MultiBackend> + Send
-                + 'static,
+            >: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>
+                + Send + 'static,
         {
-            type BoxedClause = diesel::internal::derives::multiconnection::BoxedLimitOffsetClause<
+            type BoxedClause = ::diesel::internal::derives::multiconnection::BoxedLimitOffsetClause<
                 'a,
                 super::multi_connection_impl::backend::MultiBackend,
             >;
             fn into_boxed(self) -> Self::BoxedClause {
-                diesel::internal::derives::multiconnection::BoxedLimitOffsetClause {
+                ::diesel::internal::derives::multiconnection::BoxedLimitOffsetClause {
                     limit: Some(Box::new(self.limit_clause)),
                     offset: Some(Box::new(self.offset_clause)),
                 }
@@ -851,11 +854,11 @@ mod multi_connection_impl {
             ST,
             QS,
             GB,
-        > diesel::query_builder::QueryFragment<
+        > ::diesel::query_builder::QueryFragment<
             super::backend::MultiBackend,
             super::backend::MultiSelectStatementSyntax,
         >
-        for diesel::internal::derives::multiconnection::BoxedCloneSelectStatement<
+        for ::diesel::internal::derives::multiconnection::BoxedCloneSelectStatement<
             'a,
             ST,
             QS,
@@ -863,25 +866,25 @@ mod multi_connection_impl {
             GB,
         >
         where
-            QS: diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
+            QS: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
         {
             fn walk_ast<'b>(
                 &'b self,
-                pass: diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
-            ) -> diesel::QueryResult<()> {
-                use diesel::internal::derives::multiconnection::BoxedCloneQueryHelper;
+                pass: ::diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
+            ) -> ::diesel::QueryResult<()> {
+                use ::diesel::internal::derives::multiconnection::BoxedCloneQueryHelper;
                 self.build_query(pass, |where_clause, pass| where_clause.walk_ast(pass))
             }
         }
-        impl diesel::query_builder::QueryFragment<super::backend::MultiBackend>
-        for diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause<
+        impl ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>
+        for ::diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause<
             '_,
             super::backend::MultiBackend,
         > {
             fn walk_ast<'b>(
                 &'b self,
-                mut pass: diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
-            ) -> diesel::QueryResult<()> {
+                mut pass: ::diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
+            ) -> ::diesel::QueryResult<()> {
                 if let Some(limit) = &self.limit {
                     limit.walk_ast(pass.reborrow())?;
                 }
@@ -893,20 +896,20 @@ mod multi_connection_impl {
         }
         impl<
             'a,
-        > diesel::query_builder::IntoBoxedCloneClause<
+        > ::diesel::query_builder::IntoBoxedCloneClause<
             'a,
             super::multi_connection_impl::backend::MultiBackend,
         >
-        for diesel::internal::derives::multiconnection::LimitOffsetClause<
-            diesel::internal::derives::multiconnection::NoLimitClause,
-            diesel::internal::derives::multiconnection::NoOffsetClause,
+        for ::diesel::internal::derives::multiconnection::LimitOffsetClause<
+            ::diesel::internal::derives::multiconnection::NoLimitClause,
+            ::diesel::internal::derives::multiconnection::NoOffsetClause,
         > {
-            type BoxedCloneClause = diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause<
+            type BoxedCloneClause = ::diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause<
                 'a,
                 super::multi_connection_impl::backend::MultiBackend,
             >;
             fn into_boxed_clone(self) -> Self::BoxedCloneClause {
-                diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause {
+                ::diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause {
                     limit: None,
                     offset: None,
                 }
@@ -915,26 +918,26 @@ mod multi_connection_impl {
         impl<
             'a,
             L,
-        > diesel::query_builder::IntoBoxedCloneClause<
+        > ::diesel::query_builder::IntoBoxedCloneClause<
             'a,
             super::multi_connection_impl::backend::MultiBackend,
         >
-        for diesel::internal::derives::multiconnection::LimitOffsetClause<
-            diesel::internal::derives::multiconnection::LimitClause<L>,
-            diesel::internal::derives::multiconnection::NoOffsetClause,
+        for ::diesel::internal::derives::multiconnection::LimitOffsetClause<
+            ::diesel::internal::derives::multiconnection::LimitClause<L>,
+            ::diesel::internal::derives::multiconnection::NoOffsetClause,
         >
         where
-            diesel::internal::derives::multiconnection::LimitClause<
+            ::diesel::internal::derives::multiconnection::LimitClause<
                 L,
-            >: diesel::query_builder::QueryFragment<super::backend::MultiBackend> + Send
-                + Sync + 'static,
+            >: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>
+                + Send + Sync + 'static,
         {
-            type BoxedCloneClause = diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause<
+            type BoxedCloneClause = ::diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause<
                 'a,
                 super::multi_connection_impl::backend::MultiBackend,
             >;
             fn into_boxed_clone(self) -> Self::BoxedCloneClause {
-                diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause {
+                ::diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause {
                     limit: Some(std::sync::Arc::new(self.limit_clause)),
                     offset: None,
                 }
@@ -943,26 +946,26 @@ mod multi_connection_impl {
         impl<
             'a,
             O,
-        > diesel::query_builder::IntoBoxedCloneClause<
+        > ::diesel::query_builder::IntoBoxedCloneClause<
             'a,
             super::multi_connection_impl::backend::MultiBackend,
         >
-        for diesel::internal::derives::multiconnection::LimitOffsetClause<
-            diesel::internal::derives::multiconnection::NoLimitClause,
-            diesel::internal::derives::multiconnection::OffsetClause<O>,
+        for ::diesel::internal::derives::multiconnection::LimitOffsetClause<
+            ::diesel::internal::derives::multiconnection::NoLimitClause,
+            ::diesel::internal::derives::multiconnection::OffsetClause<O>,
         >
         where
-            diesel::internal::derives::multiconnection::OffsetClause<
+            ::diesel::internal::derives::multiconnection::OffsetClause<
                 O,
-            >: diesel::query_builder::QueryFragment<super::backend::MultiBackend> + Send
-                + Sync + 'static,
+            >: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>
+                + Send + Sync + 'static,
         {
-            type BoxedCloneClause = diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause<
+            type BoxedCloneClause = ::diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause<
                 'a,
                 super::multi_connection_impl::backend::MultiBackend,
             >;
             fn into_boxed_clone(self) -> Self::BoxedCloneClause {
-                diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause {
+                ::diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause {
                     limit: None,
                     offset: Some(std::sync::Arc::new(self.offset_clause)),
                 }
@@ -972,32 +975,32 @@ mod multi_connection_impl {
             'a,
             L,
             O,
-        > diesel::query_builder::IntoBoxedCloneClause<
+        > ::diesel::query_builder::IntoBoxedCloneClause<
             'a,
             super::multi_connection_impl::backend::MultiBackend,
         >
-        for diesel::internal::derives::multiconnection::LimitOffsetClause<
-            diesel::internal::derives::multiconnection::LimitClause<L>,
-            diesel::internal::derives::multiconnection::OffsetClause<O>,
+        for ::diesel::internal::derives::multiconnection::LimitOffsetClause<
+            ::diesel::internal::derives::multiconnection::LimitClause<L>,
+            ::diesel::internal::derives::multiconnection::OffsetClause<O>,
         >
         where
-            L: diesel::query_builder::QueryFragment<super::backend::MultiBackend> + Send
-                + Sync + 'a,
-            O: diesel::query_builder::QueryFragment<super::backend::MultiBackend> + Send
-                + Sync + 'a,
-            diesel::internal::derives::multiconnection::LimitClause<
+            L: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>
+                + Send + Sync + 'a,
+            O: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>
+                + Send + Sync + 'a,
+            ::diesel::internal::derives::multiconnection::LimitClause<
                 L,
-            >: diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
-            diesel::internal::derives::multiconnection::OffsetClause<
+            >: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
+            ::diesel::internal::derives::multiconnection::OffsetClause<
                 O,
-            >: diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
+            >: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
         {
-            type BoxedCloneClause = diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause<
+            type BoxedCloneClause = ::diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause<
                 'a,
                 super::multi_connection_impl::backend::MultiBackend,
             >;
             fn into_boxed_clone(self) -> Self::BoxedCloneClause {
-                diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause {
+                ::diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause {
                     limit: Some(std::sync::Arc::new(self.limit_clause)),
                     offset: Some(std::sync::Arc::new(self.offset_clause)),
                 }
@@ -1006,48 +1009,48 @@ mod multi_connection_impl {
         impl<
             Col,
             Expr,
-        > diesel::insertable::InsertValues<
+        > ::diesel::insertable::InsertValues<
             super::multi_connection_impl::backend::MultiBackend,
             Col::Table,
         >
-        for diesel::insertable::DefaultableColumnInsertValue<
-            diesel::insertable::ColumnInsertValue<Col, Expr>,
+        for ::diesel::insertable::DefaultableColumnInsertValue<
+            ::diesel::insertable::ColumnInsertValue<Col, Expr>,
         >
         where
-            Col: diesel::prelude::Column,
-            Expr: diesel::prelude::Expression<SqlType = Col::SqlType>,
-            Expr: diesel::prelude::AppearsOnTable<
-                diesel::internal::derives::multiconnection::NoFromClause,
+            Col: ::diesel::prelude::Column,
+            Expr: ::diesel::prelude::Expression<SqlType = Col::SqlType>,
+            Expr: ::diesel::prelude::AppearsOnTable<
+                ::diesel::internal::derives::multiconnection::NoFromClause,
             >,
-            Self: diesel::query_builder::QueryFragment<
+            Self: ::diesel::query_builder::QueryFragment<
                 super::multi_connection_impl::backend::MultiBackend,
             >,
-            diesel::insertable::DefaultableColumnInsertValue<
-                diesel::insertable::ColumnInsertValue<Col, Expr>,
-            >: diesel::insertable::InsertValues<
-                <PgConnection as diesel::connection::Connection>::Backend,
+            ::diesel::insertable::DefaultableColumnInsertValue<
+                ::diesel::insertable::ColumnInsertValue<Col, Expr>,
+            >: ::diesel::insertable::InsertValues<
+                <PgConnection as ::diesel::connection::Connection>::Backend,
                 Col::Table,
             >,
-            diesel::insertable::DefaultableColumnInsertValue<
-                diesel::insertable::ColumnInsertValue<Col, Expr>,
-            >: diesel::insertable::InsertValues<
-                <diesel::SqliteConnection as diesel::connection::Connection>::Backend,
+            ::diesel::insertable::DefaultableColumnInsertValue<
+                ::diesel::insertable::ColumnInsertValue<Col, Expr>,
+            >: ::diesel::insertable::InsertValues<
+                <diesel::SqliteConnection as ::diesel::connection::Connection>::Backend,
                 Col::Table,
             >,
         {
             fn column_names(
                 &self,
-                mut out: diesel::query_builder::AstPass<
+                mut out: ::diesel::query_builder::AstPass<
                     '_,
                     '_,
                     super::multi_connection_impl::backend::MultiBackend,
                 >,
-            ) -> diesel::QueryResult<()> {
-                use diesel::internal::derives::multiconnection::AstPassHelper;
+            ) -> ::diesel::QueryResult<()> {
+                use ::diesel::internal::derives::multiconnection::AstPassHelper;
                 match out.backend() {
                     super::backend::MultiBackend::Pg(_) => {
-                        <Self as diesel::insertable::InsertValues<
-                            <PgConnection as diesel::connection::Connection>::Backend,
+                        <Self as ::diesel::insertable::InsertValues<
+                            <PgConnection as ::diesel::connection::Connection>::Backend,
                             Col::Table,
                         >>::column_names(
                             &self,
@@ -1057,7 +1060,7 @@ mod multi_connection_impl {
                                     super::query_builder::MultiQueryBuilder::pg,
                                     super::backend::MultiBackend::pg,
                                     |l| {
-                                        <PgConnection as diesel::internal::derives::multiconnection::MultiConnectionHelper>::from_any(
+                                        <PgConnection as ::diesel::internal::derives::multiconnection::MultiConnectionHelper>::from_any(
                                                 l,
                                             )
                                             .expect(
@@ -1068,8 +1071,8 @@ mod multi_connection_impl {
                         )
                     }
                     super::backend::MultiBackend::Sqlite(_) => {
-                        <Self as diesel::insertable::InsertValues<
-                            <diesel::SqliteConnection as diesel::connection::Connection>::Backend,
+                        <Self as ::diesel::insertable::InsertValues<
+                            <diesel::SqliteConnection as ::diesel::connection::Connection>::Backend,
                             Col::Table,
                         >>::column_names(
                             &self,
@@ -1079,7 +1082,7 @@ mod multi_connection_impl {
                                     super::query_builder::MultiQueryBuilder::sqlite,
                                     super::backend::MultiBackend::sqlite,
                                     |l| {
-                                        <diesel::SqliteConnection as diesel::internal::derives::multiconnection::MultiConnectionHelper>::from_any(
+                                        <diesel::SqliteConnection as ::diesel::internal::derives::multiconnection::MultiConnectionHelper>::from_any(
                                                 l,
                                             )
                                             .expect(
@@ -1097,12 +1100,12 @@ mod multi_connection_impl {
         use super::*;
         pub enum MultiBindCollector<'a> {
             Pg(
-                <<PgConnection as diesel::connection::Connection>::Backend as diesel::backend::Backend>::BindCollector<
+                <<PgConnection as ::diesel::connection::Connection>::Backend as ::diesel::backend::Backend>::BindCollector<
                     'a,
                 >,
             ),
             Sqlite(
-                <<diesel::SqliteConnection as diesel::connection::Connection>::Backend as diesel::backend::Backend>::BindCollector<
+                <<diesel::SqliteConnection as ::diesel::connection::Connection>::Backend as ::diesel::backend::Backend>::BindCollector<
                     'a,
                 >,
             ),
@@ -1110,7 +1113,7 @@ mod multi_connection_impl {
         impl<'a> MultiBindCollector<'a> {
             pub(super) fn pg(
                 &mut self,
-            ) -> &mut <<PgConnection as diesel::connection::Connection>::Backend as diesel::backend::Backend>::BindCollector<
+            ) -> &mut <<PgConnection as ::diesel::connection::Connection>::Backend as ::diesel::backend::Backend>::BindCollector<
                 'a,
             > {
                 match self {
@@ -1120,7 +1123,7 @@ mod multi_connection_impl {
             }
             pub(super) fn sqlite(
                 &mut self,
-            ) -> &mut <<diesel::SqliteConnection as diesel::connection::Connection>::Backend as diesel::backend::Backend>::BindCollector<
+            ) -> &mut <<diesel::SqliteConnection as ::diesel::connection::Connection>::Backend as ::diesel::backend::Backend>::BindCollector<
                 'a,
             > {
                 match self {
@@ -1129,13 +1132,13 @@ mod multi_connection_impl {
                 }
             }
         }
-        trait PushBoundValueToCollectorDB<DB: diesel::backend::Backend> {
+        trait PushBoundValueToCollectorDB<DB: ::diesel::backend::Backend> {
             fn push_bound_value<'a: 'b, 'b>(
                 &self,
                 v: InnerBindValueKind<'a>,
-                collector: &mut <DB as diesel::backend::Backend>::BindCollector<'b>,
-                lookup: &mut <DB as diesel::sql_types::TypeMetadata>::MetadataLookup,
-            ) -> diesel::result::QueryResult<()>;
+                collector: &mut <DB as ::diesel::backend::Backend>::BindCollector<'b>,
+                lookup: &mut <DB as ::diesel::sql_types::TypeMetadata>::MetadataLookup,
+            ) -> ::diesel::result::QueryResult<()>;
         }
         struct PushBoundValueToCollectorImpl<ST, T: ?Sized> {
             p: std::marker::PhantomData<(ST, T)>,
@@ -1143,20 +1146,21 @@ mod multi_connection_impl {
         impl<ST, T, DB> PushBoundValueToCollectorDB<DB>
         for PushBoundValueToCollectorImpl<ST, T>
         where
-            DB: diesel::backend::Backend + diesel::sql_types::HasSqlType<ST>,
-            T: diesel::serialize::ToSql<ST, DB> + 'static,
+            DB: ::diesel::backend::Backend + ::diesel::sql_types::HasSqlType<ST>,
+            T: ::diesel::serialize::ToSql<ST, DB> + 'static,
             Option<
                 T,
-            >: diesel::serialize::ToSql<diesel::sql_types::Nullable<ST>, DB> + 'static,
-            ST: diesel::sql_types::SqlType,
+            >: ::diesel::serialize::ToSql<::diesel::sql_types::Nullable<ST>, DB>
+                + 'static,
+            ST: ::diesel::sql_types::SqlType,
         {
             fn push_bound_value<'a: 'b, 'b>(
                 &self,
                 v: InnerBindValueKind<'a>,
-                collector: &mut <DB as diesel::backend::Backend>::BindCollector<'b>,
-                lookup: &mut <DB as diesel::sql_types::TypeMetadata>::MetadataLookup,
-            ) -> diesel::result::QueryResult<()> {
-                use diesel::query_builder::BindCollector;
+                collector: &mut <DB as ::diesel::backend::Backend>::BindCollector<'b>,
+                lookup: &mut <DB as ::diesel::sql_types::TypeMetadata>::MetadataLookup,
+            ) -> ::diesel::result::QueryResult<()> {
+                use ::diesel::query_builder::BindCollector;
                 match v {
                     InnerBindValueKind::Sized(v) => {
                         let v = v
@@ -1167,7 +1171,7 @@ mod multi_connection_impl {
                     InnerBindValueKind::Null => {
                         collector
                             .push_bound_value::<
-                                diesel::sql_types::Nullable<ST>,
+                                ::diesel::sql_types::Nullable<ST>,
                                 Option<T>,
                             >(&None, lookup)
                     }
@@ -1180,60 +1184,61 @@ mod multi_connection_impl {
             }
         }
         impl<DB> PushBoundValueToCollectorDB<DB>
-        for PushBoundValueToCollectorImpl<diesel::sql_types::Text, str>
+        for PushBoundValueToCollectorImpl<::diesel::sql_types::Text, str>
         where
-            DB: diesel::backend::Backend
-                + diesel::sql_types::HasSqlType<diesel::sql_types::Text>,
-            str: diesel::serialize::ToSql<diesel::sql_types::Text, DB> + 'static,
+            DB: ::diesel::backend::Backend
+                + ::diesel::sql_types::HasSqlType<::diesel::sql_types::Text>,
+            str: ::diesel::serialize::ToSql<::diesel::sql_types::Text, DB> + 'static,
         {
             fn push_bound_value<'a: 'b, 'b>(
                 &self,
                 v: InnerBindValueKind<'a>,
-                collector: &mut <DB as diesel::backend::Backend>::BindCollector<'b>,
-                lookup: &mut <DB as diesel::sql_types::TypeMetadata>::MetadataLookup,
-            ) -> diesel::result::QueryResult<()> {
-                use diesel::query_builder::BindCollector;
+                collector: &mut <DB as ::diesel::backend::Backend>::BindCollector<'b>,
+                lookup: &mut <DB as ::diesel::sql_types::TypeMetadata>::MetadataLookup,
+            ) -> ::diesel::result::QueryResult<()> {
+                use ::diesel::query_builder::BindCollector;
                 if let InnerBindValueKind::Str(v) = v {
-                    collector.push_bound_value::<diesel::sql_types::Text, str>(v, lookup)
+                    collector
+                        .push_bound_value::<::diesel::sql_types::Text, str>(v, lookup)
                 } else {
                     unreachable!("We set the value to `InnerBindValueKind::Str`")
                 }
             }
         }
         impl<DB> PushBoundValueToCollectorDB<DB>
-        for PushBoundValueToCollectorImpl<diesel::sql_types::Binary, [u8]>
+        for PushBoundValueToCollectorImpl<::diesel::sql_types::Binary, [u8]>
         where
-            DB: diesel::backend::Backend
-                + diesel::sql_types::HasSqlType<diesel::sql_types::Binary>,
-            [u8]: diesel::serialize::ToSql<diesel::sql_types::Binary, DB> + 'static,
+            DB: ::diesel::backend::Backend
+                + ::diesel::sql_types::HasSqlType<::diesel::sql_types::Binary>,
+            [u8]: ::diesel::serialize::ToSql<::diesel::sql_types::Binary, DB> + 'static,
         {
             fn push_bound_value<'a: 'b, 'b>(
                 &self,
                 v: InnerBindValueKind<'a>,
-                collector: &mut <DB as diesel::backend::Backend>::BindCollector<'b>,
-                lookup: &mut <DB as diesel::sql_types::TypeMetadata>::MetadataLookup,
-            ) -> diesel::result::QueryResult<()> {
-                use diesel::query_builder::BindCollector;
+                collector: &mut <DB as ::diesel::backend::Backend>::BindCollector<'b>,
+                lookup: &mut <DB as ::diesel::sql_types::TypeMetadata>::MetadataLookup,
+            ) -> ::diesel::result::QueryResult<()> {
+                use ::diesel::query_builder::BindCollector;
                 if let InnerBindValueKind::Bytes(v) = v {
                     collector
-                        .push_bound_value::<diesel::sql_types::Binary, [u8]>(v, lookup)
+                        .push_bound_value::<::diesel::sql_types::Binary, [u8]>(v, lookup)
                 } else {
                     unreachable!("We set the value to `InnerBindValueKind::Binary`")
                 }
             }
         }
         trait PushBoundValueToCollector: PushBoundValueToCollectorDB<
-                <PgConnection as diesel::connection::Connection>::Backend,
+                <PgConnection as ::diesel::connection::Connection>::Backend,
             > + PushBoundValueToCollectorDB<
-                <diesel::SqliteConnection as diesel::connection::Connection>::Backend,
+                <diesel::SqliteConnection as ::diesel::connection::Connection>::Backend,
             > {}
         impl<T> PushBoundValueToCollector for T
         where
             T: PushBoundValueToCollectorDB<
-                    <PgConnection as diesel::connection::Connection>::Backend,
+                    <PgConnection as ::diesel::connection::Connection>::Backend,
                 >
                 + PushBoundValueToCollectorDB<
-                    <diesel::SqliteConnection as diesel::connection::Connection>::Backend,
+                    <diesel::SqliteConnection as ::diesel::connection::Connection>::Backend,
                 >,
         {}
         #[derive(Default)]
@@ -1250,26 +1255,28 @@ mod multi_connection_impl {
             Bytes(&'a [u8]),
             Null,
         }
-        impl<'a> From<(diesel::sql_types::Text, &'a str)> for BindValue<'a> {
-            fn from((_, v): (diesel::sql_types::Text, &'a str)) -> Self {
+        impl<'a> From<(::diesel::sql_types::Text, &'a str)> for BindValue<'a> {
+            fn from((_, v): (::diesel::sql_types::Text, &'a str)) -> Self {
                 Self {
                     inner: Some(InnerBindValue {
                         value: InnerBindValueKind::Str(v),
                         push_bound_value_to_collector: &PushBoundValueToCollectorImpl {
-                            p: std::marker::PhantomData::<(diesel::sql_types::Text, str)>,
+                            p: std::marker::PhantomData::<
+                                (::diesel::sql_types::Text, str),
+                            >,
                         },
                     }),
                 }
             }
         }
-        impl<'a> From<(diesel::sql_types::Binary, &'a [u8])> for BindValue<'a> {
-            fn from((_, v): (diesel::sql_types::Binary, &'a [u8])) -> Self {
+        impl<'a> From<(::diesel::sql_types::Binary, &'a [u8])> for BindValue<'a> {
+            fn from((_, v): (::diesel::sql_types::Binary, &'a [u8])) -> Self {
                 Self {
                     inner: Some(InnerBindValue {
                         value: InnerBindValueKind::Bytes(v),
                         push_bound_value_to_collector: &PushBoundValueToCollectorImpl {
                             p: std::marker::PhantomData::<
-                                (diesel::sql_types::Binary, [u8]),
+                                (::diesel::sql_types::Binary, [u8]),
                             >,
                         },
                     }),
@@ -1279,22 +1286,22 @@ mod multi_connection_impl {
         impl<'a, T, ST> From<(ST, &'a T)> for BindValue<'a>
         where
             T: std::any::Any
-                + diesel::serialize::ToSql<
+                + ::diesel::serialize::ToSql<
                     ST,
-                    <PgConnection as diesel::connection::Connection>::Backend,
+                    <PgConnection as ::diesel::connection::Connection>::Backend,
                 >
-                + diesel::serialize::ToSql<
+                + ::diesel::serialize::ToSql<
                     ST,
-                    <diesel::SqliteConnection as diesel::connection::Connection>::Backend,
+                    <diesel::SqliteConnection as ::diesel::connection::Connection>::Backend,
                 > + Send + Sync + 'static,
             ST: Send
-                + diesel::sql_types::SqlType<
-                    IsNull = diesel::sql_types::is_nullable::NotNull,
+                + ::diesel::sql_types::SqlType<
+                    IsNull = ::diesel::sql_types::is_nullable::NotNull,
                 > + 'static,
-            <PgConnection as diesel::connection::Connection>::Backend: diesel::sql_types::HasSqlType<
+            <PgConnection as ::diesel::connection::Connection>::Backend: ::diesel::sql_types::HasSqlType<
                 ST,
             >,
-            <diesel::SqliteConnection as diesel::connection::Connection>::Backend: diesel::sql_types::HasSqlType<
+            <diesel::SqliteConnection as ::diesel::connection::Connection>::Backend: ::diesel::sql_types::HasSqlType<
                 ST,
             >,
         {
@@ -1309,28 +1316,28 @@ mod multi_connection_impl {
                 }
             }
         }
-        impl<'a> diesel::query_builder::BindCollector<'a, MultiBackend>
+        impl<'a> ::diesel::query_builder::BindCollector<'a, MultiBackend>
         for MultiBindCollector<'a> {
             type Buffer = multi_connection_impl::bind_collector::BindValue<'a>;
             fn push_bound_value<T, U>(
                 &mut self,
                 bind: &'a U,
                 metadata_lookup: &mut (dyn std::any::Any + 'static),
-            ) -> diesel::QueryResult<()>
+            ) -> ::diesel::QueryResult<()>
             where
-                MultiBackend: diesel::sql_types::HasSqlType<T>,
-                U: diesel::serialize::ToSql<T, MultiBackend> + ?Sized + 'a,
+                MultiBackend: ::diesel::sql_types::HasSqlType<T>,
+                U: ::diesel::serialize::ToSql<T, MultiBackend> + ?Sized + 'a,
             {
                 let out = {
                     let out = multi_connection_impl::bind_collector::BindValue::default();
-                    let mut out = diesel::serialize::Output::<
+                    let mut out = ::diesel::serialize::Output::<
                         MultiBackend,
                     >::new(out, metadata_lookup);
                     let bind_is_null = bind
                         .to_sql(&mut out)
-                        .map_err(diesel::result::Error::SerializationError)?;
-                    if matches!(bind_is_null, diesel::serialize::IsNull::Yes) {
-                        let metadata = <MultiBackend as diesel::sql_types::HasSqlType<
+                        .map_err(::diesel::result::Error::SerializationError)?;
+                    if matches!(bind_is_null, ::diesel::serialize::IsNull::Yes) {
+                        let metadata = <MultiBackend as ::diesel::sql_types::HasSqlType<
                             T,
                         >>::metadata(metadata_lookup);
                         match (self, metadata) {
@@ -1366,12 +1373,12 @@ mod multi_connection_impl {
                         let callback = out.push_bound_value_to_collector;
                         let value = out.value;
                         <_ as PushBoundValueToCollectorDB<
-                            <PgConnection as diesel::connection::Connection>::Backend,
+                            <PgConnection as ::diesel::connection::Connection>::Backend,
                         >>::push_bound_value(
                             callback,
                             value,
                             bc,
-                            <PgConnection as diesel::internal::derives::multiconnection::MultiConnectionHelper>::from_any(
+                            <PgConnection as ::diesel::internal::derives::multiconnection::MultiConnectionHelper>::from_any(
                                     metadata_lookup,
                                 )
                                 .expect(
@@ -1388,12 +1395,12 @@ mod multi_connection_impl {
                         let callback = out.push_bound_value_to_collector;
                         let value = out.value;
                         <_ as PushBoundValueToCollectorDB<
-                            <diesel::SqliteConnection as diesel::connection::Connection>::Backend,
+                            <diesel::SqliteConnection as ::diesel::connection::Connection>::Backend,
                         >>::push_bound_value(
                             callback,
                             value,
                             bc,
-                            <diesel::SqliteConnection as diesel::internal::derives::multiconnection::MultiConnectionHelper>::from_any(
+                            <diesel::SqliteConnection as ::diesel::internal::derives::multiconnection::MultiConnectionHelper>::from_any(
                                     metadata_lookup,
                                 )
                                 .expect(
@@ -1407,7 +1414,7 @@ mod multi_connection_impl {
             fn push_null_value(
                 &mut self,
                 metadata: super::backend::MultiTypeMetadata,
-            ) -> diesel::QueryResult<()> {
+            ) -> ::diesel::QueryResult<()> {
                 match (self, metadata) {
                     (
                         Self::Pg(bc),
@@ -1426,338 +1433,369 @@ mod multi_connection_impl {
                 Ok(())
             }
         }
-        impl diesel::serialize::ToSql<diesel::sql_types::SmallInt, super::MultiBackend>
-        for i16 {
+        impl ::diesel::serialize::ToSql<
+            ::diesel::sql_types::SmallInt,
+            super::MultiBackend,
+        > for i16 {
             fn to_sql<'b>(
                 &'b self,
-                out: &mut diesel::serialize::Output<'b, '_, super::MultiBackend>,
-            ) -> diesel::serialize::Result {
-                out.set_value((diesel::sql_types::SmallInt, self));
-                Ok(diesel::serialize::IsNull::No)
+                out: &mut ::diesel::serialize::Output<'b, '_, super::MultiBackend>,
+            ) -> ::diesel::serialize::Result {
+                out.set_value((::diesel::sql_types::SmallInt, self));
+                Ok(::diesel::serialize::IsNull::No)
             }
         }
-        impl diesel::serialize::ToSql<diesel::sql_types::Integer, super::MultiBackend>
-        for i32 {
+        impl ::diesel::serialize::ToSql<
+            ::diesel::sql_types::Integer,
+            super::MultiBackend,
+        > for i32 {
             fn to_sql<'b>(
                 &'b self,
-                out: &mut diesel::serialize::Output<'b, '_, super::MultiBackend>,
-            ) -> diesel::serialize::Result {
-                out.set_value((diesel::sql_types::Integer, self));
-                Ok(diesel::serialize::IsNull::No)
+                out: &mut ::diesel::serialize::Output<'b, '_, super::MultiBackend>,
+            ) -> ::diesel::serialize::Result {
+                out.set_value((::diesel::sql_types::Integer, self));
+                Ok(::diesel::serialize::IsNull::No)
             }
         }
-        impl diesel::serialize::ToSql<diesel::sql_types::BigInt, super::MultiBackend>
+        impl ::diesel::serialize::ToSql<::diesel::sql_types::BigInt, super::MultiBackend>
         for i64 {
             fn to_sql<'b>(
                 &'b self,
-                out: &mut diesel::serialize::Output<'b, '_, super::MultiBackend>,
-            ) -> diesel::serialize::Result {
-                out.set_value((diesel::sql_types::BigInt, self));
-                Ok(diesel::serialize::IsNull::No)
+                out: &mut ::diesel::serialize::Output<'b, '_, super::MultiBackend>,
+            ) -> ::diesel::serialize::Result {
+                out.set_value((::diesel::sql_types::BigInt, self));
+                Ok(::diesel::serialize::IsNull::No)
             }
         }
-        impl diesel::serialize::ToSql<diesel::sql_types::Double, super::MultiBackend>
+        impl ::diesel::serialize::ToSql<::diesel::sql_types::Double, super::MultiBackend>
         for f64 {
             fn to_sql<'b>(
                 &'b self,
-                out: &mut diesel::serialize::Output<'b, '_, super::MultiBackend>,
-            ) -> diesel::serialize::Result {
-                out.set_value((diesel::sql_types::Double, self));
-                Ok(diesel::serialize::IsNull::No)
+                out: &mut ::diesel::serialize::Output<'b, '_, super::MultiBackend>,
+            ) -> ::diesel::serialize::Result {
+                out.set_value((::diesel::sql_types::Double, self));
+                Ok(::diesel::serialize::IsNull::No)
             }
         }
-        impl diesel::serialize::ToSql<diesel::sql_types::Float, super::MultiBackend>
+        impl ::diesel::serialize::ToSql<::diesel::sql_types::Float, super::MultiBackend>
         for f32 {
             fn to_sql<'b>(
                 &'b self,
-                out: &mut diesel::serialize::Output<'b, '_, super::MultiBackend>,
-            ) -> diesel::serialize::Result {
-                out.set_value((diesel::sql_types::Float, self));
-                Ok(diesel::serialize::IsNull::No)
+                out: &mut ::diesel::serialize::Output<'b, '_, super::MultiBackend>,
+            ) -> ::diesel::serialize::Result {
+                out.set_value((::diesel::sql_types::Float, self));
+                Ok(::diesel::serialize::IsNull::No)
             }
         }
-        impl diesel::serialize::ToSql<diesel::sql_types::Text, super::MultiBackend>
+        impl ::diesel::serialize::ToSql<::diesel::sql_types::Text, super::MultiBackend>
         for str {
             fn to_sql<'b>(
                 &'b self,
-                out: &mut diesel::serialize::Output<'b, '_, super::MultiBackend>,
-            ) -> diesel::serialize::Result {
-                out.set_value((diesel::sql_types::Text, self));
-                Ok(diesel::serialize::IsNull::No)
+                out: &mut ::diesel::serialize::Output<'b, '_, super::MultiBackend>,
+            ) -> ::diesel::serialize::Result {
+                out.set_value((::diesel::sql_types::Text, self));
+                Ok(::diesel::serialize::IsNull::No)
             }
         }
-        impl diesel::serialize::ToSql<diesel::sql_types::Binary, super::MultiBackend>
+        impl ::diesel::serialize::ToSql<::diesel::sql_types::Binary, super::MultiBackend>
         for [u8] {
             fn to_sql<'b>(
                 &'b self,
-                out: &mut diesel::serialize::Output<'b, '_, super::MultiBackend>,
-            ) -> diesel::serialize::Result {
-                out.set_value((diesel::sql_types::Binary, self));
-                Ok(diesel::serialize::IsNull::No)
+                out: &mut ::diesel::serialize::Output<'b, '_, super::MultiBackend>,
+            ) -> ::diesel::serialize::Result {
+                out.set_value((::diesel::sql_types::Binary, self));
+                Ok(::diesel::serialize::IsNull::No)
             }
         }
-        impl diesel::serialize::ToSql<diesel::sql_types::Bool, super::MultiBackend>
+        impl ::diesel::serialize::ToSql<::diesel::sql_types::Bool, super::MultiBackend>
         for bool {
             fn to_sql<'b>(
                 &'b self,
-                out: &mut diesel::serialize::Output<'b, '_, super::MultiBackend>,
-            ) -> diesel::serialize::Result {
-                out.set_value((diesel::sql_types::Bool, self));
-                Ok(diesel::serialize::IsNull::No)
+                out: &mut ::diesel::serialize::Output<'b, '_, super::MultiBackend>,
+            ) -> ::diesel::serialize::Result {
+                out.set_value((::diesel::sql_types::Bool, self));
+                Ok(::diesel::serialize::IsNull::No)
             }
         }
-        impl diesel::serialize::ToSql<diesel::sql_types::Numeric, super::MultiBackend>
-        for diesel::internal::derives::multiconnection::bigdecimal::BigDecimal {
+        impl ::diesel::serialize::ToSql<
+            ::diesel::sql_types::Numeric,
+            super::MultiBackend,
+        > for ::diesel::internal::derives::multiconnection::bigdecimal::BigDecimal {
             fn to_sql<'b>(
                 &'b self,
-                out: &mut diesel::serialize::Output<'b, '_, super::MultiBackend>,
-            ) -> diesel::serialize::Result {
-                out.set_value((diesel::sql_types::Numeric, self));
-                Ok(diesel::serialize::IsNull::No)
+                out: &mut ::diesel::serialize::Output<'b, '_, super::MultiBackend>,
+            ) -> ::diesel::serialize::Result {
+                out.set_value((::diesel::sql_types::Numeric, self));
+                Ok(::diesel::serialize::IsNull::No)
             }
         }
-        impl diesel::serialize::ToSql<diesel::sql_types::Timestamp, super::MultiBackend>
-        for diesel::internal::derives::multiconnection::chrono::NaiveDateTime {
+        impl ::diesel::serialize::ToSql<
+            ::diesel::sql_types::Timestamp,
+            super::MultiBackend,
+        > for ::diesel::internal::derives::multiconnection::chrono::NaiveDateTime {
             fn to_sql<'b>(
                 &'b self,
-                out: &mut diesel::serialize::Output<'b, '_, super::MultiBackend>,
-            ) -> diesel::serialize::Result {
-                out.set_value((diesel::sql_types::Timestamp, self));
-                Ok(diesel::serialize::IsNull::No)
+                out: &mut ::diesel::serialize::Output<'b, '_, super::MultiBackend>,
+            ) -> ::diesel::serialize::Result {
+                out.set_value((::diesel::sql_types::Timestamp, self));
+                Ok(::diesel::serialize::IsNull::No)
             }
         }
-        impl diesel::serialize::ToSql<diesel::sql_types::Date, super::MultiBackend>
-        for diesel::internal::derives::multiconnection::chrono::NaiveDate {
+        impl ::diesel::serialize::ToSql<::diesel::sql_types::Date, super::MultiBackend>
+        for ::diesel::internal::derives::multiconnection::chrono::NaiveDate {
             fn to_sql<'b>(
                 &'b self,
-                out: &mut diesel::serialize::Output<'b, '_, super::MultiBackend>,
-            ) -> diesel::serialize::Result {
-                out.set_value((diesel::sql_types::Date, self));
-                Ok(diesel::serialize::IsNull::No)
+                out: &mut ::diesel::serialize::Output<'b, '_, super::MultiBackend>,
+            ) -> ::diesel::serialize::Result {
+                out.set_value((::diesel::sql_types::Date, self));
+                Ok(::diesel::serialize::IsNull::No)
             }
         }
-        impl diesel::serialize::ToSql<diesel::sql_types::Time, super::MultiBackend>
-        for diesel::internal::derives::multiconnection::chrono::NaiveTime {
+        impl ::diesel::serialize::ToSql<::diesel::sql_types::Time, super::MultiBackend>
+        for ::diesel::internal::derives::multiconnection::chrono::NaiveTime {
             fn to_sql<'b>(
                 &'b self,
-                out: &mut diesel::serialize::Output<'b, '_, super::MultiBackend>,
-            ) -> diesel::serialize::Result {
-                out.set_value((diesel::sql_types::Time, self));
-                Ok(diesel::serialize::IsNull::No)
+                out: &mut ::diesel::serialize::Output<'b, '_, super::MultiBackend>,
+            ) -> ::diesel::serialize::Result {
+                out.set_value((::diesel::sql_types::Time, self));
+                Ok(::diesel::serialize::IsNull::No)
             }
         }
-        impl diesel::serialize::ToSql<diesel::sql_types::Timestamp, super::MultiBackend>
-        for diesel::internal::derives::multiconnection::time::PrimitiveDateTime {
+        impl ::diesel::serialize::ToSql<
+            ::diesel::sql_types::Timestamp,
+            super::MultiBackend,
+        > for ::diesel::internal::derives::multiconnection::time::PrimitiveDateTime {
             fn to_sql<'b>(
                 &'b self,
-                out: &mut diesel::serialize::Output<'b, '_, super::MultiBackend>,
-            ) -> diesel::serialize::Result {
-                out.set_value((diesel::sql_types::Timestamp, self));
-                Ok(diesel::serialize::IsNull::No)
+                out: &mut ::diesel::serialize::Output<'b, '_, super::MultiBackend>,
+            ) -> ::diesel::serialize::Result {
+                out.set_value((::diesel::sql_types::Timestamp, self));
+                Ok(::diesel::serialize::IsNull::No)
             }
         }
-        impl diesel::serialize::ToSql<diesel::sql_types::Time, super::MultiBackend>
-        for diesel::internal::derives::multiconnection::time::Time {
+        impl ::diesel::serialize::ToSql<::diesel::sql_types::Time, super::MultiBackend>
+        for ::diesel::internal::derives::multiconnection::time::Time {
             fn to_sql<'b>(
                 &'b self,
-                out: &mut diesel::serialize::Output<'b, '_, super::MultiBackend>,
-            ) -> diesel::serialize::Result {
-                out.set_value((diesel::sql_types::Time, self));
-                Ok(diesel::serialize::IsNull::No)
+                out: &mut ::diesel::serialize::Output<'b, '_, super::MultiBackend>,
+            ) -> ::diesel::serialize::Result {
+                out.set_value((::diesel::sql_types::Time, self));
+                Ok(::diesel::serialize::IsNull::No)
             }
         }
-        impl diesel::serialize::ToSql<diesel::sql_types::Date, super::MultiBackend>
-        for diesel::internal::derives::multiconnection::time::Date {
+        impl ::diesel::serialize::ToSql<::diesel::sql_types::Date, super::MultiBackend>
+        for ::diesel::internal::derives::multiconnection::time::Date {
             fn to_sql<'b>(
                 &'b self,
-                out: &mut diesel::serialize::Output<'b, '_, super::MultiBackend>,
-            ) -> diesel::serialize::Result {
-                out.set_value((diesel::sql_types::Date, self));
-                Ok(diesel::serialize::IsNull::No)
+                out: &mut ::diesel::serialize::Output<'b, '_, super::MultiBackend>,
+            ) -> ::diesel::serialize::Result {
+                out.set_value((::diesel::sql_types::Date, self));
+                Ok(::diesel::serialize::IsNull::No)
             }
         }
-        impl diesel::deserialize::FromSql<
-            diesel::sql_types::SmallInt,
+        impl ::diesel::deserialize::FromSql<
+            ::diesel::sql_types::SmallInt,
             super::MultiBackend,
         > for i16 {
             fn from_sql(
-                bytes: <super::MultiBackend as diesel::backend::Backend>::RawValue<'_>,
-            ) -> diesel::deserialize::Result<Self> {
-                bytes.from_sql::<Self, diesel::sql_types::SmallInt>()
+                bytes: <super::MultiBackend as ::diesel::backend::Backend>::RawValue<'_>,
+            ) -> ::diesel::deserialize::Result<Self> {
+                bytes.from_sql::<Self, ::diesel::sql_types::SmallInt>()
             }
         }
-        impl diesel::deserialize::FromSql<
-            diesel::sql_types::Integer,
+        impl ::diesel::deserialize::FromSql<
+            ::diesel::sql_types::Integer,
             super::MultiBackend,
         > for i32 {
             fn from_sql(
-                bytes: <super::MultiBackend as diesel::backend::Backend>::RawValue<'_>,
-            ) -> diesel::deserialize::Result<Self> {
-                bytes.from_sql::<Self, diesel::sql_types::Integer>()
+                bytes: <super::MultiBackend as ::diesel::backend::Backend>::RawValue<'_>,
+            ) -> ::diesel::deserialize::Result<Self> {
+                bytes.from_sql::<Self, ::diesel::sql_types::Integer>()
             }
         }
-        impl diesel::deserialize::FromSql<diesel::sql_types::BigInt, super::MultiBackend>
-        for i64 {
-            fn from_sql(
-                bytes: <super::MultiBackend as diesel::backend::Backend>::RawValue<'_>,
-            ) -> diesel::deserialize::Result<Self> {
-                bytes.from_sql::<Self, diesel::sql_types::BigInt>()
-            }
-        }
-        impl diesel::deserialize::FromSql<diesel::sql_types::Double, super::MultiBackend>
-        for f64 {
-            fn from_sql(
-                bytes: <super::MultiBackend as diesel::backend::Backend>::RawValue<'_>,
-            ) -> diesel::deserialize::Result<Self> {
-                bytes.from_sql::<Self, diesel::sql_types::Double>()
-            }
-        }
-        impl diesel::deserialize::FromSql<diesel::sql_types::Float, super::MultiBackend>
-        for f32 {
-            fn from_sql(
-                bytes: <super::MultiBackend as diesel::backend::Backend>::RawValue<'_>,
-            ) -> diesel::deserialize::Result<Self> {
-                bytes.from_sql::<Self, diesel::sql_types::Float>()
-            }
-        }
-        impl diesel::deserialize::FromSql<diesel::sql_types::Text, super::MultiBackend>
-        for String {
-            fn from_sql(
-                bytes: <super::MultiBackend as diesel::backend::Backend>::RawValue<'_>,
-            ) -> diesel::deserialize::Result<Self> {
-                bytes.from_sql::<Self, diesel::sql_types::Text>()
-            }
-        }
-        impl diesel::deserialize::FromSql<diesel::sql_types::Binary, super::MultiBackend>
-        for Vec<u8> {
-            fn from_sql(
-                bytes: <super::MultiBackend as diesel::backend::Backend>::RawValue<'_>,
-            ) -> diesel::deserialize::Result<Self> {
-                bytes.from_sql::<Self, diesel::sql_types::Binary>()
-            }
-        }
-        impl diesel::deserialize::FromSql<diesel::sql_types::Bool, super::MultiBackend>
-        for bool {
-            fn from_sql(
-                bytes: <super::MultiBackend as diesel::backend::Backend>::RawValue<'_>,
-            ) -> diesel::deserialize::Result<Self> {
-                bytes.from_sql::<Self, diesel::sql_types::Bool>()
-            }
-        }
-        impl diesel::deserialize::FromSql<
-            diesel::sql_types::Numeric,
+        impl ::diesel::deserialize::FromSql<
+            ::diesel::sql_types::BigInt,
             super::MultiBackend,
-        > for diesel::internal::derives::multiconnection::bigdecimal::BigDecimal {
+        > for i64 {
             fn from_sql(
-                bytes: <super::MultiBackend as diesel::backend::Backend>::RawValue<'_>,
-            ) -> diesel::deserialize::Result<Self> {
-                bytes.from_sql::<Self, diesel::sql_types::Numeric>()
+                bytes: <super::MultiBackend as ::diesel::backend::Backend>::RawValue<'_>,
+            ) -> ::diesel::deserialize::Result<Self> {
+                bytes.from_sql::<Self, ::diesel::sql_types::BigInt>()
             }
         }
-        impl diesel::deserialize::FromSql<
-            diesel::sql_types::Timestamp,
+        impl ::diesel::deserialize::FromSql<
+            ::diesel::sql_types::Double,
             super::MultiBackend,
-        > for diesel::internal::derives::multiconnection::chrono::NaiveDateTime {
+        > for f64 {
             fn from_sql(
-                bytes: <super::MultiBackend as diesel::backend::Backend>::RawValue<'_>,
-            ) -> diesel::deserialize::Result<Self> {
-                bytes.from_sql::<Self, diesel::sql_types::Timestamp>()
+                bytes: <super::MultiBackend as ::diesel::backend::Backend>::RawValue<'_>,
+            ) -> ::diesel::deserialize::Result<Self> {
+                bytes.from_sql::<Self, ::diesel::sql_types::Double>()
             }
         }
-        impl diesel::deserialize::FromSql<diesel::sql_types::Date, super::MultiBackend>
-        for diesel::internal::derives::multiconnection::chrono::NaiveDate {
-            fn from_sql(
-                bytes: <super::MultiBackend as diesel::backend::Backend>::RawValue<'_>,
-            ) -> diesel::deserialize::Result<Self> {
-                bytes.from_sql::<Self, diesel::sql_types::Date>()
-            }
-        }
-        impl diesel::deserialize::FromSql<diesel::sql_types::Time, super::MultiBackend>
-        for diesel::internal::derives::multiconnection::chrono::NaiveTime {
-            fn from_sql(
-                bytes: <super::MultiBackend as diesel::backend::Backend>::RawValue<'_>,
-            ) -> diesel::deserialize::Result<Self> {
-                bytes.from_sql::<Self, diesel::sql_types::Time>()
-            }
-        }
-        impl diesel::deserialize::FromSql<
-            diesel::sql_types::Timestamp,
+        impl ::diesel::deserialize::FromSql<
+            ::diesel::sql_types::Float,
             super::MultiBackend,
-        > for diesel::internal::derives::multiconnection::time::PrimitiveDateTime {
+        > for f32 {
             fn from_sql(
-                bytes: <super::MultiBackend as diesel::backend::Backend>::RawValue<'_>,
-            ) -> diesel::deserialize::Result<Self> {
-                bytes.from_sql::<Self, diesel::sql_types::Timestamp>()
+                bytes: <super::MultiBackend as ::diesel::backend::Backend>::RawValue<'_>,
+            ) -> ::diesel::deserialize::Result<Self> {
+                bytes.from_sql::<Self, ::diesel::sql_types::Float>()
             }
         }
-        impl diesel::deserialize::FromSql<diesel::sql_types::Time, super::MultiBackend>
-        for diesel::internal::derives::multiconnection::time::Time {
+        impl ::diesel::deserialize::FromSql<
+            ::diesel::sql_types::Text,
+            super::MultiBackend,
+        > for String {
             fn from_sql(
-                bytes: <super::MultiBackend as diesel::backend::Backend>::RawValue<'_>,
-            ) -> diesel::deserialize::Result<Self> {
-                bytes.from_sql::<Self, diesel::sql_types::Time>()
+                bytes: <super::MultiBackend as ::diesel::backend::Backend>::RawValue<'_>,
+            ) -> ::diesel::deserialize::Result<Self> {
+                bytes.from_sql::<Self, ::diesel::sql_types::Text>()
             }
         }
-        impl diesel::deserialize::FromSql<diesel::sql_types::Date, super::MultiBackend>
-        for diesel::internal::derives::multiconnection::time::Date {
+        impl ::diesel::deserialize::FromSql<
+            ::diesel::sql_types::Binary,
+            super::MultiBackend,
+        > for Vec<u8> {
             fn from_sql(
-                bytes: <super::MultiBackend as diesel::backend::Backend>::RawValue<'_>,
-            ) -> diesel::deserialize::Result<Self> {
-                bytes.from_sql::<Self, diesel::sql_types::Date>()
+                bytes: <super::MultiBackend as ::diesel::backend::Backend>::RawValue<'_>,
+            ) -> ::diesel::deserialize::Result<Self> {
+                bytes.from_sql::<Self, ::diesel::sql_types::Binary>()
+            }
+        }
+        impl ::diesel::deserialize::FromSql<
+            ::diesel::sql_types::Bool,
+            super::MultiBackend,
+        > for bool {
+            fn from_sql(
+                bytes: <super::MultiBackend as ::diesel::backend::Backend>::RawValue<'_>,
+            ) -> ::diesel::deserialize::Result<Self> {
+                bytes.from_sql::<Self, ::diesel::sql_types::Bool>()
+            }
+        }
+        impl ::diesel::deserialize::FromSql<
+            ::diesel::sql_types::Numeric,
+            super::MultiBackend,
+        > for ::diesel::internal::derives::multiconnection::bigdecimal::BigDecimal {
+            fn from_sql(
+                bytes: <super::MultiBackend as ::diesel::backend::Backend>::RawValue<'_>,
+            ) -> ::diesel::deserialize::Result<Self> {
+                bytes.from_sql::<Self, ::diesel::sql_types::Numeric>()
+            }
+        }
+        impl ::diesel::deserialize::FromSql<
+            ::diesel::sql_types::Timestamp,
+            super::MultiBackend,
+        > for ::diesel::internal::derives::multiconnection::chrono::NaiveDateTime {
+            fn from_sql(
+                bytes: <super::MultiBackend as ::diesel::backend::Backend>::RawValue<'_>,
+            ) -> ::diesel::deserialize::Result<Self> {
+                bytes.from_sql::<Self, ::diesel::sql_types::Timestamp>()
+            }
+        }
+        impl ::diesel::deserialize::FromSql<
+            ::diesel::sql_types::Date,
+            super::MultiBackend,
+        > for ::diesel::internal::derives::multiconnection::chrono::NaiveDate {
+            fn from_sql(
+                bytes: <super::MultiBackend as ::diesel::backend::Backend>::RawValue<'_>,
+            ) -> ::diesel::deserialize::Result<Self> {
+                bytes.from_sql::<Self, ::diesel::sql_types::Date>()
+            }
+        }
+        impl ::diesel::deserialize::FromSql<
+            ::diesel::sql_types::Time,
+            super::MultiBackend,
+        > for ::diesel::internal::derives::multiconnection::chrono::NaiveTime {
+            fn from_sql(
+                bytes: <super::MultiBackend as ::diesel::backend::Backend>::RawValue<'_>,
+            ) -> ::diesel::deserialize::Result<Self> {
+                bytes.from_sql::<Self, ::diesel::sql_types::Time>()
+            }
+        }
+        impl ::diesel::deserialize::FromSql<
+            ::diesel::sql_types::Timestamp,
+            super::MultiBackend,
+        > for ::diesel::internal::derives::multiconnection::time::PrimitiveDateTime {
+            fn from_sql(
+                bytes: <super::MultiBackend as ::diesel::backend::Backend>::RawValue<'_>,
+            ) -> ::diesel::deserialize::Result<Self> {
+                bytes.from_sql::<Self, ::diesel::sql_types::Timestamp>()
+            }
+        }
+        impl ::diesel::deserialize::FromSql<
+            ::diesel::sql_types::Time,
+            super::MultiBackend,
+        > for ::diesel::internal::derives::multiconnection::time::Time {
+            fn from_sql(
+                bytes: <super::MultiBackend as ::diesel::backend::Backend>::RawValue<'_>,
+            ) -> ::diesel::deserialize::Result<Self> {
+                bytes.from_sql::<Self, ::diesel::sql_types::Time>()
+            }
+        }
+        impl ::diesel::deserialize::FromSql<
+            ::diesel::sql_types::Date,
+            super::MultiBackend,
+        > for ::diesel::internal::derives::multiconnection::time::Date {
+            fn from_sql(
+                bytes: <super::MultiBackend as ::diesel::backend::Backend>::RawValue<'_>,
+            ) -> ::diesel::deserialize::Result<Self> {
+                bytes.from_sql::<Self, ::diesel::sql_types::Date>()
             }
         }
         impl<
             T,
             ST,
-        > diesel::internal::derives::multiconnection::EnumMapping<super::MultiBackend>
-        for diesel::internal::derives::multiconnection::IntMapping<T, ST>
+        > ::diesel::internal::derives::multiconnection::EnumMapping<super::MultiBackend>
+        for ::diesel::internal::derives::multiconnection::IntMapping<T, ST>
         where
             ST: Default,
-            T: diesel::deserialize::FromSql<ST, super::MultiBackend> + 'static
-                + diesel::internal::derives::multiconnection::IntegerMappingHelper,
+            T: ::diesel::deserialize::FromSql<ST, super::MultiBackend> + 'static
+                + ::diesel::internal::derives::multiconnection::IntegerMappingHelper,
             for<'a> BindValue<'a>: From<(ST, &'a T)>,
             i128: TryFrom<T, Error: core::fmt::Display>,
         {
             fn map_to_database_value<'b>(
-                output: &mut diesel::serialize::Output<'b, '_, super::MultiBackend>,
-                variant: &'static diesel::internal::derives::multiconnection::EnumVariant,
-            ) -> diesel::serialize::Result {
-                let v = <T as diesel::internal::derives::multiconnection::IntegerMappingHelper>::as_ref(
+                output: &mut ::diesel::serialize::Output<'b, '_, super::MultiBackend>,
+                variant: &'static ::diesel::internal::derives::multiconnection::EnumVariant,
+            ) -> ::diesel::serialize::Result {
+                let v = <T as ::diesel::internal::derives::multiconnection::IntegerMappingHelper>::as_ref(
                     &variant.discriminant,
                 )?;
                 output.set_value((ST::default(), v));
-                Ok(diesel::serialize::IsNull::No)
+                Ok(::diesel::serialize::IsNull::No)
             }
             fn map_from_database_value(
-                raw: <super::MultiBackend as diesel::backend::Backend>::RawValue<'_>,
+                raw: <super::MultiBackend as ::diesel::backend::Backend>::RawValue<'_>,
                 type_name: &'static str,
-                variants: &'static [diesel::internal::derives::multiconnection::EnumVariant],
-            ) -> diesel::deserialize::Result<usize> {
-                let i = <T as diesel::deserialize::FromSql<
+                variants: &'static [::diesel::internal::derives::multiconnection::EnumVariant],
+            ) -> ::diesel::deserialize::Result<usize> {
+                let i = <T as ::diesel::deserialize::FromSql<
                     ST,
                     super::MultiBackend,
                 >>::from_sql(raw)?;
                 Self::from_discriminant(type_name, variants, i)
             }
         }
-        impl diesel::internal::derives::multiconnection::EnumMapping<super::MultiBackend>
-        for diesel::internal::derives::multiconnection::StringMapping {
+        impl ::diesel::internal::derives::multiconnection::EnumMapping<
+            super::MultiBackend,
+        > for ::diesel::internal::derives::multiconnection::StringMapping {
             fn map_to_database_value<'b>(
-                output: &mut diesel::serialize::Output<'b, '_, super::MultiBackend>,
-                variant: &'static diesel::internal::derives::multiconnection::EnumVariant,
-            ) -> diesel::serialize::Result {
-                <&str as diesel::serialize::ToSql<
-                    diesel::sql_types::Text,
+                output: &mut ::diesel::serialize::Output<'b, '_, super::MultiBackend>,
+                variant: &'static ::diesel::internal::derives::multiconnection::EnumVariant,
+            ) -> ::diesel::serialize::Result {
+                <&str as ::diesel::serialize::ToSql<
+                    ::diesel::sql_types::Text,
                     super::MultiBackend,
                 >>::to_sql(&variant.sql_name, output)
             }
             fn map_from_database_value(
-                raw: <super::MultiBackend as diesel::backend::Backend>::RawValue<'_>,
+                raw: <super::MultiBackend as ::diesel::backend::Backend>::RawValue<'_>,
                 type_name: &'static str,
-                variants: &'static [diesel::internal::derives::multiconnection::EnumVariant],
-            ) -> diesel::deserialize::Result<usize> {
-                let s = <String as diesel::deserialize::FromSql<
-                    diesel::sql_types::Text,
+                variants: &'static [::diesel::internal::derives::multiconnection::EnumVariant],
+            ) -> ::diesel::deserialize::Result<usize> {
+                let s = <String as ::diesel::deserialize::FromSql<
+                    ::diesel::sql_types::Text,
                     super::MultiBackend,
                 >>::from_sql(raw)?;
                 Self::from_variant_name(type_name, variants, &s)
@@ -1767,40 +1805,45 @@ mod multi_connection_impl {
     mod row {
         use super::*;
         pub enum MultiRow<'conn, 'query> {
-            Pg(<PgConnection as diesel::connection::LoadConnection>::Row<'conn, 'query>),
+            Pg(
+                <PgConnection as ::diesel::connection::LoadConnection>::Row<
+                    'conn,
+                    'query,
+                >,
+            ),
             Sqlite(
-                <diesel::SqliteConnection as diesel::connection::LoadConnection>::Row<
+                <diesel::SqliteConnection as ::diesel::connection::LoadConnection>::Row<
                     'conn,
                     'query,
                 >,
             ),
         }
-        impl<'conn, 'query> diesel::internal::derives::multiconnection::RowSealed
+        impl<'conn, 'query> ::diesel::internal::derives::multiconnection::RowSealed
         for MultiRow<'conn, 'query> {}
         pub enum MultiField<'conn: 'query, 'query> {
             Pg(
-                <<PgConnection as diesel::connection::LoadConnection>::Row<
+                <<PgConnection as ::diesel::connection::LoadConnection>::Row<
                     'conn,
                     'query,
-                > as diesel::row::Row<
+                > as ::diesel::row::Row<
                     'conn,
-                    <PgConnection as diesel::connection::Connection>::Backend,
+                    <PgConnection as ::diesel::connection::Connection>::Backend,
                 >>::Field<'query>,
             ),
             Sqlite(
-                <<diesel::SqliteConnection as diesel::connection::LoadConnection>::Row<
+                <<diesel::SqliteConnection as ::diesel::connection::LoadConnection>::Row<
                     'conn,
                     'query,
-                > as diesel::row::Row<
+                > as ::diesel::row::Row<
                     'conn,
-                    <diesel::SqliteConnection as diesel::connection::Connection>::Backend,
+                    <diesel::SqliteConnection as ::diesel::connection::Connection>::Backend,
                 >>::Field<'query>,
             ),
         }
-        impl<'conn, 'query> diesel::row::Field<'conn, super::MultiBackend>
+        impl<'conn, 'query> ::diesel::row::Field<'conn, super::MultiBackend>
         for MultiField<'conn, 'query> {
             fn field_name(&self) -> Option<&str> {
-                use diesel::row::Field;
+                use ::diesel::row::Field;
                 match self {
                     Self::Pg(f) => f.field_name(),
                     Self::Sqlite(f) => f.field_name(),
@@ -1809,40 +1852,40 @@ mod multi_connection_impl {
             fn value(
                 &self,
             ) -> Option<
-                <super::MultiBackend as diesel::backend::Backend>::RawValue<'_>,
+                <super::MultiBackend as ::diesel::backend::Backend>::RawValue<'_>,
             > {
-                use diesel::row::Field;
+                use ::diesel::row::Field;
                 match self {
                     Self::Pg(f) => f.value().map(super::MultiRawValue::Pg),
                     Self::Sqlite(f) => f.value().map(super::MultiRawValue::Sqlite),
                 }
             }
         }
-        impl<'conn, 'query, 'c> diesel::row::RowIndex<&'c str>
+        impl<'conn, 'query, 'c> ::diesel::row::RowIndex<&'c str>
         for MultiRow<'conn, 'query> {
             fn idx(&self, idx: &'c str) -> Option<usize> {
-                use diesel::row::RowIndex;
+                use ::diesel::row::RowIndex;
                 match self {
                     Self::Pg(r) => r.idx(idx),
                     Self::Sqlite(r) => r.idx(idx),
                 }
             }
         }
-        impl<'conn, 'query> diesel::row::RowIndex<usize> for MultiRow<'conn, 'query> {
+        impl<'conn, 'query> ::diesel::row::RowIndex<usize> for MultiRow<'conn, 'query> {
             fn idx(&self, idx: usize) -> Option<usize> {
-                use diesel::row::RowIndex;
+                use ::diesel::row::RowIndex;
                 match self {
                     Self::Pg(r) => r.idx(idx),
                     Self::Sqlite(r) => r.idx(idx),
                 }
             }
         }
-        impl<'conn, 'query> diesel::row::Row<'conn, super::MultiBackend>
+        impl<'conn, 'query> ::diesel::row::Row<'conn, super::MultiBackend>
         for MultiRow<'conn, 'query> {
             type Field<'a> = MultiField<'a, 'a> where 'conn: 'a, Self: 'a;
             type InnerPartialRow = Self;
             fn field_count(&self) -> usize {
-                use diesel::row::Row;
+                use ::diesel::row::Row;
                 match self {
                     Self::Pg(r) => r.field_count(),
                     Self::Sqlite(r) => r.field_count(),
@@ -1851,9 +1894,9 @@ mod multi_connection_impl {
             fn get<'b, I>(&'b self, idx: I) -> Option<Self::Field<'b>>
             where
                 'conn: 'b,
-                Self: diesel::row::RowIndex<I>,
+                Self: ::diesel::row::RowIndex<I>,
             {
-                use diesel::row::{RowIndex, Row};
+                use ::diesel::row::{RowIndex, Row};
                 let idx = self.idx(idx)?;
                 match self {
                     Self::Pg(r) => r.get(idx).map(MultiField::Pg),
@@ -1863,29 +1906,32 @@ mod multi_connection_impl {
             fn partial_row(
                 &self,
                 range: std::ops::Range<usize>,
-            ) -> diesel::internal::derives::multiconnection::PartialRow<
+            ) -> ::diesel::internal::derives::multiconnection::PartialRow<
                 '_,
                 Self::InnerPartialRow,
             > {
-                diesel::internal::derives::multiconnection::PartialRow::new(self, range)
+                ::diesel::internal::derives::multiconnection::PartialRow::new(
+                    self,
+                    range,
+                )
             }
         }
         pub enum MultiCursor<'conn, 'query> {
             Pg(
-                <PgConnection as diesel::connection::LoadConnection>::Cursor<
+                <PgConnection as ::diesel::connection::LoadConnection>::Cursor<
                     'conn,
                     'query,
                 >,
             ),
             Sqlite(
-                <diesel::SqliteConnection as diesel::connection::LoadConnection>::Cursor<
+                <diesel::SqliteConnection as ::diesel::connection::LoadConnection>::Cursor<
                     'conn,
                     'query,
                 >,
             ),
         }
         impl<'conn, 'query> Iterator for MultiCursor<'conn, 'query> {
-            type Item = diesel::QueryResult<MultiRow<'conn, 'query>>;
+            type Item = ::diesel::QueryResult<MultiRow<'conn, 'query>>;
             fn next(&mut self) -> Option<Self::Item> {
                 match self {
                     Self::Pg(r) => Some(r.next()?.map(MultiRow::Pg)),
@@ -1897,15 +1943,18 @@ mod multi_connection_impl {
     mod connection {
         use super::*;
         pub(super) use super::DbConnection as MultiConnection;
-        impl diesel::connection::SimpleConnection for MultiConnection {
-            fn batch_execute(&mut self, query: &str) -> diesel::result::QueryResult<()> {
+        impl ::diesel::connection::SimpleConnection for MultiConnection {
+            fn batch_execute(
+                &mut self,
+                query: &str,
+            ) -> ::diesel::result::QueryResult<()> {
                 match self {
                     Self::Pg(conn) => conn.batch_execute(query),
                     Self::Sqlite(conn) => conn.batch_execute(query),
                 }
             }
         }
-        impl diesel::internal::derives::multiconnection::ConnectionSealed
+        impl ::diesel::internal::derives::multiconnection::ConnectionSealed
         for MultiConnection {}
         struct SerializedQuery<T, C> {
             inner: T,
@@ -1913,26 +1962,26 @@ mod multi_connection_impl {
             query_builder: super::query_builder::MultiQueryBuilder,
             p: std::marker::PhantomData<C>,
         }
-        trait BindParamHelper: diesel::connection::Connection {
+        trait BindParamHelper: ::diesel::connection::Connection {
             fn handle_inner_pass<'a, 'b: 'a>(
-                collector: &mut <Self::Backend as diesel::backend::Backend>::BindCollector<
+                collector: &mut <Self::Backend as ::diesel::backend::Backend>::BindCollector<
                     'a,
                 >,
-                lookup: &mut <Self::Backend as diesel::sql_types::TypeMetadata>::MetadataLookup,
+                lookup: &mut <Self::Backend as ::diesel::sql_types::TypeMetadata>::MetadataLookup,
                 backend: &'b MultiBackend,
-                q: &'b impl diesel::query_builder::QueryFragment<MultiBackend>,
-            ) -> diesel::QueryResult<()>;
+                q: &'b impl ::diesel::query_builder::QueryFragment<MultiBackend>,
+            ) -> ::diesel::QueryResult<()>;
         }
         impl BindParamHelper for PgConnection {
             fn handle_inner_pass<'a, 'b: 'a>(
-                outer_collector: &mut <Self::Backend as diesel::backend::Backend>::BindCollector<
+                outer_collector: &mut <Self::Backend as ::diesel::backend::Backend>::BindCollector<
                     'a,
                 >,
-                lookup: &mut <Self::Backend as diesel::sql_types::TypeMetadata>::MetadataLookup,
+                lookup: &mut <Self::Backend as ::diesel::sql_types::TypeMetadata>::MetadataLookup,
                 backend: &'b MultiBackend,
-                q: &'b impl diesel::query_builder::QueryFragment<MultiBackend>,
-            ) -> diesel::QueryResult<()> {
-                use diesel::internal::derives::multiconnection::MultiConnectionHelper;
+                q: &'b impl ::diesel::query_builder::QueryFragment<MultiBackend>,
+            ) -> ::diesel::QueryResult<()> {
+                use ::diesel::internal::derives::multiconnection::MultiConnectionHelper;
                 let mut collector = super::bind_collector::MultiBindCollector::Pg(
                     Default::default(),
                 );
@@ -1946,14 +1995,14 @@ mod multi_connection_impl {
         }
         impl BindParamHelper for diesel::SqliteConnection {
             fn handle_inner_pass<'a, 'b: 'a>(
-                outer_collector: &mut <Self::Backend as diesel::backend::Backend>::BindCollector<
+                outer_collector: &mut <Self::Backend as ::diesel::backend::Backend>::BindCollector<
                     'a,
                 >,
-                lookup: &mut <Self::Backend as diesel::sql_types::TypeMetadata>::MetadataLookup,
+                lookup: &mut <Self::Backend as ::diesel::sql_types::TypeMetadata>::MetadataLookup,
                 backend: &'b MultiBackend,
-                q: &'b impl diesel::query_builder::QueryFragment<MultiBackend>,
-            ) -> diesel::QueryResult<()> {
-                use diesel::internal::derives::multiconnection::MultiConnectionHelper;
+                q: &'b impl ::diesel::query_builder::QueryFragment<MultiBackend>,
+            ) -> ::diesel::QueryResult<()> {
+                use ::diesel::internal::derives::multiconnection::MultiConnectionHelper;
                 let mut collector = super::bind_collector::MultiBindCollector::Sqlite(
                     Default::default(),
                 );
@@ -1965,19 +2014,20 @@ mod multi_connection_impl {
                 Ok(())
             }
         }
-        impl<T, DB, C> diesel::query_builder::QueryFragment<DB> for SerializedQuery<T, C>
+        impl<T, DB, C> ::diesel::query_builder::QueryFragment<DB>
+        for SerializedQuery<T, C>
         where
-            DB: diesel::backend::Backend + 'static,
-            T: diesel::query_builder::QueryFragment<MultiBackend>,
-            C: diesel::connection::Connection<Backend = DB> + BindParamHelper
-                + diesel::internal::derives::multiconnection::MultiConnectionHelper,
+            DB: ::diesel::backend::Backend + 'static,
+            T: ::diesel::query_builder::QueryFragment<MultiBackend>,
+            C: ::diesel::connection::Connection<Backend = DB> + BindParamHelper
+                + ::diesel::internal::derives::multiconnection::MultiConnectionHelper,
         {
             fn walk_ast<'b>(
                 &'b self,
-                mut pass: diesel::query_builder::AstPass<'_, 'b, DB>,
-            ) -> diesel::QueryResult<()> {
-                use diesel::query_builder::QueryBuilder;
-                use diesel::internal::derives::multiconnection::AstPassHelper;
+                mut pass: ::diesel::query_builder::AstPass<'_, 'b, DB>,
+            ) -> ::diesel::QueryResult<()> {
+                use ::diesel::query_builder::QueryBuilder;
+                use ::diesel::internal::derives::multiconnection::AstPassHelper;
                 let mut query_builder = self.query_builder.duplicate();
                 self.inner.to_sql(&mut query_builder, &self.backend)?;
                 pass.push_sql(&query_builder.finish());
@@ -1993,7 +2043,7 @@ mod multi_connection_impl {
                     )?;
                 }
                 if let Some((formatter, _backend)) = pass.debug_binds() {
-                    let pass = diesel::query_builder::AstPass::<
+                    let pass = ::diesel::query_builder::AstPass::<
                         MultiBackend,
                     >::collect_debug_binds_pass(formatter, &self.backend);
                     self.inner.walk_ast(pass)?;
@@ -2001,23 +2051,23 @@ mod multi_connection_impl {
                 Ok(())
             }
         }
-        impl<T, C> diesel::query_builder::QueryId for SerializedQuery<T, C>
+        impl<T, C> ::diesel::query_builder::QueryId for SerializedQuery<T, C>
         where
-            T: diesel::query_builder::QueryId,
+            T: ::diesel::query_builder::QueryId,
         {
-            type QueryId = <T as diesel::query_builder::QueryId>::QueryId;
-            const HAS_STATIC_QUERY_ID: bool = <T as diesel::query_builder::QueryId>::HAS_STATIC_QUERY_ID;
+            type QueryId = <T as ::diesel::query_builder::QueryId>::QueryId;
+            const HAS_STATIC_QUERY_ID: bool = <T as ::diesel::query_builder::QueryId>::HAS_STATIC_QUERY_ID;
         }
-        impl<T, C> diesel::query_builder::Query for SerializedQuery<T, C>
+        impl<T, C> ::diesel::query_builder::Query for SerializedQuery<T, C>
         where
-            T: diesel::query_builder::Query,
+            T: ::diesel::query_builder::Query,
         {
-            type SqlType = diesel::sql_types::Untyped;
+            type SqlType = ::diesel::sql_types::Untyped;
         }
-        impl diesel::connection::Connection for MultiConnection {
+        impl ::diesel::connection::Connection for MultiConnection {
             type Backend = super::MultiBackend;
             type TransactionManager = Self;
-            fn establish(database_url: &str) -> diesel::ConnectionResult<Self> {
+            fn establish(database_url: &str) -> ::diesel::ConnectionResult<Self> {
                 if let Ok(conn) = PgConnection::establish(database_url) {
                     return Ok(Self::Pg(conn));
                 }
@@ -2025,7 +2075,7 @@ mod multi_connection_impl {
                     return Ok(Self::Sqlite(conn));
                 }
                 Err(
-                    diesel::ConnectionError::BadConnection(
+                    ::diesel::ConnectionError::BadConnection(
                         "Invalid connection url for multiconnection".into(),
                     ),
                 )
@@ -2033,10 +2083,10 @@ mod multi_connection_impl {
             fn execute_returning_count<T>(
                 &mut self,
                 source: &T,
-            ) -> diesel::result::QueryResult<usize>
+            ) -> ::diesel::result::QueryResult<usize>
             where
-                T: diesel::query_builder::QueryFragment<Self::Backend>
-                    + diesel::query_builder::QueryId,
+                T: ::diesel::query_builder::QueryFragment<Self::Backend>
+                    + ::diesel::query_builder::QueryId,
             {
                 match self {
                     Self::Pg(conn) => {
@@ -2065,36 +2115,36 @@ mod multi_connection_impl {
             }
             fn transaction_state(
                 &mut self,
-            ) -> &mut <Self::TransactionManager as diesel::connection::TransactionManager<
+            ) -> &mut <Self::TransactionManager as ::diesel::connection::TransactionManager<
                 Self,
             >>::TransactionStateData {
                 self
             }
             fn instrumentation(
                 &mut self,
-            ) -> &mut dyn diesel::connection::Instrumentation {
+            ) -> &mut dyn ::diesel::connection::Instrumentation {
                 match self {
                     Self::Pg(conn) => {
-                        diesel::connection::Connection::instrumentation(conn)
+                        ::diesel::connection::Connection::instrumentation(conn)
                     }
                     Self::Sqlite(conn) => {
-                        diesel::connection::Connection::instrumentation(conn)
+                        ::diesel::connection::Connection::instrumentation(conn)
                     }
                 }
             }
             fn set_instrumentation(
                 &mut self,
-                instrumentation: impl diesel::connection::Instrumentation,
+                instrumentation: impl ::diesel::connection::Instrumentation,
             ) {
                 match self {
                     Self::Pg(conn) => {
-                        diesel::connection::Connection::set_instrumentation(
+                        ::diesel::connection::Connection::set_instrumentation(
                             conn,
                             instrumentation,
                         );
                     }
                     Self::Sqlite(conn) => {
-                        diesel::connection::Connection::set_instrumentation(
+                        ::diesel::connection::Connection::set_instrumentation(
                             conn,
                             instrumentation,
                         );
@@ -2103,42 +2153,42 @@ mod multi_connection_impl {
             }
             fn set_prepared_statement_cache_size(
                 &mut self,
-                size: diesel::connection::CacheSize,
+                size: ::diesel::connection::CacheSize,
             ) {
                 match self {
                     Self::Pg(conn) => {
-                        diesel::connection::Connection::set_prepared_statement_cache_size(
+                        ::diesel::connection::Connection::set_prepared_statement_cache_size(
                             conn,
                             size,
                         );
                     }
                     Self::Sqlite(conn) => {
-                        diesel::connection::Connection::set_prepared_statement_cache_size(
+                        ::diesel::connection::Connection::set_prepared_statement_cache_size(
                             conn,
                             size,
                         );
                     }
                 }
             }
-            fn begin_test_transaction(&mut self) -> diesel::QueryResult<()> {
+            fn begin_test_transaction(&mut self) -> ::diesel::QueryResult<()> {
                 match self {
                     Self::Pg(conn) => conn.begin_test_transaction(),
                     Self::Sqlite(conn) => conn.begin_test_transaction(),
                 }
             }
         }
-        impl diesel::connection::LoadConnection for MultiConnection {
+        impl ::diesel::connection::LoadConnection for MultiConnection {
             type Cursor<'conn, 'query> = super::row::MultiCursor<'conn, 'query>;
             type Row<'conn, 'query> = super::MultiRow<'conn, 'query>;
             fn load<'conn, 'query, T>(
                 &'conn mut self,
                 source: T,
-            ) -> diesel::result::QueryResult<Self::Cursor<'conn, 'query>>
+            ) -> ::diesel::result::QueryResult<Self::Cursor<'conn, 'query>>
             where
-                T: diesel::query_builder::Query
-                    + diesel::query_builder::QueryFragment<Self::Backend>
-                    + diesel::query_builder::QueryId + 'query,
-                Self::Backend: diesel::expression::QueryMetadata<T::SqlType>,
+                T: ::diesel::query_builder::Query
+                    + ::diesel::query_builder::QueryFragment<Self::Backend>
+                    + ::diesel::query_builder::QueryId + 'query,
+                Self::Backend: ::diesel::expression::QueryMetadata<T::SqlType>,
             {
                 match self {
                     Self::Pg(conn) => {
@@ -2150,7 +2200,7 @@ mod multi_connection_impl {
                             ),
                             p: std::marker::PhantomData::<PgConnection>,
                         };
-                        let r = <PgConnection as diesel::connection::LoadConnection>::load(
+                        let r = <PgConnection as ::diesel::connection::LoadConnection>::load(
                             conn,
                             query,
                         );
@@ -2165,7 +2215,7 @@ mod multi_connection_impl {
                             ),
                             p: std::marker::PhantomData::<diesel::SqliteConnection>,
                         };
-                        let r = <diesel::SqliteConnection as diesel::connection::LoadConnection>::load(
+                        let r = <diesel::SqliteConnection as ::diesel::connection::LoadConnection>::load(
                             conn,
                             query,
                         );
@@ -2174,18 +2224,20 @@ mod multi_connection_impl {
                 }
             }
         }
-        impl diesel::connection::TransactionManager<MultiConnection>
+        impl ::diesel::connection::TransactionManager<MultiConnection>
         for MultiConnection {
             type TransactionStateData = Self;
-            fn begin_transaction(conn: &mut MultiConnection) -> diesel::QueryResult<()> {
+            fn begin_transaction(
+                conn: &mut MultiConnection,
+            ) -> ::diesel::QueryResult<()> {
                 match conn {
                     Self::Pg(conn) => {
-                        <PgConnection as diesel::connection::Connection>::TransactionManager::begin_transaction(
+                        <PgConnection as ::diesel::connection::Connection>::TransactionManager::begin_transaction(
                             conn,
                         )
                     }
                     Self::Sqlite(conn) => {
-                        <diesel::SqliteConnection as diesel::connection::Connection>::TransactionManager::begin_transaction(
+                        <diesel::SqliteConnection as ::diesel::connection::Connection>::TransactionManager::begin_transaction(
                             conn,
                         )
                     }
@@ -2193,15 +2245,15 @@ mod multi_connection_impl {
             }
             fn rollback_transaction(
                 conn: &mut MultiConnection,
-            ) -> diesel::QueryResult<()> {
+            ) -> ::diesel::QueryResult<()> {
                 match conn {
                     Self::Pg(conn) => {
-                        <PgConnection as diesel::connection::Connection>::TransactionManager::rollback_transaction(
+                        <PgConnection as ::diesel::connection::Connection>::TransactionManager::rollback_transaction(
                             conn,
                         )
                     }
                     Self::Sqlite(conn) => {
-                        <diesel::SqliteConnection as diesel::connection::Connection>::TransactionManager::rollback_transaction(
+                        <diesel::SqliteConnection as ::diesel::connection::Connection>::TransactionManager::rollback_transaction(
                             conn,
                         )
                     }
@@ -2209,15 +2261,15 @@ mod multi_connection_impl {
             }
             fn commit_transaction(
                 conn: &mut MultiConnection,
-            ) -> diesel::QueryResult<()> {
+            ) -> ::diesel::QueryResult<()> {
                 match conn {
                     Self::Pg(conn) => {
-                        <PgConnection as diesel::connection::Connection>::TransactionManager::commit_transaction(
+                        <PgConnection as ::diesel::connection::Connection>::TransactionManager::commit_transaction(
                             conn,
                         )
                     }
                     Self::Sqlite(conn) => {
-                        <diesel::SqliteConnection as diesel::connection::Connection>::TransactionManager::commit_transaction(
+                        <diesel::SqliteConnection as ::diesel::connection::Connection>::TransactionManager::commit_transaction(
                             conn,
                         )
                     }
@@ -2225,15 +2277,15 @@ mod multi_connection_impl {
             }
             fn transaction_manager_status_mut(
                 conn: &mut MultiConnection,
-            ) -> &mut diesel::connection::TransactionManagerStatus {
+            ) -> &mut ::diesel::connection::TransactionManagerStatus {
                 match conn {
                     Self::Pg(conn) => {
-                        <PgConnection as diesel::connection::Connection>::TransactionManager::transaction_manager_status_mut(
+                        <PgConnection as ::diesel::connection::Connection>::TransactionManager::transaction_manager_status_mut(
                             conn,
                         )
                     }
                     Self::Sqlite(conn) => {
-                        <diesel::SqliteConnection as diesel::connection::Connection>::TransactionManager::transaction_manager_status_mut(
+                        <diesel::SqliteConnection as ::diesel::connection::Connection>::TransactionManager::transaction_manager_status_mut(
                             conn,
                         )
                     }
@@ -2242,66 +2294,69 @@ mod multi_connection_impl {
             fn is_broken_transaction_manager(conn: &mut MultiConnection) -> bool {
                 match conn {
                     Self::Pg(conn) => {
-                        <PgConnection as diesel::connection::Connection>::TransactionManager::is_broken_transaction_manager(
+                        <PgConnection as ::diesel::connection::Connection>::TransactionManager::is_broken_transaction_manager(
                             conn,
                         )
                     }
                     Self::Sqlite(conn) => {
-                        <diesel::SqliteConnection as diesel::connection::Connection>::TransactionManager::is_broken_transaction_manager(
+                        <diesel::SqliteConnection as ::diesel::connection::Connection>::TransactionManager::is_broken_transaction_manager(
                             conn,
                         )
                     }
                 }
             }
         }
-        impl diesel::migration::MigrationConnection for MultiConnection {
-            fn setup(&mut self) -> diesel::QueryResult<usize> {
+        impl ::diesel::migration::MigrationConnection for MultiConnection {
+            fn setup(&mut self) -> ::diesel::QueryResult<usize> {
                 match self {
                     Self::Pg(conn) => {
-                        use diesel::migration::MigrationConnection;
+                        use ::diesel::migration::MigrationConnection;
                         conn.setup()
                     }
                     Self::Sqlite(conn) => {
-                        use diesel::migration::MigrationConnection;
+                        use ::diesel::migration::MigrationConnection;
                         conn.setup()
                     }
                 }
             }
-            fn read_search_path(&mut self) -> diesel::QueryResult<Option<String>> {
+            fn read_search_path(&mut self) -> ::diesel::QueryResult<Option<String>> {
                 match self {
                     Self::Pg(conn) => {
-                        use diesel::migration::MigrationConnection;
+                        use ::diesel::migration::MigrationConnection;
                         conn.read_search_path()
                     }
                     Self::Sqlite(conn) => {
-                        use diesel::migration::MigrationConnection;
+                        use ::diesel::migration::MigrationConnection;
                         conn.read_search_path()
                     }
                 }
             }
-            fn set_search_path(&mut self, search_path: &str) -> diesel::QueryResult<()> {
+            fn set_search_path(
+                &mut self,
+                search_path: &str,
+            ) -> ::diesel::QueryResult<()> {
                 match self {
                     Self::Pg(conn) => {
-                        use diesel::migration::MigrationConnection;
+                        use ::diesel::migration::MigrationConnection;
                         conn.set_search_path(search_path)
                     }
                     Self::Sqlite(conn) => {
-                        use diesel::migration::MigrationConnection;
+                        use ::diesel::migration::MigrationConnection;
                         conn.set_search_path(search_path)
                     }
                 }
             }
         }
-        impl diesel::r2d2::R2D2Connection for MultiConnection {
-            fn ping(&mut self) -> diesel::QueryResult<()> {
-                use diesel::r2d2::R2D2Connection;
+        impl ::diesel::r2d2::R2D2Connection for MultiConnection {
+            fn ping(&mut self) -> ::diesel::QueryResult<()> {
+                use ::diesel::r2d2::R2D2Connection;
                 match self {
                     Self::Pg(conn) => conn.ping(),
                     Self::Sqlite(conn) => conn.ping(),
                 }
             }
             fn is_broken(&mut self) -> bool {
-                use diesel::r2d2::R2D2Connection;
+                use ::diesel::r2d2::R2D2Connection;
                 match self {
                     Self::Pg(conn) => conn.is_broken(),
                     Self::Sqlite(conn) => conn.is_broken(),

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__multiconnection_2.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__multiconnection_2.snap
@@ -37,10 +37,10 @@ mod multi_connection_impl {
                 lookup: &mut dyn std::any::Any,
             ) -> MultiTypeMetadata
             where
-                <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend: diesel::sql_types::HasSqlType<
+                <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend: ::diesel::sql_types::HasSqlType<
                     ST,
                 >,
-                <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend: diesel::sql_types::HasSqlType<
+                <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend: ::diesel::sql_types::HasSqlType<
                     ST,
                 >,
             {
@@ -49,7 +49,7 @@ mod multi_connection_impl {
                     lookup,
                 ) {
                     ret.Pg = Some(
-                        <<diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend as diesel::sql_types::HasSqlType<
+                        <<diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend as ::diesel::sql_types::HasSqlType<
                             ST,
                         >>::metadata(lookup),
                     );
@@ -58,7 +58,7 @@ mod multi_connection_impl {
                     lookup,
                 ) {
                     ret.Sqlite = Some(
-                        <<diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend as diesel::sql_types::HasSqlType<
+                        <<diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend as ::diesel::sql_types::HasSqlType<
                             ST,
                         >>::metadata(lookup),
                     );
@@ -69,20 +69,20 @@ mod multi_connection_impl {
         impl MultiBackend {
             pub fn walk_variant_ast<'b, T>(
                 ast_node: &'b T,
-                pass: diesel::query_builder::AstPass<'_, 'b, Self>,
-            ) -> diesel::QueryResult<()>
+                pass: ::diesel::query_builder::AstPass<'_, 'b, Self>,
+            ) -> ::diesel::QueryResult<()>
             where
-                T: diesel::query_builder::QueryFragment<
+                T: ::diesel::query_builder::QueryFragment<
                     <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >,
-                T: diesel::query_builder::QueryFragment<
+                T: ::diesel::query_builder::QueryFragment<
                     <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >,
             {
-                use diesel::internal::derives::multiconnection::AstPassHelper;
+                use ::diesel::internal::derives::multiconnection::AstPassHelper;
                 match pass.backend() {
                     super::backend::MultiBackend::Pg(_) => {
-                        <T as diesel::query_builder::QueryFragment<
+                        <T as ::diesel::query_builder::QueryFragment<
                             <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend,
                         >>::walk_ast(
                             ast_node,
@@ -103,7 +103,7 @@ mod multi_connection_impl {
                         )
                     }
                     super::backend::MultiBackend::Sqlite(_) => {
-                        <T as diesel::query_builder::QueryFragment<
+                        <T as ::diesel::query_builder::QueryFragment<
                             <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend,
                         >>::walk_ast(
                             ast_node,
@@ -128,37 +128,37 @@ mod multi_connection_impl {
         }
         pub enum MultiRawValue<'a> {
             Pg(
-                <<diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend as diesel::backend::Backend>::RawValue<
+                <<diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend as ::diesel::backend::Backend>::RawValue<
                     'a,
                 >,
             ),
             Sqlite(
-                <<diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend as diesel::backend::Backend>::RawValue<
+                <<diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend as ::diesel::backend::Backend>::RawValue<
                     'a,
                 >,
             ),
         }
         impl MultiRawValue<'_> {
-            pub fn from_sql<T, ST>(self) -> diesel::deserialize::Result<T>
+            pub fn from_sql<T, ST>(self) -> ::diesel::deserialize::Result<T>
             where
-                T: diesel::deserialize::FromSql<
+                T: ::diesel::deserialize::FromSql<
                     ST,
                     <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >,
-                T: diesel::deserialize::FromSql<
+                T: ::diesel::deserialize::FromSql<
                     ST,
                     <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >,
             {
                 match self {
                     Self::Pg(b) => {
-                        <T as diesel::deserialize::FromSql<
+                        <T as ::diesel::deserialize::FromSql<
                             ST,
                             <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend,
                         >>::from_sql(b)
                     }
                     Self::Sqlite(b) => {
-                        <T as diesel::deserialize::FromSql<
+                        <T as ::diesel::deserialize::FromSql<
                             ST,
                             <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend,
                         >>::from_sql(b)
@@ -166,7 +166,7 @@ mod multi_connection_impl {
                 }
             }
         }
-        impl diesel::backend::Backend for MultiBackend {
+        impl ::diesel::backend::Backend for MultiBackend {
             type QueryBuilder = super::query_builder::MultiQueryBuilder;
             type RawValue<'a> = MultiRawValue<'a>;
             type BindCollector<'a> = super::bind_collector::MultiBindCollector<'a>;
@@ -175,13 +175,13 @@ mod multi_connection_impl {
         #[allow(non_snake_case)]
         pub struct MultiTypeMetadata {
             pub(super) Pg: Option<
-                <<diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend as diesel::sql_types::TypeMetadata>::TypeMetadata,
+                <<diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend as ::diesel::sql_types::TypeMetadata>::TypeMetadata,
             >,
             pub(super) Sqlite: Option<
-                <<diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend as diesel::sql_types::TypeMetadata>::TypeMetadata,
+                <<diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend as ::diesel::sql_types::TypeMetadata>::TypeMetadata,
             >,
         }
-        impl diesel::sql_types::TypeMetadata for MultiBackend {
+        impl ::diesel::sql_types::TypeMetadata for MultiBackend {
             type TypeMetadata = MultiTypeMetadata;
             type MetadataLookup = dyn std::any::Any;
         }
@@ -200,9 +200,9 @@ mod multi_connection_impl {
         pub struct MultiWindowFrameExclusionSupport;
         pub struct MultiAggregateFunctionExpressions;
         pub struct MultiBuiltInWindowFunctionRequireOrder;
-        impl diesel::backend::SqlDialect for MultiBackend {
+        impl ::diesel::backend::SqlDialect for MultiBackend {
             type ReturningClause = MultiReturningClause;
-            type OnConflictClause = diesel::internal::derives::multiconnection::sql_dialect::on_conflict_clause::DoesNotSupportOnConflictClause;
+            type OnConflictClause = ::diesel::internal::derives::multiconnection::sql_dialect::on_conflict_clause::DoesNotSupportOnConflictClause;
             type InsertWithDefaultKeyword = MultiInsertWithDefaultKeyword;
             type BatchInsertSupport = MultiBatchInsertSupport;
             type BatchUpdateSupport = MultiBatchUpdateSupport;
@@ -218,80 +218,80 @@ mod multi_connection_impl {
             type AggregateFunctionExpressions = MultiAggregateFunctionExpressions;
             type BuiltInWindowFunctionRequireOrder = MultiBuiltInWindowFunctionRequireOrder;
         }
-        impl diesel::internal::derives::multiconnection::TrustedBackend
+        impl ::diesel::internal::derives::multiconnection::TrustedBackend
         for MultiBackend {}
-        impl diesel::internal::derives::multiconnection::DieselReserveSpecialization
+        impl ::diesel::internal::derives::multiconnection::DieselReserveSpecialization
         for MultiBackend {}
-        impl diesel::sql_types::HasSqlType<diesel::sql_types::SmallInt>
+        impl ::diesel::sql_types::HasSqlType<::diesel::sql_types::SmallInt>
         for super::MultiBackend {
             fn metadata(lookup: &mut Self::MetadataLookup) -> Self::TypeMetadata {
-                Self::lookup_sql_type::<diesel::sql_types::SmallInt>(lookup)
+                Self::lookup_sql_type::<::diesel::sql_types::SmallInt>(lookup)
             }
         }
-        impl diesel::sql_types::HasSqlType<diesel::sql_types::Integer>
+        impl ::diesel::sql_types::HasSqlType<::diesel::sql_types::Integer>
         for super::MultiBackend {
             fn metadata(lookup: &mut Self::MetadataLookup) -> Self::TypeMetadata {
-                Self::lookup_sql_type::<diesel::sql_types::Integer>(lookup)
+                Self::lookup_sql_type::<::diesel::sql_types::Integer>(lookup)
             }
         }
-        impl diesel::sql_types::HasSqlType<diesel::sql_types::BigInt>
+        impl ::diesel::sql_types::HasSqlType<::diesel::sql_types::BigInt>
         for super::MultiBackend {
             fn metadata(lookup: &mut Self::MetadataLookup) -> Self::TypeMetadata {
-                Self::lookup_sql_type::<diesel::sql_types::BigInt>(lookup)
+                Self::lookup_sql_type::<::diesel::sql_types::BigInt>(lookup)
             }
         }
-        impl diesel::sql_types::HasSqlType<diesel::sql_types::Double>
+        impl ::diesel::sql_types::HasSqlType<::diesel::sql_types::Double>
         for super::MultiBackend {
             fn metadata(lookup: &mut Self::MetadataLookup) -> Self::TypeMetadata {
-                Self::lookup_sql_type::<diesel::sql_types::Double>(lookup)
+                Self::lookup_sql_type::<::diesel::sql_types::Double>(lookup)
             }
         }
-        impl diesel::sql_types::HasSqlType<diesel::sql_types::Float>
+        impl ::diesel::sql_types::HasSqlType<::diesel::sql_types::Float>
         for super::MultiBackend {
             fn metadata(lookup: &mut Self::MetadataLookup) -> Self::TypeMetadata {
-                Self::lookup_sql_type::<diesel::sql_types::Float>(lookup)
+                Self::lookup_sql_type::<::diesel::sql_types::Float>(lookup)
             }
         }
-        impl diesel::sql_types::HasSqlType<diesel::sql_types::Text>
+        impl ::diesel::sql_types::HasSqlType<::diesel::sql_types::Text>
         for super::MultiBackend {
             fn metadata(lookup: &mut Self::MetadataLookup) -> Self::TypeMetadata {
-                Self::lookup_sql_type::<diesel::sql_types::Text>(lookup)
+                Self::lookup_sql_type::<::diesel::sql_types::Text>(lookup)
             }
         }
-        impl diesel::sql_types::HasSqlType<diesel::sql_types::Binary>
+        impl ::diesel::sql_types::HasSqlType<::diesel::sql_types::Binary>
         for super::MultiBackend {
             fn metadata(lookup: &mut Self::MetadataLookup) -> Self::TypeMetadata {
-                Self::lookup_sql_type::<diesel::sql_types::Binary>(lookup)
+                Self::lookup_sql_type::<::diesel::sql_types::Binary>(lookup)
             }
         }
-        impl diesel::sql_types::HasSqlType<diesel::sql_types::Date>
+        impl ::diesel::sql_types::HasSqlType<::diesel::sql_types::Date>
         for super::MultiBackend {
             fn metadata(lookup: &mut Self::MetadataLookup) -> Self::TypeMetadata {
-                Self::lookup_sql_type::<diesel::sql_types::Date>(lookup)
+                Self::lookup_sql_type::<::diesel::sql_types::Date>(lookup)
             }
         }
-        impl diesel::sql_types::HasSqlType<diesel::sql_types::Time>
+        impl ::diesel::sql_types::HasSqlType<::diesel::sql_types::Time>
         for super::MultiBackend {
             fn metadata(lookup: &mut Self::MetadataLookup) -> Self::TypeMetadata {
-                Self::lookup_sql_type::<diesel::sql_types::Time>(lookup)
+                Self::lookup_sql_type::<::diesel::sql_types::Time>(lookup)
             }
         }
-        impl diesel::sql_types::HasSqlType<diesel::sql_types::Timestamp>
+        impl ::diesel::sql_types::HasSqlType<::diesel::sql_types::Timestamp>
         for super::MultiBackend {
             fn metadata(lookup: &mut Self::MetadataLookup) -> Self::TypeMetadata {
-                Self::lookup_sql_type::<diesel::sql_types::Timestamp>(lookup)
+                Self::lookup_sql_type::<::diesel::sql_types::Timestamp>(lookup)
             }
         }
-        impl diesel::sql_types::HasSqlType<diesel::sql_types::Bool>
+        impl ::diesel::sql_types::HasSqlType<::diesel::sql_types::Bool>
         for super::MultiBackend {
             fn metadata(lookup: &mut Self::MetadataLookup) -> Self::TypeMetadata {
-                Self::lookup_sql_type::<diesel::sql_types::Bool>(lookup)
+                Self::lookup_sql_type::<::diesel::sql_types::Bool>(lookup)
             }
         }
-        impl diesel::sql_types::HasSqlType<diesel::sql_types::Numeric>
+        impl ::diesel::sql_types::HasSqlType<::diesel::sql_types::Numeric>
         for super::MultiBackend {
             fn metadata(lookup: &mut Self::MetadataLookup) -> Self::TypeMetadata {
-                Self::lookup_sql_type::<diesel::sql_types::Numeric>(lookup)
+                Self::lookup_sql_type::<::diesel::sql_types::Numeric>(lookup)
             }
         }
     }
@@ -299,10 +299,10 @@ mod multi_connection_impl {
         use super::*;
         pub enum MultiQueryBuilder {
             Pg(
-                <<diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend as diesel::backend::Backend>::QueryBuilder,
+                <<diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend as ::diesel::backend::Backend>::QueryBuilder,
             ),
             Sqlite(
-                <<diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend as diesel::backend::Backend>::QueryBuilder,
+                <<diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend as ::diesel::backend::Backend>::QueryBuilder,
             ),
         }
         impl MultiQueryBuilder {
@@ -316,7 +316,7 @@ mod multi_connection_impl {
         impl MultiQueryBuilder {
             pub(super) fn pg(
                 &mut self,
-            ) -> &mut <<diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend as diesel::backend::Backend>::QueryBuilder {
+            ) -> &mut <<diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend as ::diesel::backend::Backend>::QueryBuilder {
                 match self {
                     Self::Pg(qb) => qb,
                     _ => unreachable!(),
@@ -324,14 +324,14 @@ mod multi_connection_impl {
             }
             pub(super) fn sqlite(
                 &mut self,
-            ) -> &mut <<diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend as diesel::backend::Backend>::QueryBuilder {
+            ) -> &mut <<diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend as ::diesel::backend::Backend>::QueryBuilder {
                 match self {
                     Self::Sqlite(qb) => qb,
                     _ => unreachable!(),
                 }
             }
         }
-        impl diesel::query_builder::QueryBuilder<super::MultiBackend>
+        impl ::diesel::query_builder::QueryBuilder<super::MultiBackend>
         for MultiQueryBuilder {
             fn push_sql(&mut self, sql: &str) {
                 match self {
@@ -339,7 +339,10 @@ mod multi_connection_impl {
                     Self::Sqlite(q) => q.push_sql(sql),
                 }
             }
-            fn push_identifier(&mut self, identifier: &str) -> diesel::QueryResult<()> {
+            fn push_identifier(
+                &mut self,
+                identifier: &str,
+            ) -> ::diesel::QueryResult<()> {
                 match self {
                     Self::Pg(q) => q.push_identifier(identifier),
                     Self::Sqlite(q) => q.push_identifier(identifier),
@@ -358,209 +361,209 @@ mod multi_connection_impl {
                 }
             }
         }
-        impl<L, O> diesel::query_builder::QueryFragment<super::backend::MultiBackend>
-        for diesel::internal::derives::multiconnection::LimitOffsetClause<L, O>
+        impl<L, O> ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>
+        for ::diesel::internal::derives::multiconnection::LimitOffsetClause<L, O>
         where
-            Self: diesel::query_builder::QueryFragment<
+            Self: ::diesel::query_builder::QueryFragment<
                     <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >
-                + diesel::query_builder::QueryFragment<
+                + ::diesel::query_builder::QueryFragment<
                     <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >,
         {
             fn walk_ast<'b>(
                 &'b self,
-                pass: diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
-            ) -> diesel::QueryResult<()> {
+                pass: ::diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
+            ) -> ::diesel::QueryResult<()> {
                 super::backend::MultiBackend::walk_variant_ast(self, pass)
             }
         }
         impl<
             L,
             R,
-        > diesel::query_builder::QueryFragment<
+        > ::diesel::query_builder::QueryFragment<
             super::backend::MultiBackend,
             super::backend::MultiConcatClauseSyntax,
-        > for diesel::internal::derives::multiconnection::Concat<L, R>
+        > for ::diesel::internal::derives::multiconnection::Concat<L, R>
         where
-            Self: diesel::query_builder::QueryFragment<
+            Self: ::diesel::query_builder::QueryFragment<
                     <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >
-                + diesel::query_builder::QueryFragment<
+                + ::diesel::query_builder::QueryFragment<
                     <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >,
         {
             fn walk_ast<'b>(
                 &'b self,
-                pass: diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
-            ) -> diesel::QueryResult<()> {
+                pass: ::diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
+            ) -> ::diesel::QueryResult<()> {
                 super::backend::MultiBackend::walk_variant_ast(self, pass)
             }
         }
         impl<
             T,
             U,
-        > diesel::query_builder::QueryFragment<
+        > ::diesel::query_builder::QueryFragment<
             super::backend::MultiBackend,
             super::backend::MultiArrayComparisonSyntax,
-        > for diesel::internal::derives::multiconnection::array_comparison::In<T, U>
+        > for ::diesel::internal::derives::multiconnection::array_comparison::In<T, U>
         where
-            Self: diesel::query_builder::QueryFragment<
+            Self: ::diesel::query_builder::QueryFragment<
                     <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >
-                + diesel::query_builder::QueryFragment<
+                + ::diesel::query_builder::QueryFragment<
                     <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >,
         {
             fn walk_ast<'b>(
                 &'b self,
-                pass: diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
-            ) -> diesel::QueryResult<()> {
+                pass: ::diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
+            ) -> ::diesel::QueryResult<()> {
                 super::backend::MultiBackend::walk_variant_ast(self, pass)
             }
         }
         impl<
             T,
             U,
-        > diesel::query_builder::QueryFragment<
+        > ::diesel::query_builder::QueryFragment<
             super::backend::MultiBackend,
             super::backend::MultiArrayComparisonSyntax,
-        > for diesel::internal::derives::multiconnection::array_comparison::NotIn<T, U>
+        > for ::diesel::internal::derives::multiconnection::array_comparison::NotIn<T, U>
         where
-            Self: diesel::query_builder::QueryFragment<
+            Self: ::diesel::query_builder::QueryFragment<
                     <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >
-                + diesel::query_builder::QueryFragment<
+                + ::diesel::query_builder::QueryFragment<
                     <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >,
         {
             fn walk_ast<'b>(
                 &'b self,
-                pass: diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
-            ) -> diesel::QueryResult<()> {
+                pass: ::diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
+            ) -> ::diesel::QueryResult<()> {
                 super::backend::MultiBackend::walk_variant_ast(self, pass)
             }
         }
         impl<
             ST,
             I,
-        > diesel::query_builder::QueryFragment<
+        > ::diesel::query_builder::QueryFragment<
             super::backend::MultiBackend,
             super::backend::MultiArrayComparisonSyntax,
-        > for diesel::internal::derives::multiconnection::array_comparison::Many<ST, I>
+        > for ::diesel::internal::derives::multiconnection::array_comparison::Many<ST, I>
         where
-            Self: diesel::query_builder::QueryFragment<
+            Self: ::diesel::query_builder::QueryFragment<
                     <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >
-                + diesel::query_builder::QueryFragment<
+                + ::diesel::query_builder::QueryFragment<
                     <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >,
         {
             fn walk_ast<'b>(
                 &'b self,
-                pass: diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
-            ) -> diesel::QueryResult<()> {
+                pass: ::diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
+            ) -> ::diesel::QueryResult<()> {
                 super::backend::MultiBackend::walk_variant_ast(self, pass)
             }
         }
         impl<
             T,
-        > diesel::query_builder::QueryFragment<
+        > ::diesel::query_builder::QueryFragment<
             super::backend::MultiBackend,
             super::backend::MultiExistsSyntax,
-        > for diesel::internal::derives::multiconnection::Exists<T>
+        > for ::diesel::internal::derives::multiconnection::Exists<T>
         where
-            Self: diesel::query_builder::QueryFragment<
+            Self: ::diesel::query_builder::QueryFragment<
                     <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >
-                + diesel::query_builder::QueryFragment<
+                + ::diesel::query_builder::QueryFragment<
                     <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >,
         {
             fn walk_ast<'b>(
                 &'b self,
-                pass: diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
-            ) -> diesel::QueryResult<()> {
+                pass: ::diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
+            ) -> ::diesel::QueryResult<()> {
                 super::backend::MultiBackend::walk_variant_ast(self, pass)
             }
         }
-        impl diesel::query_builder::QueryFragment<
+        impl ::diesel::query_builder::QueryFragment<
             super::backend::MultiBackend,
             super::backend::MultiEmptyFromClauseSyntax,
-        > for diesel::internal::derives::multiconnection::NoFromClause
+        > for ::diesel::internal::derives::multiconnection::NoFromClause
         where
-            Self: diesel::query_builder::QueryFragment<
+            Self: ::diesel::query_builder::QueryFragment<
                     <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >
-                + diesel::query_builder::QueryFragment<
+                + ::diesel::query_builder::QueryFragment<
                     <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >,
         {
             fn walk_ast<'b>(
                 &'b self,
-                pass: diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
-            ) -> diesel::QueryResult<()> {
+                pass: ::diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
+            ) -> ::diesel::QueryResult<()> {
                 super::backend::MultiBackend::walk_variant_ast(self, pass)
             }
         }
-        impl diesel::query_builder::QueryFragment<
+        impl ::diesel::query_builder::QueryFragment<
             super::backend::MultiBackend,
             super::backend::MultiDefaultValueClauseForInsert,
-        > for diesel::internal::derives::multiconnection::DefaultValues
+        > for ::diesel::internal::derives::multiconnection::DefaultValues
         where
-            Self: diesel::query_builder::QueryFragment<
+            Self: ::diesel::query_builder::QueryFragment<
                     <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >
-                + diesel::query_builder::QueryFragment<
+                + ::diesel::query_builder::QueryFragment<
                     <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >,
         {
             fn walk_ast<'b>(
                 &'b self,
-                pass: diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
-            ) -> diesel::QueryResult<()> {
+                pass: ::diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
+            ) -> ::diesel::QueryResult<()> {
                 super::backend::MultiBackend::walk_variant_ast(self, pass)
             }
         }
         impl<
             Expr,
-        > diesel::query_builder::QueryFragment<
+        > ::diesel::query_builder::QueryFragment<
             super::backend::MultiBackend,
             super::backend::MultiReturningClause,
-        > for diesel::internal::derives::multiconnection::ReturningClause<Expr>
+        > for ::diesel::internal::derives::multiconnection::ReturningClause<Expr>
         where
-            Self: diesel::query_builder::QueryFragment<
+            Self: ::diesel::query_builder::QueryFragment<
                     <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >
-                + diesel::query_builder::QueryFragment<
+                + ::diesel::query_builder::QueryFragment<
                     <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >,
         {
             fn walk_ast<'b>(
                 &'b self,
-                pass: diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
-            ) -> diesel::QueryResult<()> {
+                pass: ::diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
+            ) -> ::diesel::QueryResult<()> {
                 super::backend::MultiBackend::walk_variant_ast(self, pass)
             }
         }
         impl<
             Expr,
-        > diesel::query_builder::QueryFragment<
+        > ::diesel::query_builder::QueryFragment<
             super::backend::MultiBackend,
             super::backend::MultiInsertWithDefaultKeyword,
-        > for diesel::insertable::DefaultableColumnInsertValue<Expr>
+        > for ::diesel::insertable::DefaultableColumnInsertValue<Expr>
         where
-            Self: diesel::query_builder::QueryFragment<
+            Self: ::diesel::query_builder::QueryFragment<
                     <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >
-                + diesel::query_builder::QueryFragment<
+                + ::diesel::query_builder::QueryFragment<
                     <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >,
         {
             fn walk_ast<'b>(
                 &'b self,
-                pass: diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
-            ) -> diesel::QueryResult<()> {
+                pass: ::diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
+            ) -> ::diesel::QueryResult<()> {
                 super::backend::MultiBackend::walk_variant_ast(self, pass)
             }
         }
@@ -569,28 +572,28 @@ mod multi_connection_impl {
             V,
             QId,
             const HAS_STATIC_QUERY_ID: bool,
-        > diesel::query_builder::QueryFragment<
+        > ::diesel::query_builder::QueryFragment<
             super::backend::MultiBackend,
             super::backend::MultiBatchInsertSupport,
         >
-        for diesel::internal::derives::multiconnection::BatchInsert<
+        for ::diesel::internal::derives::multiconnection::BatchInsert<
             V,
             Tab,
             QId,
             HAS_STATIC_QUERY_ID,
         >
         where
-            Self: diesel::query_builder::QueryFragment<
+            Self: ::diesel::query_builder::QueryFragment<
                     <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >
-                + diesel::query_builder::QueryFragment<
+                + ::diesel::query_builder::QueryFragment<
                     <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >,
         {
             fn walk_ast<'b>(
                 &'b self,
-                pass: diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
-            ) -> diesel::QueryResult<()> {
+                pass: ::diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
+            ) -> ::diesel::QueryResult<()> {
                 super::backend::MultiBackend::walk_variant_ast(self, pass)
             }
         }
@@ -599,43 +602,43 @@ mod multi_connection_impl {
             C,
             PK,
             Tab,
-        > diesel::query_builder::QueryFragment<
+        > ::diesel::query_builder::QueryFragment<
             super::backend::MultiBackend,
             super::backend::MultiBatchUpdateSupport,
-        > for diesel::internal::derives::multiconnection::BatchUpdate<I, C, PK, Tab>
+        > for ::diesel::internal::derives::multiconnection::BatchUpdate<I, C, PK, Tab>
         where
-            Self: diesel::query_builder::QueryFragment<
+            Self: ::diesel::query_builder::QueryFragment<
                     <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >
-                + diesel::query_builder::QueryFragment<
+                + ::diesel::query_builder::QueryFragment<
                     <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >,
         {
             fn walk_ast<'b>(
                 &'b self,
-                pass: diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
-            ) -> diesel::QueryResult<()> {
+                pass: ::diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
+            ) -> ::diesel::QueryResult<()> {
                 super::backend::MultiBackend::walk_variant_ast(self, pass)
             }
         }
         impl<
             S,
-        > diesel::query_builder::QueryFragment<
+        > ::diesel::query_builder::QueryFragment<
             super::backend::MultiBackend,
             super::backend::MultiAliasSyntax,
-        > for diesel::query_source::Alias<S>
+        > for ::diesel::query_source::Alias<S>
         where
-            Self: diesel::query_builder::QueryFragment<
+            Self: ::diesel::query_builder::QueryFragment<
                     <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >
-                + diesel::query_builder::QueryFragment<
+                + ::diesel::query_builder::QueryFragment<
                     <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >,
         {
             fn walk_ast<'b>(
                 &'b self,
-                pass: diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
-            ) -> diesel::QueryResult<()> {
+                pass: ::diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
+            ) -> ::diesel::QueryResult<()> {
                 super::backend::MultiBackend::walk_variant_ast(self, pass)
             }
         }
@@ -649,11 +652,11 @@ mod multi_connection_impl {
             G,
             H,
             LC,
-        > diesel::query_builder::QueryFragment<
+        > ::diesel::query_builder::QueryFragment<
             super::backend::MultiBackend,
             super::backend::MultiSelectStatementSyntax,
         >
-        for diesel::internal::derives::multiconnection::SelectStatement<
+        for ::diesel::internal::derives::multiconnection::SelectStatement<
             F,
             S,
             D,
@@ -665,21 +668,21 @@ mod multi_connection_impl {
             LC,
         >
         where
-            S: diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
-            F: diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
-            D: diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
-            W: diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
-            O: diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
-            LOf: diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
-            G: diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
-            H: diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
-            LC: diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
+            S: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
+            F: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
+            D: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
+            W: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
+            O: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
+            LOf: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
+            G: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
+            H: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
+            LC: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
         {
             fn walk_ast<'b>(
                 &'b self,
-                mut out: diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
-            ) -> diesel::QueryResult<()> {
-                use diesel::internal::derives::multiconnection::SelectStatementAccessor;
+                mut out: ::diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
+            ) -> ::diesel::QueryResult<()> {
+                use ::diesel::internal::derives::multiconnection::SelectStatementAccessor;
                 out.push_sql("SELECT ");
                 self.distinct_clause().walk_ast(out.reborrow())?;
                 self.select_clause().walk_ast(out.reborrow())?;
@@ -698,11 +701,11 @@ mod multi_connection_impl {
             ST,
             QS,
             GB,
-        > diesel::query_builder::QueryFragment<
+        > ::diesel::query_builder::QueryFragment<
             super::backend::MultiBackend,
             super::backend::MultiSelectStatementSyntax,
         >
-        for diesel::internal::derives::multiconnection::BoxedSelectStatement<
+        for ::diesel::internal::derives::multiconnection::BoxedSelectStatement<
             'a,
             ST,
             QS,
@@ -710,25 +713,25 @@ mod multi_connection_impl {
             GB,
         >
         where
-            QS: diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
+            QS: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
         {
             fn walk_ast<'b>(
                 &'b self,
-                pass: diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
-            ) -> diesel::QueryResult<()> {
-                use diesel::internal::derives::multiconnection::BoxedQueryHelper;
+                pass: ::diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
+            ) -> ::diesel::QueryResult<()> {
+                use ::diesel::internal::derives::multiconnection::BoxedQueryHelper;
                 self.build_query(pass, |where_clause, pass| where_clause.walk_ast(pass))
             }
         }
-        impl diesel::query_builder::QueryFragment<super::backend::MultiBackend>
-        for diesel::internal::derives::multiconnection::BoxedLimitOffsetClause<
+        impl ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>
+        for ::diesel::internal::derives::multiconnection::BoxedLimitOffsetClause<
             '_,
             super::backend::MultiBackend,
         > {
             fn walk_ast<'b>(
                 &'b self,
-                mut pass: diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
-            ) -> diesel::QueryResult<()> {
+                mut pass: ::diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
+            ) -> ::diesel::QueryResult<()> {
                 if let Some(limit) = &self.limit {
                     limit.walk_ast(pass.reborrow())?;
                 }
@@ -740,20 +743,20 @@ mod multi_connection_impl {
         }
         impl<
             'a,
-        > diesel::query_builder::IntoBoxedClause<
+        > ::diesel::query_builder::IntoBoxedClause<
             'a,
             super::multi_connection_impl::backend::MultiBackend,
         >
-        for diesel::internal::derives::multiconnection::LimitOffsetClause<
-            diesel::internal::derives::multiconnection::NoLimitClause,
-            diesel::internal::derives::multiconnection::NoOffsetClause,
+        for ::diesel::internal::derives::multiconnection::LimitOffsetClause<
+            ::diesel::internal::derives::multiconnection::NoLimitClause,
+            ::diesel::internal::derives::multiconnection::NoOffsetClause,
         > {
-            type BoxedClause = diesel::internal::derives::multiconnection::BoxedLimitOffsetClause<
+            type BoxedClause = ::diesel::internal::derives::multiconnection::BoxedLimitOffsetClause<
                 'a,
                 super::multi_connection_impl::backend::MultiBackend,
             >;
             fn into_boxed(self) -> Self::BoxedClause {
-                diesel::internal::derives::multiconnection::BoxedLimitOffsetClause {
+                ::diesel::internal::derives::multiconnection::BoxedLimitOffsetClause {
                     limit: None,
                     offset: None,
                 }
@@ -762,26 +765,26 @@ mod multi_connection_impl {
         impl<
             'a,
             L,
-        > diesel::query_builder::IntoBoxedClause<
+        > ::diesel::query_builder::IntoBoxedClause<
             'a,
             super::multi_connection_impl::backend::MultiBackend,
         >
-        for diesel::internal::derives::multiconnection::LimitOffsetClause<
-            diesel::internal::derives::multiconnection::LimitClause<L>,
-            diesel::internal::derives::multiconnection::NoOffsetClause,
+        for ::diesel::internal::derives::multiconnection::LimitOffsetClause<
+            ::diesel::internal::derives::multiconnection::LimitClause<L>,
+            ::diesel::internal::derives::multiconnection::NoOffsetClause,
         >
         where
-            diesel::internal::derives::multiconnection::LimitClause<
+            ::diesel::internal::derives::multiconnection::LimitClause<
                 L,
-            >: diesel::query_builder::QueryFragment<super::backend::MultiBackend> + Send
-                + 'static,
+            >: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>
+                + Send + 'static,
         {
-            type BoxedClause = diesel::internal::derives::multiconnection::BoxedLimitOffsetClause<
+            type BoxedClause = ::diesel::internal::derives::multiconnection::BoxedLimitOffsetClause<
                 'a,
                 super::multi_connection_impl::backend::MultiBackend,
             >;
             fn into_boxed(self) -> Self::BoxedClause {
-                diesel::internal::derives::multiconnection::BoxedLimitOffsetClause {
+                ::diesel::internal::derives::multiconnection::BoxedLimitOffsetClause {
                     limit: Some(Box::new(self.limit_clause)),
                     offset: None,
                 }
@@ -790,26 +793,26 @@ mod multi_connection_impl {
         impl<
             'a,
             O,
-        > diesel::query_builder::IntoBoxedClause<
+        > ::diesel::query_builder::IntoBoxedClause<
             'a,
             super::multi_connection_impl::backend::MultiBackend,
         >
-        for diesel::internal::derives::multiconnection::LimitOffsetClause<
-            diesel::internal::derives::multiconnection::NoLimitClause,
-            diesel::internal::derives::multiconnection::OffsetClause<O>,
+        for ::diesel::internal::derives::multiconnection::LimitOffsetClause<
+            ::diesel::internal::derives::multiconnection::NoLimitClause,
+            ::diesel::internal::derives::multiconnection::OffsetClause<O>,
         >
         where
-            diesel::internal::derives::multiconnection::OffsetClause<
+            ::diesel::internal::derives::multiconnection::OffsetClause<
                 O,
-            >: diesel::query_builder::QueryFragment<super::backend::MultiBackend> + Send
-                + 'static,
+            >: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>
+                + Send + 'static,
         {
-            type BoxedClause = diesel::internal::derives::multiconnection::BoxedLimitOffsetClause<
+            type BoxedClause = ::diesel::internal::derives::multiconnection::BoxedLimitOffsetClause<
                 'a,
                 super::multi_connection_impl::backend::MultiBackend,
             >;
             fn into_boxed(self) -> Self::BoxedClause {
-                diesel::internal::derives::multiconnection::BoxedLimitOffsetClause {
+                ::diesel::internal::derives::multiconnection::BoxedLimitOffsetClause {
                     limit: None,
                     offset: Some(Box::new(self.offset_clause)),
                 }
@@ -819,30 +822,30 @@ mod multi_connection_impl {
             'a,
             L,
             O,
-        > diesel::query_builder::IntoBoxedClause<
+        > ::diesel::query_builder::IntoBoxedClause<
             'a,
             super::multi_connection_impl::backend::MultiBackend,
         >
-        for diesel::internal::derives::multiconnection::LimitOffsetClause<
-            diesel::internal::derives::multiconnection::LimitClause<L>,
-            diesel::internal::derives::multiconnection::OffsetClause<O>,
+        for ::diesel::internal::derives::multiconnection::LimitOffsetClause<
+            ::diesel::internal::derives::multiconnection::LimitClause<L>,
+            ::diesel::internal::derives::multiconnection::OffsetClause<O>,
         >
         where
-            diesel::internal::derives::multiconnection::LimitClause<
+            ::diesel::internal::derives::multiconnection::LimitClause<
                 L,
-            >: diesel::query_builder::QueryFragment<super::backend::MultiBackend> + Send
-                + 'static,
-            diesel::internal::derives::multiconnection::OffsetClause<
+            >: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>
+                + Send + 'static,
+            ::diesel::internal::derives::multiconnection::OffsetClause<
                 O,
-            >: diesel::query_builder::QueryFragment<super::backend::MultiBackend> + Send
-                + 'static,
+            >: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>
+                + Send + 'static,
         {
-            type BoxedClause = diesel::internal::derives::multiconnection::BoxedLimitOffsetClause<
+            type BoxedClause = ::diesel::internal::derives::multiconnection::BoxedLimitOffsetClause<
                 'a,
                 super::multi_connection_impl::backend::MultiBackend,
             >;
             fn into_boxed(self) -> Self::BoxedClause {
-                diesel::internal::derives::multiconnection::BoxedLimitOffsetClause {
+                ::diesel::internal::derives::multiconnection::BoxedLimitOffsetClause {
                     limit: Some(Box::new(self.limit_clause)),
                     offset: Some(Box::new(self.offset_clause)),
                 }
@@ -853,11 +856,11 @@ mod multi_connection_impl {
             ST,
             QS,
             GB,
-        > diesel::query_builder::QueryFragment<
+        > ::diesel::query_builder::QueryFragment<
             super::backend::MultiBackend,
             super::backend::MultiSelectStatementSyntax,
         >
-        for diesel::internal::derives::multiconnection::BoxedCloneSelectStatement<
+        for ::diesel::internal::derives::multiconnection::BoxedCloneSelectStatement<
             'a,
             ST,
             QS,
@@ -865,25 +868,25 @@ mod multi_connection_impl {
             GB,
         >
         where
-            QS: diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
+            QS: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
         {
             fn walk_ast<'b>(
                 &'b self,
-                pass: diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
-            ) -> diesel::QueryResult<()> {
-                use diesel::internal::derives::multiconnection::BoxedCloneQueryHelper;
+                pass: ::diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
+            ) -> ::diesel::QueryResult<()> {
+                use ::diesel::internal::derives::multiconnection::BoxedCloneQueryHelper;
                 self.build_query(pass, |where_clause, pass| where_clause.walk_ast(pass))
             }
         }
-        impl diesel::query_builder::QueryFragment<super::backend::MultiBackend>
-        for diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause<
+        impl ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>
+        for ::diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause<
             '_,
             super::backend::MultiBackend,
         > {
             fn walk_ast<'b>(
                 &'b self,
-                mut pass: diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
-            ) -> diesel::QueryResult<()> {
+                mut pass: ::diesel::query_builder::AstPass<'_, 'b, MultiBackend>,
+            ) -> ::diesel::QueryResult<()> {
                 if let Some(limit) = &self.limit {
                     limit.walk_ast(pass.reborrow())?;
                 }
@@ -895,20 +898,20 @@ mod multi_connection_impl {
         }
         impl<
             'a,
-        > diesel::query_builder::IntoBoxedCloneClause<
+        > ::diesel::query_builder::IntoBoxedCloneClause<
             'a,
             super::multi_connection_impl::backend::MultiBackend,
         >
-        for diesel::internal::derives::multiconnection::LimitOffsetClause<
-            diesel::internal::derives::multiconnection::NoLimitClause,
-            diesel::internal::derives::multiconnection::NoOffsetClause,
+        for ::diesel::internal::derives::multiconnection::LimitOffsetClause<
+            ::diesel::internal::derives::multiconnection::NoLimitClause,
+            ::diesel::internal::derives::multiconnection::NoOffsetClause,
         > {
-            type BoxedCloneClause = diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause<
+            type BoxedCloneClause = ::diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause<
                 'a,
                 super::multi_connection_impl::backend::MultiBackend,
             >;
             fn into_boxed_clone(self) -> Self::BoxedCloneClause {
-                diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause {
+                ::diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause {
                     limit: None,
                     offset: None,
                 }
@@ -917,26 +920,26 @@ mod multi_connection_impl {
         impl<
             'a,
             L,
-        > diesel::query_builder::IntoBoxedCloneClause<
+        > ::diesel::query_builder::IntoBoxedCloneClause<
             'a,
             super::multi_connection_impl::backend::MultiBackend,
         >
-        for diesel::internal::derives::multiconnection::LimitOffsetClause<
-            diesel::internal::derives::multiconnection::LimitClause<L>,
-            diesel::internal::derives::multiconnection::NoOffsetClause,
+        for ::diesel::internal::derives::multiconnection::LimitOffsetClause<
+            ::diesel::internal::derives::multiconnection::LimitClause<L>,
+            ::diesel::internal::derives::multiconnection::NoOffsetClause,
         >
         where
-            diesel::internal::derives::multiconnection::LimitClause<
+            ::diesel::internal::derives::multiconnection::LimitClause<
                 L,
-            >: diesel::query_builder::QueryFragment<super::backend::MultiBackend> + Send
-                + Sync + 'static,
+            >: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>
+                + Send + Sync + 'static,
         {
-            type BoxedCloneClause = diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause<
+            type BoxedCloneClause = ::diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause<
                 'a,
                 super::multi_connection_impl::backend::MultiBackend,
             >;
             fn into_boxed_clone(self) -> Self::BoxedCloneClause {
-                diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause {
+                ::diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause {
                     limit: Some(std::sync::Arc::new(self.limit_clause)),
                     offset: None,
                 }
@@ -945,26 +948,26 @@ mod multi_connection_impl {
         impl<
             'a,
             O,
-        > diesel::query_builder::IntoBoxedCloneClause<
+        > ::diesel::query_builder::IntoBoxedCloneClause<
             'a,
             super::multi_connection_impl::backend::MultiBackend,
         >
-        for diesel::internal::derives::multiconnection::LimitOffsetClause<
-            diesel::internal::derives::multiconnection::NoLimitClause,
-            diesel::internal::derives::multiconnection::OffsetClause<O>,
+        for ::diesel::internal::derives::multiconnection::LimitOffsetClause<
+            ::diesel::internal::derives::multiconnection::NoLimitClause,
+            ::diesel::internal::derives::multiconnection::OffsetClause<O>,
         >
         where
-            diesel::internal::derives::multiconnection::OffsetClause<
+            ::diesel::internal::derives::multiconnection::OffsetClause<
                 O,
-            >: diesel::query_builder::QueryFragment<super::backend::MultiBackend> + Send
-                + Sync + 'static,
+            >: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>
+                + Send + Sync + 'static,
         {
-            type BoxedCloneClause = diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause<
+            type BoxedCloneClause = ::diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause<
                 'a,
                 super::multi_connection_impl::backend::MultiBackend,
             >;
             fn into_boxed_clone(self) -> Self::BoxedCloneClause {
-                diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause {
+                ::diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause {
                     limit: None,
                     offset: Some(std::sync::Arc::new(self.offset_clause)),
                 }
@@ -974,32 +977,32 @@ mod multi_connection_impl {
             'a,
             L,
             O,
-        > diesel::query_builder::IntoBoxedCloneClause<
+        > ::diesel::query_builder::IntoBoxedCloneClause<
             'a,
             super::multi_connection_impl::backend::MultiBackend,
         >
-        for diesel::internal::derives::multiconnection::LimitOffsetClause<
-            diesel::internal::derives::multiconnection::LimitClause<L>,
-            diesel::internal::derives::multiconnection::OffsetClause<O>,
+        for ::diesel::internal::derives::multiconnection::LimitOffsetClause<
+            ::diesel::internal::derives::multiconnection::LimitClause<L>,
+            ::diesel::internal::derives::multiconnection::OffsetClause<O>,
         >
         where
-            L: diesel::query_builder::QueryFragment<super::backend::MultiBackend> + Send
-                + Sync + 'a,
-            O: diesel::query_builder::QueryFragment<super::backend::MultiBackend> + Send
-                + Sync + 'a,
-            diesel::internal::derives::multiconnection::LimitClause<
+            L: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>
+                + Send + Sync + 'a,
+            O: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>
+                + Send + Sync + 'a,
+            ::diesel::internal::derives::multiconnection::LimitClause<
                 L,
-            >: diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
-            diesel::internal::derives::multiconnection::OffsetClause<
+            >: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
+            ::diesel::internal::derives::multiconnection::OffsetClause<
                 O,
-            >: diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
+            >: ::diesel::query_builder::QueryFragment<super::backend::MultiBackend>,
         {
-            type BoxedCloneClause = diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause<
+            type BoxedCloneClause = ::diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause<
                 'a,
                 super::multi_connection_impl::backend::MultiBackend,
             >;
             fn into_boxed_clone(self) -> Self::BoxedCloneClause {
-                diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause {
+                ::diesel::internal::derives::multiconnection::BoxedCloneLimitOffsetClause {
                     limit: Some(std::sync::Arc::new(self.limit_clause)),
                     offset: Some(std::sync::Arc::new(self.offset_clause)),
                 }
@@ -1008,47 +1011,47 @@ mod multi_connection_impl {
         impl<
             Col,
             Expr,
-        > diesel::insertable::InsertValues<
+        > ::diesel::insertable::InsertValues<
             super::multi_connection_impl::backend::MultiBackend,
             Col::Table,
         >
-        for diesel::insertable::DefaultableColumnInsertValue<
-            diesel::insertable::ColumnInsertValue<Col, Expr>,
+        for ::diesel::insertable::DefaultableColumnInsertValue<
+            ::diesel::insertable::ColumnInsertValue<Col, Expr>,
         >
         where
-            Col: diesel::prelude::Column,
-            Expr: diesel::prelude::Expression<SqlType = Col::SqlType>,
-            Expr: diesel::prelude::AppearsOnTable<
-                diesel::internal::derives::multiconnection::NoFromClause,
+            Col: ::diesel::prelude::Column,
+            Expr: ::diesel::prelude::Expression<SqlType = Col::SqlType>,
+            Expr: ::diesel::prelude::AppearsOnTable<
+                ::diesel::internal::derives::multiconnection::NoFromClause,
             >,
-            Self: diesel::query_builder::QueryFragment<
+            Self: ::diesel::query_builder::QueryFragment<
                 super::multi_connection_impl::backend::MultiBackend,
             >,
-            diesel::insertable::DefaultableColumnInsertValue<
-                diesel::insertable::ColumnInsertValue<Col, Expr>,
-            >: diesel::insertable::InsertValues<
+            ::diesel::insertable::DefaultableColumnInsertValue<
+                ::diesel::insertable::ColumnInsertValue<Col, Expr>,
+            >: ::diesel::insertable::InsertValues<
                 <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend,
                 Col::Table,
             >,
-            diesel::insertable::DefaultableColumnInsertValue<
-                diesel::insertable::ColumnInsertValue<Col, Expr>,
-            >: diesel::insertable::InsertValues<
+            ::diesel::insertable::DefaultableColumnInsertValue<
+                ::diesel::insertable::ColumnInsertValue<Col, Expr>,
+            >: ::diesel::insertable::InsertValues<
                 <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend,
                 Col::Table,
             >,
         {
             fn column_names(
                 &self,
-                mut out: diesel::query_builder::AstPass<
+                mut out: ::diesel::query_builder::AstPass<
                     '_,
                     '_,
                     super::multi_connection_impl::backend::MultiBackend,
                 >,
-            ) -> diesel::QueryResult<()> {
-                use diesel::internal::derives::multiconnection::AstPassHelper;
+            ) -> ::diesel::QueryResult<()> {
+                use ::diesel::internal::derives::multiconnection::AstPassHelper;
                 match out.backend() {
                     super::backend::MultiBackend::Pg(_) => {
-                        <Self as diesel::insertable::InsertValues<
+                        <Self as ::diesel::insertable::InsertValues<
                             <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend,
                             Col::Table,
                         >>::column_names(
@@ -1070,7 +1073,7 @@ mod multi_connection_impl {
                         )
                     }
                     super::backend::MultiBackend::Sqlite(_) => {
-                        <Self as diesel::insertable::InsertValues<
+                        <Self as ::diesel::insertable::InsertValues<
                             <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend,
                             Col::Table,
                         >>::column_names(
@@ -1099,12 +1102,12 @@ mod multi_connection_impl {
         use super::*;
         pub enum MultiBindCollector<'a> {
             Pg(
-                <<diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend as diesel::backend::Backend>::BindCollector<
+                <<diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend as ::diesel::backend::Backend>::BindCollector<
                     'a,
                 >,
             ),
             Sqlite(
-                <<diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend as diesel::backend::Backend>::BindCollector<
+                <<diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend as ::diesel::backend::Backend>::BindCollector<
                     'a,
                 >,
             ),
@@ -1112,7 +1115,7 @@ mod multi_connection_impl {
         impl<'a> MultiBindCollector<'a> {
             pub(super) fn pg(
                 &mut self,
-            ) -> &mut <<diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend as diesel::backend::Backend>::BindCollector<
+            ) -> &mut <<diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend as ::diesel::backend::Backend>::BindCollector<
                 'a,
             > {
                 match self {
@@ -1122,7 +1125,7 @@ mod multi_connection_impl {
             }
             pub(super) fn sqlite(
                 &mut self,
-            ) -> &mut <<diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend as diesel::backend::Backend>::BindCollector<
+            ) -> &mut <<diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend as ::diesel::backend::Backend>::BindCollector<
                 'a,
             > {
                 match self {
@@ -1131,13 +1134,13 @@ mod multi_connection_impl {
                 }
             }
         }
-        trait PushBoundValueToCollectorDB<DB: diesel::backend::Backend> {
+        trait PushBoundValueToCollectorDB<DB: ::diesel::backend::Backend> {
             fn push_bound_value<'a: 'b, 'b>(
                 &self,
                 v: InnerBindValueKind<'a>,
-                collector: &mut <DB as diesel::backend::Backend>::BindCollector<'b>,
-                lookup: &mut <DB as diesel::sql_types::TypeMetadata>::MetadataLookup,
-            ) -> diesel::result::QueryResult<()>;
+                collector: &mut <DB as ::diesel::backend::Backend>::BindCollector<'b>,
+                lookup: &mut <DB as ::diesel::sql_types::TypeMetadata>::MetadataLookup,
+            ) -> ::diesel::result::QueryResult<()>;
         }
         struct PushBoundValueToCollectorImpl<ST, T: ?Sized> {
             p: std::marker::PhantomData<(ST, T)>,
@@ -1145,20 +1148,21 @@ mod multi_connection_impl {
         impl<ST, T, DB> PushBoundValueToCollectorDB<DB>
         for PushBoundValueToCollectorImpl<ST, T>
         where
-            DB: diesel::backend::Backend + diesel::sql_types::HasSqlType<ST>,
-            T: diesel::serialize::ToSql<ST, DB> + 'static,
+            DB: ::diesel::backend::Backend + ::diesel::sql_types::HasSqlType<ST>,
+            T: ::diesel::serialize::ToSql<ST, DB> + 'static,
             Option<
                 T,
-            >: diesel::serialize::ToSql<diesel::sql_types::Nullable<ST>, DB> + 'static,
-            ST: diesel::sql_types::SqlType,
+            >: ::diesel::serialize::ToSql<::diesel::sql_types::Nullable<ST>, DB>
+                + 'static,
+            ST: ::diesel::sql_types::SqlType,
         {
             fn push_bound_value<'a: 'b, 'b>(
                 &self,
                 v: InnerBindValueKind<'a>,
-                collector: &mut <DB as diesel::backend::Backend>::BindCollector<'b>,
-                lookup: &mut <DB as diesel::sql_types::TypeMetadata>::MetadataLookup,
-            ) -> diesel::result::QueryResult<()> {
-                use diesel::query_builder::BindCollector;
+                collector: &mut <DB as ::diesel::backend::Backend>::BindCollector<'b>,
+                lookup: &mut <DB as ::diesel::sql_types::TypeMetadata>::MetadataLookup,
+            ) -> ::diesel::result::QueryResult<()> {
+                use ::diesel::query_builder::BindCollector;
                 match v {
                     InnerBindValueKind::Sized(v) => {
                         let v = v
@@ -1169,7 +1173,7 @@ mod multi_connection_impl {
                     InnerBindValueKind::Null => {
                         collector
                             .push_bound_value::<
-                                diesel::sql_types::Nullable<ST>,
+                                ::diesel::sql_types::Nullable<ST>,
                                 Option<T>,
                             >(&None, lookup)
                     }
@@ -1182,43 +1186,44 @@ mod multi_connection_impl {
             }
         }
         impl<DB> PushBoundValueToCollectorDB<DB>
-        for PushBoundValueToCollectorImpl<diesel::sql_types::Text, str>
+        for PushBoundValueToCollectorImpl<::diesel::sql_types::Text, str>
         where
-            DB: diesel::backend::Backend
-                + diesel::sql_types::HasSqlType<diesel::sql_types::Text>,
-            str: diesel::serialize::ToSql<diesel::sql_types::Text, DB> + 'static,
+            DB: ::diesel::backend::Backend
+                + ::diesel::sql_types::HasSqlType<::diesel::sql_types::Text>,
+            str: ::diesel::serialize::ToSql<::diesel::sql_types::Text, DB> + 'static,
         {
             fn push_bound_value<'a: 'b, 'b>(
                 &self,
                 v: InnerBindValueKind<'a>,
-                collector: &mut <DB as diesel::backend::Backend>::BindCollector<'b>,
-                lookup: &mut <DB as diesel::sql_types::TypeMetadata>::MetadataLookup,
-            ) -> diesel::result::QueryResult<()> {
-                use diesel::query_builder::BindCollector;
+                collector: &mut <DB as ::diesel::backend::Backend>::BindCollector<'b>,
+                lookup: &mut <DB as ::diesel::sql_types::TypeMetadata>::MetadataLookup,
+            ) -> ::diesel::result::QueryResult<()> {
+                use ::diesel::query_builder::BindCollector;
                 if let InnerBindValueKind::Str(v) = v {
-                    collector.push_bound_value::<diesel::sql_types::Text, str>(v, lookup)
+                    collector
+                        .push_bound_value::<::diesel::sql_types::Text, str>(v, lookup)
                 } else {
                     unreachable!("We set the value to `InnerBindValueKind::Str`")
                 }
             }
         }
         impl<DB> PushBoundValueToCollectorDB<DB>
-        for PushBoundValueToCollectorImpl<diesel::sql_types::Binary, [u8]>
+        for PushBoundValueToCollectorImpl<::diesel::sql_types::Binary, [u8]>
         where
-            DB: diesel::backend::Backend
-                + diesel::sql_types::HasSqlType<diesel::sql_types::Binary>,
-            [u8]: diesel::serialize::ToSql<diesel::sql_types::Binary, DB> + 'static,
+            DB: ::diesel::backend::Backend
+                + ::diesel::sql_types::HasSqlType<::diesel::sql_types::Binary>,
+            [u8]: ::diesel::serialize::ToSql<::diesel::sql_types::Binary, DB> + 'static,
         {
             fn push_bound_value<'a: 'b, 'b>(
                 &self,
                 v: InnerBindValueKind<'a>,
-                collector: &mut <DB as diesel::backend::Backend>::BindCollector<'b>,
-                lookup: &mut <DB as diesel::sql_types::TypeMetadata>::MetadataLookup,
-            ) -> diesel::result::QueryResult<()> {
-                use diesel::query_builder::BindCollector;
+                collector: &mut <DB as ::diesel::backend::Backend>::BindCollector<'b>,
+                lookup: &mut <DB as ::diesel::sql_types::TypeMetadata>::MetadataLookup,
+            ) -> ::diesel::result::QueryResult<()> {
+                use ::diesel::query_builder::BindCollector;
                 if let InnerBindValueKind::Bytes(v) = v {
                     collector
-                        .push_bound_value::<diesel::sql_types::Binary, [u8]>(v, lookup)
+                        .push_bound_value::<::diesel::sql_types::Binary, [u8]>(v, lookup)
                 } else {
                     unreachable!("We set the value to `InnerBindValueKind::Binary`")
                 }
@@ -1252,26 +1257,28 @@ mod multi_connection_impl {
             Bytes(&'a [u8]),
             Null,
         }
-        impl<'a> From<(diesel::sql_types::Text, &'a str)> for BindValue<'a> {
-            fn from((_, v): (diesel::sql_types::Text, &'a str)) -> Self {
+        impl<'a> From<(::diesel::sql_types::Text, &'a str)> for BindValue<'a> {
+            fn from((_, v): (::diesel::sql_types::Text, &'a str)) -> Self {
                 Self {
                     inner: Some(InnerBindValue {
                         value: InnerBindValueKind::Str(v),
                         push_bound_value_to_collector: &PushBoundValueToCollectorImpl {
-                            p: std::marker::PhantomData::<(diesel::sql_types::Text, str)>,
+                            p: std::marker::PhantomData::<
+                                (::diesel::sql_types::Text, str),
+                            >,
                         },
                     }),
                 }
             }
         }
-        impl<'a> From<(diesel::sql_types::Binary, &'a [u8])> for BindValue<'a> {
-            fn from((_, v): (diesel::sql_types::Binary, &'a [u8])) -> Self {
+        impl<'a> From<(::diesel::sql_types::Binary, &'a [u8])> for BindValue<'a> {
+            fn from((_, v): (::diesel::sql_types::Binary, &'a [u8])) -> Self {
                 Self {
                     inner: Some(InnerBindValue {
                         value: InnerBindValueKind::Bytes(v),
                         push_bound_value_to_collector: &PushBoundValueToCollectorImpl {
                             p: std::marker::PhantomData::<
-                                (diesel::sql_types::Binary, [u8]),
+                                (::diesel::sql_types::Binary, [u8]),
                             >,
                         },
                     }),
@@ -1281,22 +1288,22 @@ mod multi_connection_impl {
         impl<'a, T, ST> From<(ST, &'a T)> for BindValue<'a>
         where
             T: std::any::Any
-                + diesel::serialize::ToSql<
+                + ::diesel::serialize::ToSql<
                     ST,
                     <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >
-                + diesel::serialize::ToSql<
+                + ::diesel::serialize::ToSql<
                     ST,
                     <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend,
                 > + Send + Sync + 'static,
             ST: Send
-                + diesel::sql_types::SqlType<
-                    IsNull = diesel::sql_types::is_nullable::NotNull,
+                + ::diesel::sql_types::SqlType<
+                    IsNull = ::diesel::sql_types::is_nullable::NotNull,
                 > + 'static,
-            <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend: diesel::sql_types::HasSqlType<
+            <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend: ::diesel::sql_types::HasSqlType<
                 ST,
             >,
-            <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend: diesel::sql_types::HasSqlType<
+            <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend: ::diesel::sql_types::HasSqlType<
                 ST,
             >,
         {
@@ -1311,28 +1318,28 @@ mod multi_connection_impl {
                 }
             }
         }
-        impl<'a> diesel::query_builder::BindCollector<'a, MultiBackend>
+        impl<'a> ::diesel::query_builder::BindCollector<'a, MultiBackend>
         for MultiBindCollector<'a> {
             type Buffer = multi_connection_impl::bind_collector::BindValue<'a>;
             fn push_bound_value<T, U>(
                 &mut self,
                 bind: &'a U,
                 metadata_lookup: &mut (dyn std::any::Any + 'static),
-            ) -> diesel::QueryResult<()>
+            ) -> ::diesel::QueryResult<()>
             where
-                MultiBackend: diesel::sql_types::HasSqlType<T>,
-                U: diesel::serialize::ToSql<T, MultiBackend> + ?Sized + 'a,
+                MultiBackend: ::diesel::sql_types::HasSqlType<T>,
+                U: ::diesel::serialize::ToSql<T, MultiBackend> + ?Sized + 'a,
             {
                 let out = {
                     let out = multi_connection_impl::bind_collector::BindValue::default();
-                    let mut out = diesel::serialize::Output::<
+                    let mut out = ::diesel::serialize::Output::<
                         MultiBackend,
                     >::new(out, metadata_lookup);
                     let bind_is_null = bind
                         .to_sql(&mut out)
-                        .map_err(diesel::result::Error::SerializationError)?;
-                    if matches!(bind_is_null, diesel::serialize::IsNull::Yes) {
-                        let metadata = <MultiBackend as diesel::sql_types::HasSqlType<
+                        .map_err(::diesel::result::Error::SerializationError)?;
+                    if matches!(bind_is_null, ::diesel::serialize::IsNull::Yes) {
+                        let metadata = <MultiBackend as ::diesel::sql_types::HasSqlType<
                             T,
                         >>::metadata(metadata_lookup);
                         match (self, metadata) {
@@ -1409,7 +1416,7 @@ mod multi_connection_impl {
             fn push_null_value(
                 &mut self,
                 metadata: super::backend::MultiTypeMetadata,
-            ) -> diesel::QueryResult<()> {
+            ) -> ::diesel::QueryResult<()> {
                 match (self, metadata) {
                     (
                         Self::Pg(bc),
@@ -1428,338 +1435,369 @@ mod multi_connection_impl {
                 Ok(())
             }
         }
-        impl diesel::serialize::ToSql<diesel::sql_types::SmallInt, super::MultiBackend>
-        for i16 {
+        impl ::diesel::serialize::ToSql<
+            ::diesel::sql_types::SmallInt,
+            super::MultiBackend,
+        > for i16 {
             fn to_sql<'b>(
                 &'b self,
-                out: &mut diesel::serialize::Output<'b, '_, super::MultiBackend>,
-            ) -> diesel::serialize::Result {
-                out.set_value((diesel::sql_types::SmallInt, self));
-                Ok(diesel::serialize::IsNull::No)
+                out: &mut ::diesel::serialize::Output<'b, '_, super::MultiBackend>,
+            ) -> ::diesel::serialize::Result {
+                out.set_value((::diesel::sql_types::SmallInt, self));
+                Ok(::diesel::serialize::IsNull::No)
             }
         }
-        impl diesel::serialize::ToSql<diesel::sql_types::Integer, super::MultiBackend>
-        for i32 {
+        impl ::diesel::serialize::ToSql<
+            ::diesel::sql_types::Integer,
+            super::MultiBackend,
+        > for i32 {
             fn to_sql<'b>(
                 &'b self,
-                out: &mut diesel::serialize::Output<'b, '_, super::MultiBackend>,
-            ) -> diesel::serialize::Result {
-                out.set_value((diesel::sql_types::Integer, self));
-                Ok(diesel::serialize::IsNull::No)
+                out: &mut ::diesel::serialize::Output<'b, '_, super::MultiBackend>,
+            ) -> ::diesel::serialize::Result {
+                out.set_value((::diesel::sql_types::Integer, self));
+                Ok(::diesel::serialize::IsNull::No)
             }
         }
-        impl diesel::serialize::ToSql<diesel::sql_types::BigInt, super::MultiBackend>
+        impl ::diesel::serialize::ToSql<::diesel::sql_types::BigInt, super::MultiBackend>
         for i64 {
             fn to_sql<'b>(
                 &'b self,
-                out: &mut diesel::serialize::Output<'b, '_, super::MultiBackend>,
-            ) -> diesel::serialize::Result {
-                out.set_value((diesel::sql_types::BigInt, self));
-                Ok(diesel::serialize::IsNull::No)
+                out: &mut ::diesel::serialize::Output<'b, '_, super::MultiBackend>,
+            ) -> ::diesel::serialize::Result {
+                out.set_value((::diesel::sql_types::BigInt, self));
+                Ok(::diesel::serialize::IsNull::No)
             }
         }
-        impl diesel::serialize::ToSql<diesel::sql_types::Double, super::MultiBackend>
+        impl ::diesel::serialize::ToSql<::diesel::sql_types::Double, super::MultiBackend>
         for f64 {
             fn to_sql<'b>(
                 &'b self,
-                out: &mut diesel::serialize::Output<'b, '_, super::MultiBackend>,
-            ) -> diesel::serialize::Result {
-                out.set_value((diesel::sql_types::Double, self));
-                Ok(diesel::serialize::IsNull::No)
+                out: &mut ::diesel::serialize::Output<'b, '_, super::MultiBackend>,
+            ) -> ::diesel::serialize::Result {
+                out.set_value((::diesel::sql_types::Double, self));
+                Ok(::diesel::serialize::IsNull::No)
             }
         }
-        impl diesel::serialize::ToSql<diesel::sql_types::Float, super::MultiBackend>
+        impl ::diesel::serialize::ToSql<::diesel::sql_types::Float, super::MultiBackend>
         for f32 {
             fn to_sql<'b>(
                 &'b self,
-                out: &mut diesel::serialize::Output<'b, '_, super::MultiBackend>,
-            ) -> diesel::serialize::Result {
-                out.set_value((diesel::sql_types::Float, self));
-                Ok(diesel::serialize::IsNull::No)
+                out: &mut ::diesel::serialize::Output<'b, '_, super::MultiBackend>,
+            ) -> ::diesel::serialize::Result {
+                out.set_value((::diesel::sql_types::Float, self));
+                Ok(::diesel::serialize::IsNull::No)
             }
         }
-        impl diesel::serialize::ToSql<diesel::sql_types::Text, super::MultiBackend>
+        impl ::diesel::serialize::ToSql<::diesel::sql_types::Text, super::MultiBackend>
         for str {
             fn to_sql<'b>(
                 &'b self,
-                out: &mut diesel::serialize::Output<'b, '_, super::MultiBackend>,
-            ) -> diesel::serialize::Result {
-                out.set_value((diesel::sql_types::Text, self));
-                Ok(diesel::serialize::IsNull::No)
+                out: &mut ::diesel::serialize::Output<'b, '_, super::MultiBackend>,
+            ) -> ::diesel::serialize::Result {
+                out.set_value((::diesel::sql_types::Text, self));
+                Ok(::diesel::serialize::IsNull::No)
             }
         }
-        impl diesel::serialize::ToSql<diesel::sql_types::Binary, super::MultiBackend>
+        impl ::diesel::serialize::ToSql<::diesel::sql_types::Binary, super::MultiBackend>
         for [u8] {
             fn to_sql<'b>(
                 &'b self,
-                out: &mut diesel::serialize::Output<'b, '_, super::MultiBackend>,
-            ) -> diesel::serialize::Result {
-                out.set_value((diesel::sql_types::Binary, self));
-                Ok(diesel::serialize::IsNull::No)
+                out: &mut ::diesel::serialize::Output<'b, '_, super::MultiBackend>,
+            ) -> ::diesel::serialize::Result {
+                out.set_value((::diesel::sql_types::Binary, self));
+                Ok(::diesel::serialize::IsNull::No)
             }
         }
-        impl diesel::serialize::ToSql<diesel::sql_types::Bool, super::MultiBackend>
+        impl ::diesel::serialize::ToSql<::diesel::sql_types::Bool, super::MultiBackend>
         for bool {
             fn to_sql<'b>(
                 &'b self,
-                out: &mut diesel::serialize::Output<'b, '_, super::MultiBackend>,
-            ) -> diesel::serialize::Result {
-                out.set_value((diesel::sql_types::Bool, self));
-                Ok(diesel::serialize::IsNull::No)
+                out: &mut ::diesel::serialize::Output<'b, '_, super::MultiBackend>,
+            ) -> ::diesel::serialize::Result {
+                out.set_value((::diesel::sql_types::Bool, self));
+                Ok(::diesel::serialize::IsNull::No)
             }
         }
-        impl diesel::serialize::ToSql<diesel::sql_types::Numeric, super::MultiBackend>
-        for diesel::internal::derives::multiconnection::bigdecimal::BigDecimal {
+        impl ::diesel::serialize::ToSql<
+            ::diesel::sql_types::Numeric,
+            super::MultiBackend,
+        > for ::diesel::internal::derives::multiconnection::bigdecimal::BigDecimal {
             fn to_sql<'b>(
                 &'b self,
-                out: &mut diesel::serialize::Output<'b, '_, super::MultiBackend>,
-            ) -> diesel::serialize::Result {
-                out.set_value((diesel::sql_types::Numeric, self));
-                Ok(diesel::serialize::IsNull::No)
+                out: &mut ::diesel::serialize::Output<'b, '_, super::MultiBackend>,
+            ) -> ::diesel::serialize::Result {
+                out.set_value((::diesel::sql_types::Numeric, self));
+                Ok(::diesel::serialize::IsNull::No)
             }
         }
-        impl diesel::serialize::ToSql<diesel::sql_types::Timestamp, super::MultiBackend>
-        for diesel::internal::derives::multiconnection::chrono::NaiveDateTime {
+        impl ::diesel::serialize::ToSql<
+            ::diesel::sql_types::Timestamp,
+            super::MultiBackend,
+        > for ::diesel::internal::derives::multiconnection::chrono::NaiveDateTime {
             fn to_sql<'b>(
                 &'b self,
-                out: &mut diesel::serialize::Output<'b, '_, super::MultiBackend>,
-            ) -> diesel::serialize::Result {
-                out.set_value((diesel::sql_types::Timestamp, self));
-                Ok(diesel::serialize::IsNull::No)
+                out: &mut ::diesel::serialize::Output<'b, '_, super::MultiBackend>,
+            ) -> ::diesel::serialize::Result {
+                out.set_value((::diesel::sql_types::Timestamp, self));
+                Ok(::diesel::serialize::IsNull::No)
             }
         }
-        impl diesel::serialize::ToSql<diesel::sql_types::Date, super::MultiBackend>
-        for diesel::internal::derives::multiconnection::chrono::NaiveDate {
+        impl ::diesel::serialize::ToSql<::diesel::sql_types::Date, super::MultiBackend>
+        for ::diesel::internal::derives::multiconnection::chrono::NaiveDate {
             fn to_sql<'b>(
                 &'b self,
-                out: &mut diesel::serialize::Output<'b, '_, super::MultiBackend>,
-            ) -> diesel::serialize::Result {
-                out.set_value((diesel::sql_types::Date, self));
-                Ok(diesel::serialize::IsNull::No)
+                out: &mut ::diesel::serialize::Output<'b, '_, super::MultiBackend>,
+            ) -> ::diesel::serialize::Result {
+                out.set_value((::diesel::sql_types::Date, self));
+                Ok(::diesel::serialize::IsNull::No)
             }
         }
-        impl diesel::serialize::ToSql<diesel::sql_types::Time, super::MultiBackend>
-        for diesel::internal::derives::multiconnection::chrono::NaiveTime {
+        impl ::diesel::serialize::ToSql<::diesel::sql_types::Time, super::MultiBackend>
+        for ::diesel::internal::derives::multiconnection::chrono::NaiveTime {
             fn to_sql<'b>(
                 &'b self,
-                out: &mut diesel::serialize::Output<'b, '_, super::MultiBackend>,
-            ) -> diesel::serialize::Result {
-                out.set_value((diesel::sql_types::Time, self));
-                Ok(diesel::serialize::IsNull::No)
+                out: &mut ::diesel::serialize::Output<'b, '_, super::MultiBackend>,
+            ) -> ::diesel::serialize::Result {
+                out.set_value((::diesel::sql_types::Time, self));
+                Ok(::diesel::serialize::IsNull::No)
             }
         }
-        impl diesel::serialize::ToSql<diesel::sql_types::Timestamp, super::MultiBackend>
-        for diesel::internal::derives::multiconnection::time::PrimitiveDateTime {
+        impl ::diesel::serialize::ToSql<
+            ::diesel::sql_types::Timestamp,
+            super::MultiBackend,
+        > for ::diesel::internal::derives::multiconnection::time::PrimitiveDateTime {
             fn to_sql<'b>(
                 &'b self,
-                out: &mut diesel::serialize::Output<'b, '_, super::MultiBackend>,
-            ) -> diesel::serialize::Result {
-                out.set_value((diesel::sql_types::Timestamp, self));
-                Ok(diesel::serialize::IsNull::No)
+                out: &mut ::diesel::serialize::Output<'b, '_, super::MultiBackend>,
+            ) -> ::diesel::serialize::Result {
+                out.set_value((::diesel::sql_types::Timestamp, self));
+                Ok(::diesel::serialize::IsNull::No)
             }
         }
-        impl diesel::serialize::ToSql<diesel::sql_types::Time, super::MultiBackend>
-        for diesel::internal::derives::multiconnection::time::Time {
+        impl ::diesel::serialize::ToSql<::diesel::sql_types::Time, super::MultiBackend>
+        for ::diesel::internal::derives::multiconnection::time::Time {
             fn to_sql<'b>(
                 &'b self,
-                out: &mut diesel::serialize::Output<'b, '_, super::MultiBackend>,
-            ) -> diesel::serialize::Result {
-                out.set_value((diesel::sql_types::Time, self));
-                Ok(diesel::serialize::IsNull::No)
+                out: &mut ::diesel::serialize::Output<'b, '_, super::MultiBackend>,
+            ) -> ::diesel::serialize::Result {
+                out.set_value((::diesel::sql_types::Time, self));
+                Ok(::diesel::serialize::IsNull::No)
             }
         }
-        impl diesel::serialize::ToSql<diesel::sql_types::Date, super::MultiBackend>
-        for diesel::internal::derives::multiconnection::time::Date {
+        impl ::diesel::serialize::ToSql<::diesel::sql_types::Date, super::MultiBackend>
+        for ::diesel::internal::derives::multiconnection::time::Date {
             fn to_sql<'b>(
                 &'b self,
-                out: &mut diesel::serialize::Output<'b, '_, super::MultiBackend>,
-            ) -> diesel::serialize::Result {
-                out.set_value((diesel::sql_types::Date, self));
-                Ok(diesel::serialize::IsNull::No)
+                out: &mut ::diesel::serialize::Output<'b, '_, super::MultiBackend>,
+            ) -> ::diesel::serialize::Result {
+                out.set_value((::diesel::sql_types::Date, self));
+                Ok(::diesel::serialize::IsNull::No)
             }
         }
-        impl diesel::deserialize::FromSql<
-            diesel::sql_types::SmallInt,
+        impl ::diesel::deserialize::FromSql<
+            ::diesel::sql_types::SmallInt,
             super::MultiBackend,
         > for i16 {
             fn from_sql(
-                bytes: <super::MultiBackend as diesel::backend::Backend>::RawValue<'_>,
-            ) -> diesel::deserialize::Result<Self> {
-                bytes.from_sql::<Self, diesel::sql_types::SmallInt>()
+                bytes: <super::MultiBackend as ::diesel::backend::Backend>::RawValue<'_>,
+            ) -> ::diesel::deserialize::Result<Self> {
+                bytes.from_sql::<Self, ::diesel::sql_types::SmallInt>()
             }
         }
-        impl diesel::deserialize::FromSql<
-            diesel::sql_types::Integer,
+        impl ::diesel::deserialize::FromSql<
+            ::diesel::sql_types::Integer,
             super::MultiBackend,
         > for i32 {
             fn from_sql(
-                bytes: <super::MultiBackend as diesel::backend::Backend>::RawValue<'_>,
-            ) -> diesel::deserialize::Result<Self> {
-                bytes.from_sql::<Self, diesel::sql_types::Integer>()
+                bytes: <super::MultiBackend as ::diesel::backend::Backend>::RawValue<'_>,
+            ) -> ::diesel::deserialize::Result<Self> {
+                bytes.from_sql::<Self, ::diesel::sql_types::Integer>()
             }
         }
-        impl diesel::deserialize::FromSql<diesel::sql_types::BigInt, super::MultiBackend>
-        for i64 {
-            fn from_sql(
-                bytes: <super::MultiBackend as diesel::backend::Backend>::RawValue<'_>,
-            ) -> diesel::deserialize::Result<Self> {
-                bytes.from_sql::<Self, diesel::sql_types::BigInt>()
-            }
-        }
-        impl diesel::deserialize::FromSql<diesel::sql_types::Double, super::MultiBackend>
-        for f64 {
-            fn from_sql(
-                bytes: <super::MultiBackend as diesel::backend::Backend>::RawValue<'_>,
-            ) -> diesel::deserialize::Result<Self> {
-                bytes.from_sql::<Self, diesel::sql_types::Double>()
-            }
-        }
-        impl diesel::deserialize::FromSql<diesel::sql_types::Float, super::MultiBackend>
-        for f32 {
-            fn from_sql(
-                bytes: <super::MultiBackend as diesel::backend::Backend>::RawValue<'_>,
-            ) -> diesel::deserialize::Result<Self> {
-                bytes.from_sql::<Self, diesel::sql_types::Float>()
-            }
-        }
-        impl diesel::deserialize::FromSql<diesel::sql_types::Text, super::MultiBackend>
-        for String {
-            fn from_sql(
-                bytes: <super::MultiBackend as diesel::backend::Backend>::RawValue<'_>,
-            ) -> diesel::deserialize::Result<Self> {
-                bytes.from_sql::<Self, diesel::sql_types::Text>()
-            }
-        }
-        impl diesel::deserialize::FromSql<diesel::sql_types::Binary, super::MultiBackend>
-        for Vec<u8> {
-            fn from_sql(
-                bytes: <super::MultiBackend as diesel::backend::Backend>::RawValue<'_>,
-            ) -> diesel::deserialize::Result<Self> {
-                bytes.from_sql::<Self, diesel::sql_types::Binary>()
-            }
-        }
-        impl diesel::deserialize::FromSql<diesel::sql_types::Bool, super::MultiBackend>
-        for bool {
-            fn from_sql(
-                bytes: <super::MultiBackend as diesel::backend::Backend>::RawValue<'_>,
-            ) -> diesel::deserialize::Result<Self> {
-                bytes.from_sql::<Self, diesel::sql_types::Bool>()
-            }
-        }
-        impl diesel::deserialize::FromSql<
-            diesel::sql_types::Numeric,
+        impl ::diesel::deserialize::FromSql<
+            ::diesel::sql_types::BigInt,
             super::MultiBackend,
-        > for diesel::internal::derives::multiconnection::bigdecimal::BigDecimal {
+        > for i64 {
             fn from_sql(
-                bytes: <super::MultiBackend as diesel::backend::Backend>::RawValue<'_>,
-            ) -> diesel::deserialize::Result<Self> {
-                bytes.from_sql::<Self, diesel::sql_types::Numeric>()
+                bytes: <super::MultiBackend as ::diesel::backend::Backend>::RawValue<'_>,
+            ) -> ::diesel::deserialize::Result<Self> {
+                bytes.from_sql::<Self, ::diesel::sql_types::BigInt>()
             }
         }
-        impl diesel::deserialize::FromSql<
-            diesel::sql_types::Timestamp,
+        impl ::diesel::deserialize::FromSql<
+            ::diesel::sql_types::Double,
             super::MultiBackend,
-        > for diesel::internal::derives::multiconnection::chrono::NaiveDateTime {
+        > for f64 {
             fn from_sql(
-                bytes: <super::MultiBackend as diesel::backend::Backend>::RawValue<'_>,
-            ) -> diesel::deserialize::Result<Self> {
-                bytes.from_sql::<Self, diesel::sql_types::Timestamp>()
+                bytes: <super::MultiBackend as ::diesel::backend::Backend>::RawValue<'_>,
+            ) -> ::diesel::deserialize::Result<Self> {
+                bytes.from_sql::<Self, ::diesel::sql_types::Double>()
             }
         }
-        impl diesel::deserialize::FromSql<diesel::sql_types::Date, super::MultiBackend>
-        for diesel::internal::derives::multiconnection::chrono::NaiveDate {
-            fn from_sql(
-                bytes: <super::MultiBackend as diesel::backend::Backend>::RawValue<'_>,
-            ) -> diesel::deserialize::Result<Self> {
-                bytes.from_sql::<Self, diesel::sql_types::Date>()
-            }
-        }
-        impl diesel::deserialize::FromSql<diesel::sql_types::Time, super::MultiBackend>
-        for diesel::internal::derives::multiconnection::chrono::NaiveTime {
-            fn from_sql(
-                bytes: <super::MultiBackend as diesel::backend::Backend>::RawValue<'_>,
-            ) -> diesel::deserialize::Result<Self> {
-                bytes.from_sql::<Self, diesel::sql_types::Time>()
-            }
-        }
-        impl diesel::deserialize::FromSql<
-            diesel::sql_types::Timestamp,
+        impl ::diesel::deserialize::FromSql<
+            ::diesel::sql_types::Float,
             super::MultiBackend,
-        > for diesel::internal::derives::multiconnection::time::PrimitiveDateTime {
+        > for f32 {
             fn from_sql(
-                bytes: <super::MultiBackend as diesel::backend::Backend>::RawValue<'_>,
-            ) -> diesel::deserialize::Result<Self> {
-                bytes.from_sql::<Self, diesel::sql_types::Timestamp>()
+                bytes: <super::MultiBackend as ::diesel::backend::Backend>::RawValue<'_>,
+            ) -> ::diesel::deserialize::Result<Self> {
+                bytes.from_sql::<Self, ::diesel::sql_types::Float>()
             }
         }
-        impl diesel::deserialize::FromSql<diesel::sql_types::Time, super::MultiBackend>
-        for diesel::internal::derives::multiconnection::time::Time {
+        impl ::diesel::deserialize::FromSql<
+            ::diesel::sql_types::Text,
+            super::MultiBackend,
+        > for String {
             fn from_sql(
-                bytes: <super::MultiBackend as diesel::backend::Backend>::RawValue<'_>,
-            ) -> diesel::deserialize::Result<Self> {
-                bytes.from_sql::<Self, diesel::sql_types::Time>()
+                bytes: <super::MultiBackend as ::diesel::backend::Backend>::RawValue<'_>,
+            ) -> ::diesel::deserialize::Result<Self> {
+                bytes.from_sql::<Self, ::diesel::sql_types::Text>()
             }
         }
-        impl diesel::deserialize::FromSql<diesel::sql_types::Date, super::MultiBackend>
-        for diesel::internal::derives::multiconnection::time::Date {
+        impl ::diesel::deserialize::FromSql<
+            ::diesel::sql_types::Binary,
+            super::MultiBackend,
+        > for Vec<u8> {
             fn from_sql(
-                bytes: <super::MultiBackend as diesel::backend::Backend>::RawValue<'_>,
-            ) -> diesel::deserialize::Result<Self> {
-                bytes.from_sql::<Self, diesel::sql_types::Date>()
+                bytes: <super::MultiBackend as ::diesel::backend::Backend>::RawValue<'_>,
+            ) -> ::diesel::deserialize::Result<Self> {
+                bytes.from_sql::<Self, ::diesel::sql_types::Binary>()
+            }
+        }
+        impl ::diesel::deserialize::FromSql<
+            ::diesel::sql_types::Bool,
+            super::MultiBackend,
+        > for bool {
+            fn from_sql(
+                bytes: <super::MultiBackend as ::diesel::backend::Backend>::RawValue<'_>,
+            ) -> ::diesel::deserialize::Result<Self> {
+                bytes.from_sql::<Self, ::diesel::sql_types::Bool>()
+            }
+        }
+        impl ::diesel::deserialize::FromSql<
+            ::diesel::sql_types::Numeric,
+            super::MultiBackend,
+        > for ::diesel::internal::derives::multiconnection::bigdecimal::BigDecimal {
+            fn from_sql(
+                bytes: <super::MultiBackend as ::diesel::backend::Backend>::RawValue<'_>,
+            ) -> ::diesel::deserialize::Result<Self> {
+                bytes.from_sql::<Self, ::diesel::sql_types::Numeric>()
+            }
+        }
+        impl ::diesel::deserialize::FromSql<
+            ::diesel::sql_types::Timestamp,
+            super::MultiBackend,
+        > for ::diesel::internal::derives::multiconnection::chrono::NaiveDateTime {
+            fn from_sql(
+                bytes: <super::MultiBackend as ::diesel::backend::Backend>::RawValue<'_>,
+            ) -> ::diesel::deserialize::Result<Self> {
+                bytes.from_sql::<Self, ::diesel::sql_types::Timestamp>()
+            }
+        }
+        impl ::diesel::deserialize::FromSql<
+            ::diesel::sql_types::Date,
+            super::MultiBackend,
+        > for ::diesel::internal::derives::multiconnection::chrono::NaiveDate {
+            fn from_sql(
+                bytes: <super::MultiBackend as ::diesel::backend::Backend>::RawValue<'_>,
+            ) -> ::diesel::deserialize::Result<Self> {
+                bytes.from_sql::<Self, ::diesel::sql_types::Date>()
+            }
+        }
+        impl ::diesel::deserialize::FromSql<
+            ::diesel::sql_types::Time,
+            super::MultiBackend,
+        > for ::diesel::internal::derives::multiconnection::chrono::NaiveTime {
+            fn from_sql(
+                bytes: <super::MultiBackend as ::diesel::backend::Backend>::RawValue<'_>,
+            ) -> ::diesel::deserialize::Result<Self> {
+                bytes.from_sql::<Self, ::diesel::sql_types::Time>()
+            }
+        }
+        impl ::diesel::deserialize::FromSql<
+            ::diesel::sql_types::Timestamp,
+            super::MultiBackend,
+        > for ::diesel::internal::derives::multiconnection::time::PrimitiveDateTime {
+            fn from_sql(
+                bytes: <super::MultiBackend as ::diesel::backend::Backend>::RawValue<'_>,
+            ) -> ::diesel::deserialize::Result<Self> {
+                bytes.from_sql::<Self, ::diesel::sql_types::Timestamp>()
+            }
+        }
+        impl ::diesel::deserialize::FromSql<
+            ::diesel::sql_types::Time,
+            super::MultiBackend,
+        > for ::diesel::internal::derives::multiconnection::time::Time {
+            fn from_sql(
+                bytes: <super::MultiBackend as ::diesel::backend::Backend>::RawValue<'_>,
+            ) -> ::diesel::deserialize::Result<Self> {
+                bytes.from_sql::<Self, ::diesel::sql_types::Time>()
+            }
+        }
+        impl ::diesel::deserialize::FromSql<
+            ::diesel::sql_types::Date,
+            super::MultiBackend,
+        > for ::diesel::internal::derives::multiconnection::time::Date {
+            fn from_sql(
+                bytes: <super::MultiBackend as ::diesel::backend::Backend>::RawValue<'_>,
+            ) -> ::diesel::deserialize::Result<Self> {
+                bytes.from_sql::<Self, ::diesel::sql_types::Date>()
             }
         }
         impl<
             T,
             ST,
-        > diesel::internal::derives::multiconnection::EnumMapping<super::MultiBackend>
-        for diesel::internal::derives::multiconnection::IntMapping<T, ST>
+        > ::diesel::internal::derives::multiconnection::EnumMapping<super::MultiBackend>
+        for ::diesel::internal::derives::multiconnection::IntMapping<T, ST>
         where
             ST: Default,
-            T: diesel::deserialize::FromSql<ST, super::MultiBackend> + 'static
-                + diesel::internal::derives::multiconnection::IntegerMappingHelper,
+            T: ::diesel::deserialize::FromSql<ST, super::MultiBackend> + 'static
+                + ::diesel::internal::derives::multiconnection::IntegerMappingHelper,
             for<'a> BindValue<'a>: From<(ST, &'a T)>,
             i128: TryFrom<T, Error: core::fmt::Display>,
         {
             fn map_to_database_value<'b>(
-                output: &mut diesel::serialize::Output<'b, '_, super::MultiBackend>,
-                variant: &'static diesel::internal::derives::multiconnection::EnumVariant,
-            ) -> diesel::serialize::Result {
-                let v = <T as diesel::internal::derives::multiconnection::IntegerMappingHelper>::as_ref(
+                output: &mut ::diesel::serialize::Output<'b, '_, super::MultiBackend>,
+                variant: &'static ::diesel::internal::derives::multiconnection::EnumVariant,
+            ) -> ::diesel::serialize::Result {
+                let v = <T as ::diesel::internal::derives::multiconnection::IntegerMappingHelper>::as_ref(
                     &variant.discriminant,
                 )?;
                 output.set_value((ST::default(), v));
-                Ok(diesel::serialize::IsNull::No)
+                Ok(::diesel::serialize::IsNull::No)
             }
             fn map_from_database_value(
-                raw: <super::MultiBackend as diesel::backend::Backend>::RawValue<'_>,
+                raw: <super::MultiBackend as ::diesel::backend::Backend>::RawValue<'_>,
                 type_name: &'static str,
-                variants: &'static [diesel::internal::derives::multiconnection::EnumVariant],
-            ) -> diesel::deserialize::Result<usize> {
-                let i = <T as diesel::deserialize::FromSql<
+                variants: &'static [::diesel::internal::derives::multiconnection::EnumVariant],
+            ) -> ::diesel::deserialize::Result<usize> {
+                let i = <T as ::diesel::deserialize::FromSql<
                     ST,
                     super::MultiBackend,
                 >>::from_sql(raw)?;
                 Self::from_discriminant(type_name, variants, i)
             }
         }
-        impl diesel::internal::derives::multiconnection::EnumMapping<super::MultiBackend>
-        for diesel::internal::derives::multiconnection::StringMapping {
+        impl ::diesel::internal::derives::multiconnection::EnumMapping<
+            super::MultiBackend,
+        > for ::diesel::internal::derives::multiconnection::StringMapping {
             fn map_to_database_value<'b>(
-                output: &mut diesel::serialize::Output<'b, '_, super::MultiBackend>,
-                variant: &'static diesel::internal::derives::multiconnection::EnumVariant,
-            ) -> diesel::serialize::Result {
-                <&str as diesel::serialize::ToSql<
-                    diesel::sql_types::Text,
+                output: &mut ::diesel::serialize::Output<'b, '_, super::MultiBackend>,
+                variant: &'static ::diesel::internal::derives::multiconnection::EnumVariant,
+            ) -> ::diesel::serialize::Result {
+                <&str as ::diesel::serialize::ToSql<
+                    ::diesel::sql_types::Text,
                     super::MultiBackend,
                 >>::to_sql(&variant.sql_name, output)
             }
             fn map_from_database_value(
-                raw: <super::MultiBackend as diesel::backend::Backend>::RawValue<'_>,
+                raw: <super::MultiBackend as ::diesel::backend::Backend>::RawValue<'_>,
                 type_name: &'static str,
-                variants: &'static [diesel::internal::derives::multiconnection::EnumVariant],
-            ) -> diesel::deserialize::Result<usize> {
-                let s = <String as diesel::deserialize::FromSql<
-                    diesel::sql_types::Text,
+                variants: &'static [::diesel::internal::derives::multiconnection::EnumVariant],
+            ) -> ::diesel::deserialize::Result<usize> {
+                let s = <String as ::diesel::deserialize::FromSql<
+                    ::diesel::sql_types::Text,
                     super::MultiBackend,
                 >>::from_sql(raw)?;
                 Self::from_variant_name(type_name, variants, &s)
@@ -1782,14 +1820,14 @@ mod multi_connection_impl {
                 >,
             ),
         }
-        impl<'conn, 'query> diesel::internal::derives::multiconnection::RowSealed
+        impl<'conn, 'query> ::diesel::internal::derives::multiconnection::RowSealed
         for MultiRow<'conn, 'query> {}
         pub enum MultiField<'conn: 'query, 'query> {
             Pg(
                 <<diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Row<
                     'conn,
                     'query,
-                > as diesel::row::Row<
+                > as ::diesel::row::Row<
                     'conn,
                     <diesel_async::AsyncPgConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >>::Field<'query>,
@@ -1798,16 +1836,16 @@ mod multi_connection_impl {
                 <<diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Row<
                     'conn,
                     'query,
-                > as diesel::row::Row<
+                > as ::diesel::row::Row<
                     'conn,
                     <diesel_async::AsyncMysqlConnection as diesel_async::AsyncConnectionCore>::Backend,
                 >>::Field<'query>,
             ),
         }
-        impl<'conn, 'query> diesel::row::Field<'conn, super::MultiBackend>
+        impl<'conn, 'query> ::diesel::row::Field<'conn, super::MultiBackend>
         for MultiField<'conn, 'query> {
             fn field_name(&self) -> Option<&str> {
-                use diesel::row::Field;
+                use ::diesel::row::Field;
                 match self {
                     Self::Pg(f) => f.field_name(),
                     Self::Sqlite(f) => f.field_name(),
@@ -1816,40 +1854,40 @@ mod multi_connection_impl {
             fn value(
                 &self,
             ) -> Option<
-                <super::MultiBackend as diesel::backend::Backend>::RawValue<'_>,
+                <super::MultiBackend as ::diesel::backend::Backend>::RawValue<'_>,
             > {
-                use diesel::row::Field;
+                use ::diesel::row::Field;
                 match self {
                     Self::Pg(f) => f.value().map(super::MultiRawValue::Pg),
                     Self::Sqlite(f) => f.value().map(super::MultiRawValue::Sqlite),
                 }
             }
         }
-        impl<'conn, 'query, 'c> diesel::row::RowIndex<&'c str>
+        impl<'conn, 'query, 'c> ::diesel::row::RowIndex<&'c str>
         for MultiRow<'conn, 'query> {
             fn idx(&self, idx: &'c str) -> Option<usize> {
-                use diesel::row::RowIndex;
+                use ::diesel::row::RowIndex;
                 match self {
                     Self::Pg(r) => r.idx(idx),
                     Self::Sqlite(r) => r.idx(idx),
                 }
             }
         }
-        impl<'conn, 'query> diesel::row::RowIndex<usize> for MultiRow<'conn, 'query> {
+        impl<'conn, 'query> ::diesel::row::RowIndex<usize> for MultiRow<'conn, 'query> {
             fn idx(&self, idx: usize) -> Option<usize> {
-                use diesel::row::RowIndex;
+                use ::diesel::row::RowIndex;
                 match self {
                     Self::Pg(r) => r.idx(idx),
                     Self::Sqlite(r) => r.idx(idx),
                 }
             }
         }
-        impl<'conn, 'query> diesel::row::Row<'conn, super::MultiBackend>
+        impl<'conn, 'query> ::diesel::row::Row<'conn, super::MultiBackend>
         for MultiRow<'conn, 'query> {
             type Field<'a> = MultiField<'a, 'a> where 'conn: 'a, Self: 'a;
             type InnerPartialRow = Self;
             fn field_count(&self) -> usize {
-                use diesel::row::Row;
+                use ::diesel::row::Row;
                 match self {
                     Self::Pg(r) => r.field_count(),
                     Self::Sqlite(r) => r.field_count(),
@@ -1858,9 +1896,9 @@ mod multi_connection_impl {
             fn get<'b, I>(&'b self, idx: I) -> Option<Self::Field<'b>>
             where
                 'conn: 'b,
-                Self: diesel::row::RowIndex<I>,
+                Self: ::diesel::row::RowIndex<I>,
             {
-                use diesel::row::{RowIndex, Row};
+                use ::diesel::row::{RowIndex, Row};
                 let idx = self.idx(idx)?;
                 match self {
                     Self::Pg(r) => r.get(idx).map(MultiField::Pg),
@@ -1870,11 +1908,14 @@ mod multi_connection_impl {
             fn partial_row(
                 &self,
                 range: std::ops::Range<usize>,
-            ) -> diesel::internal::derives::multiconnection::PartialRow<
+            ) -> ::diesel::internal::derives::multiconnection::PartialRow<
                 '_,
                 Self::InnerPartialRow,
             > {
-                diesel::internal::derives::multiconnection::PartialRow::new(self, range)
+                ::diesel::internal::derives::multiconnection::PartialRow::new(
+                    self,
+                    range,
+                )
             }
         }
     }
@@ -1885,7 +1926,7 @@ mod multi_connection_impl {
             async fn batch_execute(
                 &mut self,
                 query: &str,
-            ) -> diesel::result::QueryResult<()> {
+            ) -> ::diesel::result::QueryResult<()> {
                 match self {
                     Self::Pg(conn) => conn.batch_execute(query).await,
                     Self::Sqlite(conn) => conn.batch_execute(query).await,
@@ -1904,23 +1945,23 @@ mod multi_connection_impl {
         }
         trait BindParamHelper: diesel_async::AsyncConnection {
             fn handle_inner_pass<'a, 'b: 'a>(
-                collector: &mut <Self::Backend as diesel::backend::Backend>::BindCollector<
+                collector: &mut <Self::Backend as ::diesel::backend::Backend>::BindCollector<
                     'a,
                 >,
-                lookup: &mut <Self::Backend as diesel::sql_types::TypeMetadata>::MetadataLookup,
+                lookup: &mut <Self::Backend as ::diesel::sql_types::TypeMetadata>::MetadataLookup,
                 backend: &'b MultiBackend,
-                q: &'b impl diesel::query_builder::QueryFragment<MultiBackend>,
-            ) -> diesel::QueryResult<()>;
+                q: &'b impl ::diesel::query_builder::QueryFragment<MultiBackend>,
+            ) -> ::diesel::QueryResult<()>;
         }
         impl BindParamHelper for diesel_async::AsyncPgConnection {
             fn handle_inner_pass<'a, 'b: 'a>(
-                outer_collector: &mut <Self::Backend as diesel::backend::Backend>::BindCollector<
+                outer_collector: &mut <Self::Backend as ::diesel::backend::Backend>::BindCollector<
                     'a,
                 >,
-                lookup: &mut <Self::Backend as diesel::sql_types::TypeMetadata>::MetadataLookup,
+                lookup: &mut <Self::Backend as ::diesel::sql_types::TypeMetadata>::MetadataLookup,
                 backend: &'b MultiBackend,
-                q: &'b impl diesel::query_builder::QueryFragment<MultiBackend>,
-            ) -> diesel::QueryResult<()> {
+                q: &'b impl ::diesel::query_builder::QueryFragment<MultiBackend>,
+            ) -> ::diesel::QueryResult<()> {
                 use diesel_async::AsyncMultiConnectionHelper;
                 let mut collector = super::bind_collector::MultiBindCollector::Pg(
                     Default::default(),
@@ -1935,13 +1976,13 @@ mod multi_connection_impl {
         }
         impl BindParamHelper for diesel_async::AsyncMysqlConnection {
             fn handle_inner_pass<'a, 'b: 'a>(
-                outer_collector: &mut <Self::Backend as diesel::backend::Backend>::BindCollector<
+                outer_collector: &mut <Self::Backend as ::diesel::backend::Backend>::BindCollector<
                     'a,
                 >,
-                lookup: &mut <Self::Backend as diesel::sql_types::TypeMetadata>::MetadataLookup,
+                lookup: &mut <Self::Backend as ::diesel::sql_types::TypeMetadata>::MetadataLookup,
                 backend: &'b MultiBackend,
-                q: &'b impl diesel::query_builder::QueryFragment<MultiBackend>,
-            ) -> diesel::QueryResult<()> {
+                q: &'b impl ::diesel::query_builder::QueryFragment<MultiBackend>,
+            ) -> ::diesel::QueryResult<()> {
                 use diesel_async::AsyncMultiConnectionHelper;
                 let mut collector = super::bind_collector::MultiBindCollector::Sqlite(
                     Default::default(),
@@ -1954,19 +1995,20 @@ mod multi_connection_impl {
                 Ok(())
             }
         }
-        impl<T, DB, C> diesel::query_builder::QueryFragment<DB> for SerializedQuery<T, C>
+        impl<T, DB, C> ::diesel::query_builder::QueryFragment<DB>
+        for SerializedQuery<T, C>
         where
-            DB: diesel::backend::Backend + 'static,
-            T: diesel::query_builder::QueryFragment<MultiBackend>,
+            DB: ::diesel::backend::Backend + 'static,
+            T: ::diesel::query_builder::QueryFragment<MultiBackend>,
             C: diesel_async::AsyncConnectionCore<Backend = DB> + BindParamHelper
                 + diesel_async::AsyncMultiConnectionHelper,
         {
             fn walk_ast<'b>(
                 &'b self,
-                mut pass: diesel::query_builder::AstPass<'_, 'b, DB>,
-            ) -> diesel::QueryResult<()> {
-                use diesel::query_builder::QueryBuilder;
-                use diesel::internal::derives::multiconnection::AstPassHelper;
+                mut pass: ::diesel::query_builder::AstPass<'_, 'b, DB>,
+            ) -> ::diesel::QueryResult<()> {
+                use ::diesel::query_builder::QueryBuilder;
+                use ::diesel::internal::derives::multiconnection::AstPassHelper;
                 let mut query_builder = self.query_builder.duplicate();
                 self.inner.to_sql(&mut query_builder, &self.backend)?;
                 pass.push_sql(&query_builder.finish());
@@ -1982,7 +2024,7 @@ mod multi_connection_impl {
                     )?;
                 }
                 if let Some((formatter, _backend)) = pass.debug_binds() {
-                    let pass = diesel::query_builder::AstPass::<
+                    let pass = ::diesel::query_builder::AstPass::<
                         MultiBackend,
                     >::collect_debug_binds_pass(formatter, &self.backend);
                     self.inner.walk_ast(pass)?;
@@ -1990,22 +2032,22 @@ mod multi_connection_impl {
                 Ok(())
             }
         }
-        impl<T, C> diesel::query_builder::QueryId for SerializedQuery<T, C>
+        impl<T, C> ::diesel::query_builder::QueryId for SerializedQuery<T, C>
         where
-            T: diesel::query_builder::QueryId,
+            T: ::diesel::query_builder::QueryId,
         {
-            type QueryId = <T as diesel::query_builder::QueryId>::QueryId;
-            const HAS_STATIC_QUERY_ID: bool = <T as diesel::query_builder::QueryId>::HAS_STATIC_QUERY_ID;
+            type QueryId = <T as ::diesel::query_builder::QueryId>::QueryId;
+            const HAS_STATIC_QUERY_ID: bool = <T as ::diesel::query_builder::QueryId>::HAS_STATIC_QUERY_ID;
         }
-        impl<T, C> diesel::query_builder::Query for SerializedQuery<T, C>
+        impl<T, C> ::diesel::query_builder::Query for SerializedQuery<T, C>
         where
-            T: diesel::query_builder::Query,
+            T: ::diesel::query_builder::Query,
         {
-            type SqlType = diesel::sql_types::Untyped;
+            type SqlType = ::diesel::sql_types::Untyped;
         }
         impl diesel_async::AsyncConnection for MultiConnection {
             type TransactionManager = Self;
-            async fn establish(database_url: &str) -> diesel::ConnectionResult<Self> {
+            async fn establish(database_url: &str) -> ::diesel::ConnectionResult<Self> {
                 if let Ok(conn) = diesel_async::AsyncPgConnection::establish(
                         database_url,
                     )
@@ -2021,7 +2063,7 @@ mod multi_connection_impl {
                     return Ok(Self::Sqlite(conn));
                 }
                 Err(
-                    diesel::ConnectionError::BadConnection(
+                    ::diesel::ConnectionError::BadConnection(
                         "Invalid connection url for multiconnection".into(),
                     ),
                 )
@@ -2035,7 +2077,7 @@ mod multi_connection_impl {
             }
             fn instrumentation(
                 &mut self,
-            ) -> &mut dyn diesel::connection::Instrumentation {
+            ) -> &mut dyn ::diesel::connection::Instrumentation {
                 match self {
                     Self::Pg(conn) => {
                         diesel_async::AsyncConnection::instrumentation(conn)
@@ -2047,7 +2089,7 @@ mod multi_connection_impl {
             }
             fn set_instrumentation(
                 &mut self,
-                instrumentation: impl diesel::connection::Instrumentation,
+                instrumentation: impl ::diesel::connection::Instrumentation,
             ) {
                 match self {
                     Self::Pg(conn) => {
@@ -2066,7 +2108,7 @@ mod multi_connection_impl {
             }
             fn set_prepared_statement_cache_size(
                 &mut self,
-                size: diesel::connection::CacheSize,
+                size: ::diesel::connection::CacheSize,
             ) {
                 match self {
                     Self::Pg(conn) => {
@@ -2083,7 +2125,7 @@ mod multi_connection_impl {
                     }
                 }
             }
-            async fn begin_test_transaction(&mut self) -> diesel::QueryResult<()> {
+            async fn begin_test_transaction(&mut self) -> ::diesel::QueryResult<()> {
                 match self {
                     Self::Pg(conn) => conn.begin_test_transaction().await,
                     Self::Sqlite(conn) => conn.begin_test_transaction().await,
@@ -2093,15 +2135,15 @@ mod multi_connection_impl {
         impl diesel_async::AsyncConnectionCore for MultiConnection {
             type LoadFuture<'conn, 'query> = futures_util::future::BoxFuture<
                 'conn,
-                diesel::QueryResult<Self::Stream<'conn, 'query>>,
+                ::diesel::QueryResult<Self::Stream<'conn, 'query>>,
             >;
             type ExecuteFuture<'conn, 'query> = futures_util::future::BoxFuture<
                 'conn,
-                diesel::QueryResult<usize>,
+                ::diesel::QueryResult<usize>,
             >;
             type Stream<'conn, 'query> = futures_util::stream::BoxStream<
                 'conn,
-                diesel::QueryResult<Self::Row<'conn, 'query>>,
+                ::diesel::QueryResult<Self::Row<'conn, 'query>>,
             >;
             type Row<'conn, 'query> = super::MultiRow<'conn, 'query>;
             type Backend = super::MultiBackend;
@@ -2110,9 +2152,9 @@ mod multi_connection_impl {
                 source: T,
             ) -> Self::LoadFuture<'conn, 'query>
             where
-                T: diesel::query_builder::AsQuery + 'query,
-                T::Query: diesel::query_builder::QueryFragment<Self::Backend>
-                    + diesel::query_builder::QueryId + 'query,
+                T: ::diesel::query_builder::AsQuery + 'query,
+                T::Query: ::diesel::query_builder::QueryFragment<Self::Backend>
+                    + ::diesel::query_builder::QueryId + 'query,
             {
                 match self {
                     Self::Pg(conn) => {
@@ -2174,8 +2216,8 @@ mod multi_connection_impl {
                 source: T,
             ) -> Self::ExecuteFuture<'conn, 'query>
             where
-                T: diesel::query_builder::QueryFragment<Self::Backend>
-                    + diesel::query_builder::QueryId + 'query,
+                T: ::diesel::query_builder::QueryFragment<Self::Backend>
+                    + ::diesel::query_builder::QueryId + 'query,
             {
                 match self {
                     Self::Pg(conn) => {
@@ -2211,7 +2253,7 @@ mod multi_connection_impl {
             type TransactionStateData = Self;
             async fn begin_transaction(
                 conn: &mut MultiConnection,
-            ) -> diesel::QueryResult<()> {
+            ) -> ::diesel::QueryResult<()> {
                 match conn {
                     Self::Pg(conn) => {
                         <diesel_async::AsyncPgConnection as diesel_async::AsyncConnection>::TransactionManager::begin_transaction(
@@ -2229,7 +2271,7 @@ mod multi_connection_impl {
             }
             async fn rollback_transaction(
                 conn: &mut MultiConnection,
-            ) -> diesel::QueryResult<()> {
+            ) -> ::diesel::QueryResult<()> {
                 match conn {
                     Self::Pg(conn) => {
                         <diesel_async::AsyncPgConnection as diesel_async::AsyncConnection>::TransactionManager::rollback_transaction(
@@ -2247,7 +2289,7 @@ mod multi_connection_impl {
             }
             async fn commit_transaction(
                 conn: &mut MultiConnection,
-            ) -> diesel::QueryResult<()> {
+            ) -> ::diesel::QueryResult<()> {
                 match conn {
                     Self::Pg(conn) => {
                         <diesel_async::AsyncPgConnection as diesel_async::AsyncConnection>::TransactionManager::commit_transaction(
@@ -2265,7 +2307,7 @@ mod multi_connection_impl {
             }
             fn transaction_manager_status_mut(
                 conn: &mut MultiConnection,
-            ) -> &mut diesel::connection::TransactionManagerStatus {
+            ) -> &mut ::diesel::connection::TransactionManagerStatus {
                 match conn {
                     Self::Pg(conn) => {
                         <diesel_async::AsyncPgConnection as diesel_async::AsyncConnection>::TransactionManager::transaction_manager_status_mut(

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__query_id_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__query_id_1.snap
@@ -5,7 +5,7 @@ info:
   input: "#[derive(QueryId)]\nstruct Query;\n"
 ---
 const _: () = {
-    use diesel;
+    use ::diesel;
     #[allow(non_camel_case_types)]
     impl diesel::query_builder::QueryId for Query {
         type QueryId = Query;

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__query_id_bounded_lifetimes.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__query_id_bounded_lifetimes.snap
@@ -5,7 +5,7 @@ info:
   input: "#[derive(QueryId)]\nstruct Query<'a: 'b, 'b> {\n    f: &'a str,\n    g: &'b str,\n}\n"
 ---
 const _: () = {
-    use diesel;
+    use ::diesel;
     #[allow(non_camel_case_types)]
     impl<'a: 'b, 'b> diesel::query_builder::QueryId for Query<'a, 'b> {
         type QueryId = Query<'static, 'static>;

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__query_id_const_before_type.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__query_id_const_before_type.snap
@@ -5,7 +5,7 @@ info:
   input: "#[derive(QueryId)]\nstruct Query<'a, const N: usize, T> {\n    f: &'a str,\n    g: T,\n}\n"
 ---
 const _: () = {
-    use diesel;
+    use ::diesel;
     #[allow(non_camel_case_types)]
     impl<
         'a,

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__query_id_lifetime.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__query_id_lifetime.snap
@@ -5,7 +5,7 @@ info:
   input: "#[derive(QueryId)]\nstruct Query<'a> {\n    f: &'a str,\n}\n"
 ---
 const _: () = {
-    use diesel;
+    use ::diesel;
     #[allow(non_camel_case_types)]
     impl<'a> diesel::query_builder::QueryId for Query<'a> {
         type QueryId = Query<'static>;

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__queryable_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__queryable_1.snap
@@ -5,7 +5,7 @@ info:
   input: "#[derive(Queryable)]\nstruct User {\n    id: i32,\n    name: String,\n}\n"
 ---
 const _: () = {
-    use diesel;
+    use ::diesel;
     use diesel::row::{Row as _, Field as _};
     impl<
         __DB: diesel::backend::Backend,

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__queryable_by_name_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__queryable_by_name_1.snap
@@ -5,7 +5,7 @@ info:
   input: "#[derive(QueryableByName)]\nstruct User {\n    id: i32,\n    name: String,\n}\n"
 ---
 const _: () = {
-    use diesel;
+    use ::diesel;
     impl<__DB: diesel::backend::Backend> diesel::deserialize::QueryableByName<__DB>
     for User
     where

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__queryable_by_name_2.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__queryable_by_name_2.snap
@@ -5,7 +5,7 @@ info:
   input: "#[derive(QueryableByName)]\npub struct UserCount {\n    #[diesel(sql_type = diesel::sql_types::BigInt)]\n    pub value: i16,\n}\n"
 ---
 const _: () = {
-    use diesel;
+    use ::diesel;
     impl<__DB: diesel::backend::Backend> diesel::deserialize::QueryableByName<__DB>
     for UserCount
     where

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__queryable_deserialize_as_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__queryable_deserialize_as_1.snap
@@ -5,7 +5,7 @@ info:
   input: "#[derive(Queryable)]\nstruct User {\n    id: i32,\n    #[diesel(deserialize_as = String)]\n    name: LowercaseString,\n}\n"
 ---
 const _: () = {
-    use diesel;
+    use ::diesel;
     use diesel::row::{Row as _, Field as _};
     impl<
         __DB: diesel::backend::Backend,

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__selectable_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__selectable_1.snap
@@ -5,7 +5,7 @@ info:
   input: "#[derive(Selectable)]\nstruct User {\n    id: i32,\n    name: String,\n}\n"
 ---
 const _: () = {
-    use diesel;
+    use ::diesel;
     use diesel::expression::Selectable;
     impl<__DB: diesel::backend::Backend> Selectable<__DB> for User {
         type SelectExpression = (users::r#id, users::r#name);

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__sql_function_1 (sqlite).snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__sql_function_1 (sqlite).snap
@@ -7,7 +7,7 @@ info:
 #[allow(non_camel_case_types)]
 pub fn lower<input>(input: input) -> lower::HelperType<input>
 where
-    input: diesel::expression::AsExpression<Text>,
+    input: ::diesel::expression::AsExpression<Text>,
 {
     lower::lower {
         input: input.as_expression(),
@@ -16,16 +16,16 @@ where
 #[doc(hidden)]
 #[allow(non_camel_case_types, non_snake_case, unused_imports)]
 pub(crate) mod lower {
-    use diesel::{self, QueryResult};
-    use diesel::expression::{
+    use ::diesel::QueryResult;
+    use ::diesel::expression::{
         AsExpression, Expression, SelectableExpression, AppearsOnTable, ValidGrouping,
     };
-    use diesel::query_builder::{QueryFragment, AstPass};
-    use diesel::sql_types::*;
-    use diesel::internal::sql_functions::*;
+    use ::diesel::query_builder::{QueryFragment, AstPass};
+    use ::diesel::sql_types::*;
+    use ::diesel::internal::sql_functions::*;
     use super::*;
-    #[derive(Debug, Clone, Copy, diesel::query_builder::QueryId)]
-    #[derive(diesel::sql_types::DieselNumericOps)]
+    #[derive(Debug, Clone, Copy, ::diesel::query_builder::QueryId)]
+    #[derive(::diesel::sql_types::DieselNumericOps)]
     pub struct lower<input> {
         pub(super) input: input,
     }
@@ -49,7 +49,7 @@ pub(crate) mod lower {
     {}
     impl<input, __DieselInternal> FunctionFragment<__DieselInternal> for lower<input>
     where
-        __DieselInternal: diesel::backend::Backend,
+        __DieselInternal: ::diesel::backend::Backend,
         input: QueryFragment<__DieselInternal>,
     {
         const FUNCTION_NAME: &'static str = "lower";
@@ -71,7 +71,7 @@ pub(crate) mod lower {
     }
     impl<input, __DieselInternal> QueryFragment<__DieselInternal> for lower<input>
     where
-        __DieselInternal: diesel::backend::Backend,
+        __DieselInternal: ::diesel::backend::Backend,
         input: QueryFragment<__DieselInternal>,
     {
         fn walk_ast<'__b>(
@@ -106,20 +106,23 @@ pub(crate) mod lower {
     /// instead, or [`register_impl_with_behavior`](self::register_impl_with_behavior)
     /// for full control over the SQLite behavior flags.
     pub fn register_impl<F, Ret, input>(
-        conn: &mut diesel::sqlite::SqliteConnection,
+        conn: &mut ::diesel::sqlite::SqliteConnection,
         f: F,
-    ) -> diesel::result::QueryResult<()>
+    ) -> ::diesel::result::QueryResult<()>
     where
         F: Fn(input) -> Ret + ::core::panic::UnwindSafe + Send + 'static,
         (
             input,
-        ): diesel::deserialize::FromSqlRow<(Text,), diesel::sqlite::Sqlite>
-            + diesel::deserialize::StaticallySizedRow<(Text,), diesel::sqlite::Sqlite>,
-        Ret: diesel::serialize::ToSql<Text, diesel::sqlite::Sqlite>,
+        ): ::diesel::deserialize::FromSqlRow<(Text,), ::diesel::sqlite::Sqlite>
+            + ::diesel::deserialize::StaticallySizedRow<
+                (Text,),
+                ::diesel::sqlite::Sqlite,
+            >,
+        Ret: ::diesel::serialize::ToSql<Text, ::diesel::sqlite::Sqlite>,
     {
         register_impl_with_behavior(
             conn,
-            diesel::sqlite::SqliteFunctionBehavior::DETERMINISTIC,
+            ::diesel::sqlite::SqliteFunctionBehavior::DETERMINISTIC,
             f,
         )
     }
@@ -136,20 +139,23 @@ pub(crate) mod lower {
     /// the SQLite behavior flags, use
     /// [`register_impl_with_behavior`](self::register_impl_with_behavior).
     pub fn register_nondeterministic_impl<F, Ret, input>(
-        conn: &mut diesel::sqlite::SqliteConnection,
+        conn: &mut ::diesel::sqlite::SqliteConnection,
         f: F,
-    ) -> diesel::result::QueryResult<()>
+    ) -> ::diesel::result::QueryResult<()>
     where
         F: FnMut(input) -> Ret + ::core::panic::UnwindSafe + Send + 'static,
         (
             input,
-        ): diesel::deserialize::FromSqlRow<(Text,), diesel::sqlite::Sqlite>
-            + diesel::deserialize::StaticallySizedRow<(Text,), diesel::sqlite::Sqlite>,
-        Ret: diesel::serialize::ToSql<Text, diesel::sqlite::Sqlite>,
+        ): ::diesel::deserialize::FromSqlRow<(Text,), ::diesel::sqlite::Sqlite>
+            + ::diesel::deserialize::StaticallySizedRow<
+                (Text,),
+                ::diesel::sqlite::Sqlite,
+            >,
+        Ret: ::diesel::serialize::ToSql<Text, ::diesel::sqlite::Sqlite>,
     {
         register_impl_with_behavior(
             conn,
-            diesel::sqlite::SqliteFunctionBehavior::empty(),
+            ::diesel::sqlite::SqliteFunctionBehavior::empty(),
             f,
         )
     }
@@ -164,17 +170,20 @@ pub(crate) mod lower {
     /// unless you need to set behavior flags explicitly. See
     /// [`SqliteFunctionBehavior`] for the available flags.
     pub fn register_impl_with_behavior<F, Ret, input>(
-        conn: &mut diesel::sqlite::SqliteConnection,
-        behavior: diesel::sqlite::SqliteFunctionBehavior,
+        conn: &mut ::diesel::sqlite::SqliteConnection,
+        behavior: ::diesel::sqlite::SqliteFunctionBehavior,
         mut f: F,
-    ) -> diesel::result::QueryResult<()>
+    ) -> ::diesel::result::QueryResult<()>
     where
         F: FnMut(input) -> Ret + ::core::panic::UnwindSafe + Send + 'static,
         (
             input,
-        ): diesel::deserialize::FromSqlRow<(Text,), diesel::sqlite::Sqlite>
-            + diesel::deserialize::StaticallySizedRow<(Text,), diesel::sqlite::Sqlite>,
-        Ret: diesel::serialize::ToSql<Text, diesel::sqlite::Sqlite>,
+        ): ::diesel::deserialize::FromSqlRow<(Text,), ::diesel::sqlite::Sqlite>
+            + ::diesel::deserialize::StaticallySizedRow<
+                (Text,),
+                ::diesel::sqlite::Sqlite,
+            >,
+        Ret: ::diesel::serialize::ToSql<Text, ::diesel::sqlite::Sqlite>,
     {
         conn.register_sql_function::<
                 (Text,),

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__sql_function_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__sql_function_1.snap
@@ -7,7 +7,7 @@ info:
 #[allow(non_camel_case_types)]
 pub fn lower<input>(input: input) -> lower::HelperType<input>
 where
-    input: diesel::expression::AsExpression<Text>,
+    input: ::diesel::expression::AsExpression<Text>,
 {
     lower::lower {
         input: input.as_expression(),
@@ -16,16 +16,16 @@ where
 #[doc(hidden)]
 #[allow(non_camel_case_types, non_snake_case, unused_imports)]
 pub(crate) mod lower {
-    use diesel::{self, QueryResult};
-    use diesel::expression::{
+    use ::diesel::QueryResult;
+    use ::diesel::expression::{
         AsExpression, Expression, SelectableExpression, AppearsOnTable, ValidGrouping,
     };
-    use diesel::query_builder::{QueryFragment, AstPass};
-    use diesel::sql_types::*;
-    use diesel::internal::sql_functions::*;
+    use ::diesel::query_builder::{QueryFragment, AstPass};
+    use ::diesel::sql_types::*;
+    use ::diesel::internal::sql_functions::*;
     use super::*;
-    #[derive(Debug, Clone, Copy, diesel::query_builder::QueryId)]
-    #[derive(diesel::sql_types::DieselNumericOps)]
+    #[derive(Debug, Clone, Copy, ::diesel::query_builder::QueryId)]
+    #[derive(::diesel::sql_types::DieselNumericOps)]
     pub struct lower<input> {
         pub(super) input: input,
     }
@@ -49,7 +49,7 @@ pub(crate) mod lower {
     {}
     impl<input, __DieselInternal> FunctionFragment<__DieselInternal> for lower<input>
     where
-        __DieselInternal: diesel::backend::Backend,
+        __DieselInternal: ::diesel::backend::Backend,
         input: QueryFragment<__DieselInternal>,
     {
         const FUNCTION_NAME: &'static str = "lower";
@@ -71,7 +71,7 @@ pub(crate) mod lower {
     }
     impl<input, __DieselInternal> QueryFragment<__DieselInternal> for lower<input>
     where
-        __DieselInternal: diesel::backend::Backend,
+        __DieselInternal: ::diesel::backend::Backend,
         input: QueryFragment<__DieselInternal>,
     {
         fn walk_ast<'__b>(

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__sql_type_1 (mariadb).snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__sql_type_1 (mariadb).snap
@@ -5,7 +5,7 @@ info:
   input: "#[derive(SqlType)]\n#[diesel(mariadb_type(name = \"Long\"))]\nstruct Integer;\n"
 ---
 const _: () = {
-    use diesel;
+    use ::diesel;
     impl diesel::sql_types::SqlType for Integer {
         type IsNull = diesel::sql_types::is_nullable::NotNull;
         const IS_ARRAY: bool = false;

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__sql_type_1 (mysql).snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__sql_type_1 (mysql).snap
@@ -5,7 +5,7 @@ info:
   input: "#[derive(SqlType)]\n#[diesel(mysql_type(name = \"Long\"))]\nstruct Integer;\n"
 ---
 const _: () = {
-    use diesel;
+    use ::diesel;
     impl diesel::sql_types::SqlType for Integer {
         type IsNull = diesel::sql_types::is_nullable::NotNull;
         const IS_ARRAY: bool = false;

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__sql_type_1 (postgres).snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__sql_type_1 (postgres).snap
@@ -5,7 +5,7 @@ info:
   input: "#[derive(SqlType)]\n#[diesel(postgres_type(oid = 42, array_oid = 142))]\nstruct Integer;\n"
 ---
 const _: () = {
-    use diesel;
+    use ::diesel;
     impl diesel::sql_types::SqlType for Integer {
         type IsNull = diesel::sql_types::is_nullable::NotNull;
         const IS_ARRAY: bool = false;

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__sql_type_1 (sqlite).snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__sql_type_1 (sqlite).snap
@@ -5,7 +5,7 @@ info:
   input: "#[derive(SqlType)]\n#[diesel(sqlite_type(name = \"Integer\"))]\nstruct Integer;\n"
 ---
 const _: () = {
-    use diesel;
+    use ::diesel;
     impl diesel::sql_types::SqlType for Integer {
         type IsNull = diesel::sql_types::is_nullable::NotNull;
         const IS_ARRAY: bool = false;

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__sql_type_enum (mariadb).snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__sql_type_enum (mariadb).snap
@@ -5,7 +5,7 @@ info:
   input: "#[derive(SqlType)]\n#[diesel(mariadb_type(name = \"Long\"))]\n#[diesel(enum_type)]\nstruct Integer;\n"
 ---
 const _: () = {
-    use diesel;
+    use ::diesel;
     impl diesel::sql_types::SqlType for Integer {
         type IsNull = diesel::sql_types::is_nullable::NotNull;
         const IS_ARRAY: bool = false;

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__sql_type_enum (mysql).snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__sql_type_enum (mysql).snap
@@ -5,7 +5,7 @@ info:
   input: "#[derive(SqlType)]\n#[diesel(mysql_type(name = \"Long\"))]\n#[diesel(enum_type)]\nstruct Integer;\n"
 ---
 const _: () = {
-    use diesel;
+    use ::diesel;
     impl diesel::sql_types::SqlType for Integer {
         type IsNull = diesel::sql_types::is_nullable::NotNull;
         const IS_ARRAY: bool = false;

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__sql_type_enum (postgres).snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__sql_type_enum (postgres).snap
@@ -5,7 +5,7 @@ info:
   input: "#[derive(SqlType)]\n#[diesel(postgres_type(oid = 42, array_oid = 142))]\n#[diesel(enum_type)]\nstruct Integer;\n"
 ---
 const _: () = {
-    use diesel;
+    use ::diesel;
     impl diesel::sql_types::SqlType for Integer {
         type IsNull = diesel::sql_types::is_nullable::NotNull;
         const IS_ARRAY: bool = false;

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__sql_type_enum (sqlite).snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__sql_type_enum (sqlite).snap
@@ -5,7 +5,7 @@ info:
   input: "#[derive(SqlType)]\n#[diesel(sqlite_type(name = \"Integer\"))]\n#[diesel(enum_type)]\nstruct Integer;\n"
 ---
 const _: () = {
-    use diesel;
+    use ::diesel;
     impl diesel::sql_types::SqlType for Integer {
         type IsNull = diesel::sql_types::is_nullable::NotNull;
         const IS_ARRAY: bool = false;

--- a/diesel_derives/src/tests/snapshots/diesel_derives__tests__valid_grouping_1.snap
+++ b/diesel_derives/src/tests/snapshots/diesel_derives__tests__valid_grouping_1.snap
@@ -5,7 +5,7 @@ info:
   input: "#[derive(ValidGrouping)]\nstruct Query;\n"
 ---
 const _: () = {
-    use diesel;
+    use ::diesel;
     impl<__GroupByClause> diesel::expression::ValidGrouping<__GroupByClause> for Query {
         type IsAggregate = diesel::expression::is_aggregate::Never;
     }

--- a/diesel_derives/src/util.rs
+++ b/diesel_derives/src/util.rs
@@ -8,13 +8,10 @@ use crate::model::Model;
 pub fn wrap_in_dummy_mod(item: TokenStream) -> TokenStream {
     quote! {
         const _: () = {
-            // This import is not actually redundant. When using diesel_derives
-            // inside of diesel, `diesel` doesn't exist as an extern crate, and
-            // to work around that it contains a private
-            // `mod diesel { pub use super::*; }` that this import will then
-            // refer to. In all other cases, this imports refers to the extern
-            // crate diesel.
-            use diesel;
+            // Rooted so that a module or item named `diesel` in the caller's
+            // scope cannot capture it. Inside diesel itself this resolves
+            // through `extern crate self as diesel`.
+            use ::diesel;
 
             #item
         };

--- a/diesel_derives/tests/path_hygiene.rs
+++ b/diesel_derives/tests/path_hygiene.rs
@@ -1,0 +1,195 @@
+//! Generated code must not depend on what the name `diesel` means where the
+//! macro was invoked.
+//!
+//! Every module below shadows that name with an empty module, so anything the
+//! expansion reaches through an unrooted `diesel::` path fails to resolve.
+
+use crate::helpers::TestBackend;
+use diesel::prelude::*;
+
+mod shadowed_schema {
+    mod diesel {}
+
+    ::diesel::table! {
+        hygiene_users (id) {
+            id -> ::diesel::sql_types::Integer,
+            name -> ::diesel::sql_types::Text,
+        }
+    }
+
+    ::diesel::table! {
+        hygiene_posts (id) {
+            id -> ::diesel::sql_types::Integer,
+            user_id -> ::diesel::sql_types::Integer,
+        }
+    }
+
+    ::diesel::joinable!(hygiene_posts -> hygiene_users (user_id));
+    ::diesel::allow_tables_to_appear_in_same_query!(hygiene_users, hygiene_posts);
+
+    #[derive(
+        ::diesel::Insertable,
+        ::diesel::Queryable,
+        ::diesel::Selectable,
+        ::diesel::QueryableByName,
+        ::diesel::AsChangeset,
+        ::diesel::Identifiable,
+    )]
+    #[diesel(table_name = hygiene_users)]
+    pub struct User {
+        pub id: i32,
+        pub name: String,
+    }
+
+    #[derive(::diesel::HasQuery, ::diesel::Insertable)]
+    #[diesel(table_name = hygiene_users)]
+    pub struct UserQuery {
+        pub id: i32,
+        pub name: String,
+    }
+
+    #[derive(::diesel::Identifiable, ::diesel::Associations, ::diesel::Queryable)]
+    #[diesel(table_name = hygiene_posts, belongs_to(User))]
+    pub struct Post {
+        pub id: i32,
+        pub user_id: i32,
+    }
+
+    #[derive(Debug, ::diesel::expression::AsExpression, ::diesel::deserialize::FromSqlRow)]
+    #[diesel(sql_type = ::diesel::sql_types::Text)]
+    pub struct Name(pub String);
+
+    #[derive(::diesel::sql_types::SqlType)]
+    pub struct MySqlType;
+
+    #[derive(
+        ::diesel::query_builder::QueryId,
+        ::diesel::sql_types::DieselNumericOps,
+        ::diesel::expression::ValidGrouping,
+    )]
+    pub struct Wrapper<T> {
+        pub inner: T,
+    }
+
+    impl<T: ::diesel::expression::Expression> ::diesel::expression::Expression for Wrapper<T> {
+        type SqlType = T::SqlType;
+    }
+
+    impl<T, DB> ::diesel::query_builder::QueryFragment<DB> for Wrapper<T>
+    where
+        DB: ::diesel::backend::Backend,
+        T: ::diesel::query_builder::QueryFragment<DB>,
+    {
+        fn walk_ast<'b>(
+            &'b self,
+            pass: ::diesel::query_builder::AstPass<'_, 'b, DB>,
+        ) -> ::diesel::QueryResult<()> {
+            self.inner.walk_ast(pass)
+        }
+    }
+}
+
+mod shadowed_functions {
+    mod diesel {}
+
+    ::diesel::define_sql_function!(
+        fn hygiene_lower(x: ::diesel::sql_types::Text) -> ::diesel::sql_types::Text
+    );
+
+    #[::diesel::declare_sql_function]
+    extern "SQL" {
+        fn hygiene_upper(x: ::diesel::sql_types::Text) -> ::diesel::sql_types::Text;
+    }
+}
+
+mod shadowed_auto_type {
+    mod diesel {}
+
+    use super::shadowed_schema::hygiene_users;
+    use ::diesel::prelude::*;
+
+    #[::diesel::dsl::auto_type]
+    pub fn named_user() -> _ {
+        hygiene_users::table.filter(hygiene_users::id.eq(1_i32))
+    }
+}
+
+mod shadowed_connection {
+    mod diesel {}
+
+    #[derive(::diesel::MultiConnection)]
+    pub enum AnyConnection {
+        #[cfg(feature = "postgres")]
+        Pg(::diesel::PgConnection),
+        #[cfg(feature = "sqlite")]
+        Sqlite(::diesel::SqliteConnection),
+        #[cfg(feature = "mysql")]
+        Mysql(::diesel::MysqlConnection),
+        #[cfg(feature = "mariadb")]
+        Mariadb(::diesel::MariadbConnection),
+    }
+}
+
+/// The derives beside a shadowed `diesel` build the statements they promise.
+#[test]
+fn derives_survive_a_shadowed_diesel_name() {
+    let user = shadowed_schema::User {
+        id: 1,
+        name: "sean".into(),
+    };
+
+    let insert = diesel::insert_into(shadowed_schema::hygiene_users::table).values(&user);
+    let sql = diesel::debug_query::<TestBackend, _>(&insert).to_string();
+    assert!(sql.contains("hygiene_users"), "{sql}");
+
+    let posts = shadowed_schema::Post::belonging_to(&user);
+    let sql = diesel::debug_query::<TestBackend, _>(&posts).to_string();
+    assert!(sql.contains("hygiene_posts"), "{sql}");
+
+    let base = <shadowed_schema::UserQuery as diesel::HasQuery<TestBackend>>::base_query();
+    let sql = diesel::debug_query::<TestBackend, _>(&base).to_string();
+    assert!(sql.contains("hygiene_users"), "{sql}");
+
+    let insert = diesel::insert_into(shadowed_schema::hygiene_users::table).values(
+        shadowed_schema::UserQuery {
+            id: 2,
+            name: "tess".into(),
+        },
+    );
+    let sql = diesel::debug_query::<TestBackend, _>(&insert).to_string();
+    assert!(sql.contains("hygiene_users"), "{sql}");
+
+    fn assert_connection<C: diesel::Connection>() {}
+    assert_connection::<shadowed_connection::AnyConnection>();
+
+    fn assert_sql_type<T: diesel::sql_types::SqlType>() {}
+    assert_sql_type::<shadowed_schema::MySqlType>();
+
+    let sum = shadowed_schema::Wrapper {
+        inner: shadowed_schema::hygiene_users::id,
+    } + 1;
+    let sql = diesel::debug_query::<TestBackend, _>(&sum).to_string();
+    assert!(sql.contains("id"), "{sql}");
+}
+
+/// A function declared beside a shadowed `diesel` renders as a call.
+#[test]
+fn sql_functions_survive_a_shadowed_diesel_name() {
+    use shadowed_functions::{hygiene_lower, hygiene_upper};
+
+    let lowered = hygiene_lower(shadowed_schema::hygiene_users::name);
+    let sql = diesel::debug_query::<TestBackend, _>(&lowered).to_string();
+    assert!(sql.contains("hygiene_lower("), "{sql}");
+
+    let uppered = hygiene_upper(shadowed_schema::hygiene_users::name);
+    let sql = diesel::debug_query::<TestBackend, _>(&uppered).to_string();
+    assert!(sql.contains("hygiene_upper("), "{sql}");
+}
+
+/// An `#[auto_type]` function beside a shadowed `diesel` infers its return type.
+#[test]
+fn auto_type_survives_a_shadowed_diesel_name() {
+    let query = shadowed_auto_type::named_user();
+    let sql = diesel::debug_query::<TestBackend, _>(&query).to_string();
+    assert!(sql.contains("hygiene_users"), "{sql}");
+}

--- a/diesel_derives/tests/tests.rs
+++ b/diesel_derives/tests/tests.rs
@@ -15,6 +15,7 @@ mod enum_;
 mod identifiable;
 mod insertable;
 mod multiconnection;
+mod path_hygiene;
 mod query_id;
 mod queryable;
 mod queryable_by_name;

--- a/dsl_auto_type/src/auto_type/expression_type_inference.rs
+++ b/dsl_auto_type/src/auto_type/expression_type_inference.rs
@@ -235,7 +235,11 @@ impl TypeInferrer<'_> {
                             )?,
                         }])
                         .collect(),
-                    leading_colon: None,
+                    leading_colon: self
+                        .local_variables_map
+                        .inferrer_settings
+                        .dsl_path
+                        .leading_colon,
                 },
                 qself: None,
                 attrs: Vec::new(),


### PR DESCRIPTION
`table!` already refers to diesel through `use ::diesel;` in the module it generates, so its expansion survives a caller in whose scope the name `diesel` means something else. Nothing else does.

This PR adds the `::` prefix to `diesel` imports in all of the derives and macros, so as to avoid naming collisions in the unfortunate situation where a module named `diesel` exists in the user crate. It also adds a regression test emulating such a scenario. I hope I have captured all macros & derives and missing `::` but there are a several so I might have missed some.